### PR TITLE
fix: handle grpc and llama-cpp with REBUILD=true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,10 @@ sources/go-llama-ggml/libbinding.a: sources/go-llama-ggml
 sources/go-piper/libpiper_binding.a: sources/go-piper
 	$(MAKE) -C sources/go-piper libpiper_binding.a example/main
 
-get-sources: sources/go-llama sources/go-llama-ggml sources/go-ggml-transformers sources/gpt4all sources/go-piper sources/go-rwkv sources/whisper.cpp sources/go-bert sources/go-stable-diffusion
+backend/cpp/llama/llama.cpp:
+	$(MAKE) -C backend/cpp/llama llama.cpp	
+
+get-sources: backend/cpp/llama/llama.cpp sources/go-llama sources/go-llama-ggml sources/go-ggml-transformers sources/gpt4all sources/go-piper sources/go-rwkv sources/whisper.cpp sources/go-bert sources/go-stable-diffusion
 	touch $@
 
 replace:
@@ -236,6 +239,7 @@ replace:
 
 prepare-sources: get-sources replace
 	$(GOCMD) mod download
+	touch $@
 
 ## GENERIC
 rebuild: ## Rebuilds the project


### PR DESCRIPTION
**Description**

This PR fixes `REBUILD=true` in the container which currently is broken.

It was caused by not handling llama.cpp source code and the grpc dependencies not installed in the final container.

This PR handles now explicitly adds in the Makefile an entry to clone the source code during the preparation of the sources and it copies the grpc built artifacts over the running container and installing them.
