### PR TITLE
Correct `models` path for current docker images

### DIFF
--- a/docs/content/howtos/easy-setup-docker-gpu.md
+++ b/docs/content/howtos/easy-setup-docker-gpu.md
@@ -42,7 +42,7 @@ THREADS=2
 GALLERIES=[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index.yaml"}, {"url": "github:go-skynet/model-gallery/huggingface.yaml","name":"huggingface"}]
 
 ## Default path for models
-MODELS_PATH=/models
+MODELS_PATH=/build/models
 
 ## Enable debug mode
 # DEBUG=true
@@ -125,7 +125,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./models:/models
+      - ./models:/build/models
       - ./images/:/tmp/generated/images/
     command: ["/usr/bin/local-ai" ]
 ```


### PR DESCRIPTION
**Description**

The expected `models` path in the Docker image has changed to `/build/models` since the tutorial was written.  Updating documentation to match.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
- [x] No, I didn't sign my commit, and don't have time time or energy to work that out RN.  It's a simple change.
 