### PR TITLE
docs: Update Features->Embeddings page to reflect backend restructuring

### DIFF
--- a/docs/content/features/embeddings.md
+++ b/docs/content/features/embeddings.md
@@ -61,7 +61,7 @@ curl http://localhost:8080/embeddings -X POST -H "Content-Type: application/json
 
 ## Huggingface embeddings
 
-To use `sentence-formers` and models in `huggingface` you can use the `huggingface` embedding backend.
+To use `sentence-transformers` and models in `huggingface` you can use the `huggingface` embedding backend.
 
 ```yaml
 name: text-embedding-ada-002
@@ -75,7 +75,7 @@ The `huggingface` backend uses Python [sentence-transformers](https://github.com
 
 {{% notice note %}}
 
-- The `huggingface` backend is an optional backend of LocalAI and uses Python. If you are running `LocalAI` from the containers you are good to go and should be already configured for use. If you are running `LocalAI` manually you must install the python dependencies (`pip install -r /path/to/LocalAI/extra/requirements`) and specify the extra backend in the `EXTERNAL_GRPC_BACKENDS` environment variable ( `EXTERNAL_GRPC_BACKENDS="huggingface-embeddings:/path/to/LocalAI/extra/grpc/huggingface/huggingface.py"` ) .
+- The `huggingface` backend is an optional backend of LocalAI and uses Python. If you are running `LocalAI` from the containers you are good to go and should be already configured for use. If you are running `LocalAI` manually you must install the python dependencies (`pip install -r /path/to/LocalAI/extra/requirements`) and specify the extra backend in the `EXTERNAL_GRPC_BACKENDS` environment variable ( `EXTERNAL_GRPC_BACKENDS="huggingface-embeddings:/path/to/LocalAI/backend/python/sentencetransformers/sentencetransformers.py"` ) .
 - The `huggingface` backend does support only embeddings of text, and not of tokens. If you need to embed tokens you can use the `bert` backend or `llama.cpp`.
 - No models are required to be downloaded before using the `huggingface` backend. The models will be downloaded automatically the first time the API is used.
 

--- a/docs/content/features/embeddings.md
+++ b/docs/content/features/embeddings.md
@@ -61,23 +61,23 @@ curl http://localhost:8080/embeddings -X POST -H "Content-Type: application/json
 
 ## Huggingface embeddings
 
-To use `sentence-transformers` and models in `huggingface` you can use the `huggingface` embedding backend.
+To use `sentence-transformers` and models in `huggingface` you can use the `sentencetransformers` embedding backend.
 
 ```yaml
 name: text-embedding-ada-002
-backend: huggingface-embeddings
+backend: sentencetransformers
 embeddings: true
 parameters:
   model: all-MiniLM-L6-v2
 ```
 
-The `huggingface` backend uses Python [sentence-transformers](https://github.com/UKPLab/sentence-transformers). For a list of all pre-trained models available see here: https://github.com/UKPLab/sentence-transformers#pre-trained-models
+The `sentencetransformers` backend uses Python [sentence-transformers](https://github.com/UKPLab/sentence-transformers). For a list of all pre-trained models available see here: https://github.com/UKPLab/sentence-transformers#pre-trained-models
 
 {{% notice note %}}
 
-- The `huggingface` backend is an optional backend of LocalAI and uses Python. If you are running `LocalAI` from the containers you are good to go and should be already configured for use. If you are running `LocalAI` manually you must install the python dependencies (`pip install -r /path/to/LocalAI/extra/requirements`) and specify the extra backend in the `EXTERNAL_GRPC_BACKENDS` environment variable ( `EXTERNAL_GRPC_BACKENDS="huggingface-embeddings:/path/to/LocalAI/backend/python/sentencetransformers/sentencetransformers.py"` ) .
-- The `huggingface` backend does support only embeddings of text, and not of tokens. If you need to embed tokens you can use the `bert` backend or `llama.cpp`.
-- No models are required to be downloaded before using the `huggingface` backend. The models will be downloaded automatically the first time the API is used.
+- The `sentencetransformers` backend is an optional backend of LocalAI and uses Python. If you are running `LocalAI` from the containers you are good to go and should be already configured for use. If you are running `LocalAI` manually you must install the python dependencies (`pip install -r /path/to/LocalAI/extra/requirements`) and specify the extra backend in the `EXTERNAL_GRPC_BACKENDS` environment variable ( `EXTERNAL_GRPC_BACKENDS="sentencetransformers:/path/to/LocalAI/backend/python/sentencetransformers/sentencetransformers.py"` ) .
+- The `sentencetransformers` backend does support only embeddings of text, and not of tokens. If you need to embed tokens you can use the `bert` backend or `llama.cpp`.
+- No models are required to be downloaded before using the `sentencetransformers` backend. The models will be downloaded automatically the first time the API is used.
 
 {{% /notice %}}
 


### PR DESCRIPTION
**Description**
The documentation website was out of date with regards to the path of the backend to run huggingface models. Since it moved to `backend/python/sentencetransformers`, I updated the documentation accordingly so that people running LocalAI outside of Docker can continue to do so.

I also changed the naming in the example YAML file to refer to the `sentencetransformers` backend instead of the `huggingface-embeddings` backend. The docker version of LocalAI knows both as an alias for the same backend, so this should not break anything there.

P.S.: Perhaps the docs should be updated to give an example on how to use the `transformers` backend as well? As I don't know what it is used for nor how one might use it, I wasn't able to include it in this PR.

**Notes for Reviewers**
The renaming from `huggingface-embeddings` to `sentencetransformers` is a separate commit, so if you don't like it, I can easily remove it from this PR.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->