### PR TITLE
fix: ExLlama Backend Context Size & Rope Scaling

### DIFF
--- a/backend/python/exllama/exllama.py
+++ b/backend/python/exllama/exllama.py
@@ -63,6 +63,10 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
 
             config = ExLlamaConfig(model_config_path)               # create config from config.json
             config.model_path = model_path                          # supply path to model weights file
+            if (request.ContextSize):
+                config.max_seq_len = request.ContextSize            # override max sequence length
+                config.max_attention_size = request.ContextSize**2  # Should be set to context_size^2. 
+                # https://github.com/turboderp/exllama/issues/220#issuecomment-1720324163
 
             model = ExLlama(config)                                 # create ExLlama instance and load the weights
             tokenizer = ExLlamaTokenizer(tokenizer_path)            # create tokenizer from tokenizer model file

--- a/backend/python/exllama/exllama.py
+++ b/backend/python/exllama/exllama.py
@@ -68,6 +68,15 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 config.max_attention_size = request.ContextSize**2  # Should be set to context_size^2. 
                 # https://github.com/turboderp/exllama/issues/220#issuecomment-1720324163
 
+            # Set Rope scaling.
+            if (request.RopeFreqScale):
+                # Alpha value for Rope scaling. 
+                # Higher value increases context but adds perplexity.
+                # alpha_value and compress_pos_emb are mutually exclusive.
+                # https://github.com/turboderp/exllama/issues/115
+                config.alpha_value = request.RopeFreqScale
+                config.calculate_rotary_embedding_base()
+
             model = ExLlama(config)                                 # create ExLlama instance and load the weights
             tokenizer = ExLlamaTokenizer(tokenizer_path)            # create tokenizer from tokenizer model file
 


### PR DESCRIPTION
**Description**

This PR fixes ExLlama backend having fixed 2048 size cache. This results in the following error when 2048 context is exceeded: `stderr RuntimeError: start (2009) + length (44) exceeds dimension size (2048)`

This PR also passes through Rope scaling config to the ExLlama backend.

**Notes for Reviewers**

These attributes are set by default [here](https://github.com/turboderp/exllama/blob/master/model.py#L39), and not loaded from the model config json. Therefore, we need to set it from LocalAI's end. It would also be nice to add warnings for all backends of unimplemented config flags that the user defined in the yaml.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->