### PR TITLE
fix: move python header comments below shebang in some backends

### DIFF
--- a/backend/python/bark/ttsbark.py
+++ b/backend/python/bark/ttsbark.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-This is the extra gRPC server of LocalAI
+This is an extra gRPC server of LocalAI for Bark TTS
 """
 from concurrent import futures
 import time

--- a/backend/python/bark/ttsbark.py
+++ b/backend/python/bark/ttsbark.py
@@ -1,8 +1,7 @@
+#!/usr/bin/env python3
 """
 This is the extra gRPC server of LocalAI
 """
-
-#!/usr/bin/env python3
 from concurrent import futures
 import time
 import argparse

--- a/backend/python/sentencetransformers/sentencetransformers.py
+++ b/backend/python/sentencetransformers/sentencetransformers.py
@@ -1,7 +1,7 @@
+#!/usr/bin/env python3
 """
 Extra gRPC server for HuggingFace SentenceTransformer models.
 """
-#!/usr/bin/env python3
 from concurrent import futures
 
 import argparse

--- a/backend/python/transformers/transformers.py
+++ b/backend/python/transformers/transformers.py
@@ -1,7 +1,7 @@
-"""
-Extra gRPC server for HuggingFace SentenceTransformer models.
-"""
 #!/usr/bin/env python3
+"""
+Extra gRPC server for HuggingFace AutoModel models.
+"""
 from concurrent import futures
 
 import argparse


### PR DESCRIPTION
**Description**

This PR fixes no specific issue, I just found the bug and fixed it right away.

The changed comments prevent direct execution of the backend Python scripts unless the platform is configured in some way to always execute .py files with Python. For platforms that rely on the shebang (#!) to tell them how to run the script, these comments led to an "exec format error" message because the shebang has to be on the very first line to be properly read by exec(see `man 2 execve`).
This should be a straightforward merge.

I also adjusted the comments themselves a bit.

Changelist:

- Move header comments below shebang line where necessary (only in backends/python/)
- Make header comment for barktts.py a tad more specific
- Fix header comment in transformers.py referring to the wrong module/library class

**Notes for Reviewers**

These comments somehow got introduced with #1144. 