### PR TITLE
Fixes the bug 1196

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,6 +267,9 @@ clean: ## Remove build related file
 	rm -rf ./go-piper
 	rm -rf $(BINARY_NAME)
 	rm -rf release/
+	rm -rf ./backend/cpp/grpc/grpc_repo
+	rm -rf ./backend/cpp/grpc/build
+	rm -rf ./backend/cpp/grpc/installed_packages
 	$(MAKE) -C backend/cpp/llama clean
 
 ## Build:
@@ -399,9 +402,28 @@ ifeq ($(BUILD_TYPE),metal)
 	cp go-llama/build/bin/ggml-metal.metal backend-assets/grpc/
 endif
 
-backend/cpp/llama/grpc-server:
-	LLAMA_VERSION=$(CPPLLAMA_VERSION) $(MAKE) -C backend/cpp/llama grpc-server
+## BACKEND CPP LLAMA 
+# Sets the variables in case it has to build the gRPC locally.
+INSTALLED_PACKAGES=$(CURDIR)/backend/cpp/grpc/installed_packages
+INSTALLED_LIB_CMAKE=$(INSTALLED_PACKAGES)/lib/cmake
+ADDED_CMAKE_ARGS=-Dabsl_DIR=${INSTALLED_LIB_CMAKE}/absl \
+                 -DProtobuf_DIR=${INSTALLED_LIB_CMAKE}/protobuf \
+                 -Dutf8_range_DIR=${INSTALLED_LIB_CMAKE}/utf8_range \
+                 -DgRPC_DIR=${INSTALLED_LIB_CMAKE}/grpc \
+                 -DCMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES=${INSTALLED_PACKAGES}/include
 
+backend/cpp/llama/grpc-server:			
+ifdef BUILD_GRPC
+	backend/cpp/grpc/script/build_grpc.sh ${INSTALLED_PACKAGES}
+	export _PROTOBUF_PROTOC=${INSTALLED_PACKAGES}/bin/proto && \
+	export _GRPC_CPP_PLUGIN_EXECUTABLE=${INSTALLED_PACKAGES}/bin/grpc_cpp_plugin && \
+	export PATH=${PATH}:${INSTALLED_PACKAGES}/bin && \
+	CMAKE_ARGS="${ADDED_CMAKE_ARGS}" LLAMA_VERSION=$(CPPLLAMA_VERSION) $(MAKE) -C backend/cpp/llama grpc-server 
+else
+	LLAMA_VERSION=$(CPPLLAMA_VERSION) $(MAKE) -C backend/cpp/llama grpc-server			
+endif
+		
+##
 backend-assets/grpc/llama-cpp: backend-assets/grpc backend/cpp/llama/grpc-server
 	cp -rfv backend/cpp/llama/grpc-server backend-assets/grpc/llama-cpp
 # TODO: every binary should have its own folder instead, so can have different metal implementations

--- a/backend/cpp/grpc/.gitignore
+++ b/backend/cpp/grpc/.gitignore
@@ -1,0 +1,3 @@
+installed_packages/
+grpc_build/
+grpc_repo/

