### PR TITLE
feat(certificates): add support for custom CA certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,9 @@ ARG GO_TAGS="stablediffusion tts"
 RUN apt-get update && \
     apt-get install -y ca-certificates cmake curl patch pip
 
+COPY --chmod=644 custom-ca-certs/* /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 # Use the variables in subsequent instructions
 RUN echo "Target Architecture: $TARGETARCH"
 RUN echo "Target Variant: $TARGETVARIANT"


### PR DESCRIPTION
**Description**

This change facilitates users working behind corporate firewalls or proxies. By allowing the integration of custom CA certificates, users can handle SSL connections that are intercepted by company infrastructure.

The idea is that users would copy their CA certificates to `custom-ca-certs`, and the Dockerfile would take care of adding them to the image so that the user doesn't get SSL certificate problems when `curl` commands run.

**Notes for Reviewers**

I decided to open this PR because of the problem I mentioned on discussion #876 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.