### PR TITLE
fix(entrypoint): cd to backend dir before start

### DIFF
--- a/backend/python/exllama/run.sh
+++ b/backend/python/exllama/run.sh
@@ -11,4 +11,6 @@ source activate exllama
 # get the directory where the bash script is located
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+cd $DIR
+
 python $DIR/exllama.py $@

--- a/backend/python/exllama2/run.sh
+++ b/backend/python/exllama2/run.sh
@@ -11,4 +11,6 @@ source activate exllama2
 # get the directory where the bash script is located
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+cd $DIR
+
 python $DIR/exllama2_backend.py $@

--- a/backend/python/vall-e-x/run.sh
+++ b/backend/python/vall-e-x/run.sh
@@ -10,4 +10,6 @@ source activate transformers
 # get the directory where the bash script is located
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+cd $DIR
+
 python $DIR/ttsvalle.py $@


### PR DESCRIPTION
Certain backends as vall-e-x are not meant to be used as a library, so we want to start the process in the same folder where the backend and all the assets are fixes #1394

This sadly wasn't caught by our tests that are running in the same folder the backend. applying the same to exllama as that similarly is not really a library