--- a/backend/cpp/grpc/script/build_grpc.sh
+++ b/backend/cpp/grpc/script/build_grpc.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Builds locally from sources the packages needed by the llama cpp backend.
+
+# Makes sure a few base packages exist.
+# sudo apt-get --no-upgrade -y install g++ gcc binutils cmake git build-essential autoconf libtool pkg-config 
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+echo "Script directory: $SCRIPT_DIR"
+
+CPP_INSTALLED_PACKAGES_DIR=$1
+if [ -z ${CPP_INSTALLED_PACKAGES_DIR} ]; then 
+    echo "CPP_INSTALLED_PACKAGES_DIR env variable not set. Don't know where to install: failed."; 
+    echo
+    exit -1
+fi
+
+if [ -d "${CPP_INSTALLED_PACKAGES_DIR}" ]; then
+  echo "gRPC installation directory already exists. Nothing to do."
+  exit 0
+fi
+
+# The depth when cloning a git repo. 1 speeds up the clone when the repo history is not needed.
+GIT_CLONE_DEPTH=1
+
+NUM_BUILD_THREADS=$(nproc --ignore=1)
+
+# Google gRPC --------------------------------------------------------------------------------------
+TAG_LIB_GRPC="v1.59.0"
+GIT_REPO_LIB_GRPC="https://github.com/grpc/grpc.git"
+GRPC_REPO_DIR="${SCRIPT_DIR}/../grpc_repo"
+GRPC_BUILD_DIR="${SCRIPT_DIR}/../grpc_build"
+SRC_DIR_LIB_GRPC="${GRPC_REPO_DIR}/grpc"
+
+echo "SRC_DIR_LIB_GRPC: ${SRC_DIR_LIB_GRPC}"
+echo "GRPC_REPO_DIR: ${GRPC_REPO_DIR}"
+echo "GRPC_BUILD_DIR: ${GRPC_BUILD_DIR}"
+
+mkdir -pv ${GRPC_REPO_DIR}
+
+rm   -rf ${GRPC_BUILD_DIR}
+mkdir -pv ${GRPC_BUILD_DIR}
+
+mkdir -pv ${CPP_INSTALLED_PACKAGES_DIR}
+	
+if [ -d "${SRC_DIR_LIB_GRPC}" ]; then
+  echo "gRPC source already exists locally. Not cloned again."
+else  
+  ( cd ${GRPC_REPO_DIR} && \
+    git clone --depth ${GIT_CLONE_DEPTH} -b ${TAG_LIB_GRPC} ${GIT_REPO_LIB_GRPC} && \
+    cd ${SRC_DIR_LIB_GRPC} && \
+    git submodule update --init --recursive --depth ${GIT_CLONE_DEPTH} 
+  )    
+fi
+
+( cd ${GRPC_BUILD_DIR} && \
+  cmake -G "Unix Makefiles" \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DgRPC_INSTALL=ON \
+     -DEXECUTABLE_OUTPUT_PATH=${CPP_INSTALLED_PACKAGES_DIR}/grpc/bin \
+     -DLIBRARY_OUTPUT_PATH=${CPP_INSTALLED_PACKAGES_DIR}/grpc/lib \
+     -DgRPC_BUILD_TESTS=OFF \
+     -DgRPC_BUILD_CSHARP_EXT=OFF \
+     -DgRPC_BUILD_GRPC_CPP_PLUGIN=ON \
+     -DgRPC_BUILD_GRPC_CSHARP_PLUGIN=OFF \
+     -DgRPC_BUILD_GRPC_NODE_PLUGIN=OFF \
+     -DgRPC_BUILD_GRPC_OBJECTIVE_C_PLUGIN=OFF \
+     -DgRPC_BUILD_GRPC_PHP_PLUGIN=OFF \
+     -DgRPC_BUILD_GRPC_PYTHON_PLUGIN=ON \
+     -DgRPC_BUILD_GRPC_RUBY_PLUGIN=OFF \
+     -Dprotobuf_WITH_ZLIB=ON \
+     -DRE2_BUILD_TESTING=OFF \
+     -DCMAKE_INSTALL_PREFIX=${CPP_INSTALLED_PACKAGES_DIR}/ \
+     ${SRC_DIR_LIB_GRPC}  && \
+  cmake --build .  -- -j ${NUM_BUILD_THREADS} && \
+  cmake --build .  --target install -- -j ${NUM_BUILD_THREADS} 
+)
+
+rm -rf ${GRPC_BUILD_DIR}
+rm -rf ${GRPC_REPO_DIR}
+


### PR DESCRIPTION
**Description**

This PR fixes the bug 1196. Previously Llama Cpp failed because it did not find gRPC libraries and the protoc compiler.

Now it is possible to build Local AI along with gRPC using the command:

`BUILD_GRPC=ON make build`

It was modified the Makefile in the root directory.  In case the variable BUILD_GRPC is defined, it runs the script at the path:

`backend/cpp/grpc/script/build_grpc.sh`

Which clones the gRPC repo and installs it at the path backend/cpp/grpc/installed_packages

The command:
`make clean`
removes gRPC and the installed files.


The command:
`make rebuild`

does not affects the installed gRPC.
Makefile was modified at the lines 405-424.

Moreover, under Linux Ubuntu, it gRPC requires the packages:
build-essential autoconf libtool pkg-config


