### PR TITLE
fix: OSX Build Fix Part 1: Metal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,12 +68,20 @@ ifndef UNAME_S
 UNAME_S := $(shell uname -s)
 endif
 
-ifeq ($(UNAME_S),Darwin)
+ifeq ($(OS),Darwin)
 	CGO_LDFLAGS += -lcblas -framework Accelerate
-ifneq ($(BUILD_TYPE),metal)
-    # explicit disable metal if on Darwin and metal is disabled
-	CMAKE_ARGS+=-DLLAMA_METAL=OFF
-endif
+	ifeq ($(OSX_SIGNING_IDENTITY),)
+		OSX_SIGNING_IDENTITY := $(shell security find-identity -v -p codesigning | grep '"' | head -n 1 | sed -E 's/.*"(.*)"/\1/')
+	endif
+
+	# on OSX, if BUILD_TYPE is blank, we should default to use Metal
+	ifeq ($(BUILD_TYPE),)
+		BUILD_TYPE=metal
+	else ifneq ($(BUILD_TYPE),metal)
+		    # explicit disable metal if on Darwin and any other value is explicitly passed.
+			CMAKE_ARGS+=-DLLAMA_METAL=OFF
+		endif
+	endif
 endif
 
 ifeq ($(BUILD_TYPE),openblas)
@@ -104,12 +112,6 @@ endif
 
 ifeq ($(BUILD_TYPE),clblas)
 	CGO_LDFLAGS+=-lOpenCL -lclblast
-endif
-
-ifeq ($(OS),Darwin)
-	ifeq ($(OSX_SIGNING_IDENTITY),)
-		OSX_SIGNING_IDENTITY := $(shell security find-identity -v -p codesigning | grep '"' | head -n 1 | sed -E 's/.*"(.*)"/\1/')
-	endif
 endif
 
 # glibc-static or glibc-devel-static required
@@ -411,9 +413,9 @@ backend-assets/grpc/llama: backend-assets/grpc sources/go-llama/libbinding.a
 	$(GOCMD) mod edit -replace github.com/go-skynet/go-llama.cpp=$(shell pwd)/sources/go-llama
 	CGO_LDFLAGS="$(CGO_LDFLAGS)" C_INCLUDE_PATH=$(shell pwd)/sources/go-llama LIBRARY_PATH=$(shell pwd)/sources/go-llama \
 	$(GOCMD) build -ldflags "$(LD_FLAGS)" -tags "$(GO_TAGS)" -o backend-assets/grpc/llama ./backend/go/llm/llama/
-# TODO: every binary should have its own folder instead, so can have different metal implementations
+# TODO: every binary should have its own folder instead, so can have different  implementations
 ifeq ($(BUILD_TYPE),metal)
-	cp go-llama/build/bin/ggml-metal.metal backend-assets/grpc/
+	cp backend/cpp/llama/llama.cpp/ggml-metal.metal backend-assets/grpc/
 endif
 
 ## BACKEND CPP LLAMA START

--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,9 @@ ifeq ($(OS),Darwin)
 	# on OSX, if BUILD_TYPE is blank, we should default to use Metal
 	ifeq ($(BUILD_TYPE),)
 		BUILD_TYPE=metal
+	# disable metal if on Darwin and any other value is explicitly passed.
 	else ifneq ($(BUILD_TYPE),metal)
-		    # explicit disable metal if on Darwin and any other value is explicitly passed.
-			CMAKE_ARGS+=-DLLAMA_METAL=OFF
-		endif
+		CMAKE_ARGS+=-DLLAMA_METAL=OFF
 	endif
 endif
 


### PR DESCRIPTION
It turns out I had _not_ in fact, made Metal the default on OSX for LocalAI to match llama.cpp (where it matters most) - and because of that, I have not been testing with `BUILD_TYPE=metal` for a while... and metal builds were broken due to the backend refactoring.


This PR addresses this issue by: 

- Fixing the `ggml-metal.metal` path
- Centralizing osx-specific logic
- Just making `BUILD_TYPE=metal` the default if `BUILD_TYPE` isn't specified at all and we're on mac so this doesn't happen again


As a sidenote, `GO_TAGS=stablediffusion` on osx is also not currently using brew opencv - that will be corrected in a followup PR as I want to get this one merged first.