### PR TITLE
prepend built binaries in PATH for BUILD_GRPC_FOR_BACKEND_LLAMA

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ ifdef BUILD_GRPC_FOR_BACKEND_LLAMA
 	$(MAKE) -C backend/cpp/grpc build
 	export _PROTOBUF_PROTOC=${INSTALLED_PACKAGES}/bin/proto && \
 	export _GRPC_CPP_PLUGIN_EXECUTABLE=${INSTALLED_PACKAGES}/bin/grpc_cpp_plugin && \
-	export PATH="${PATH}:${INSTALLED_PACKAGES}/bin" && \
+	export PATH="${INSTALLED_PACKAGES}/bin:${PATH}" && \
 	CMAKE_ARGS="${CMAKE_ARGS} ${ADDED_CMAKE_ARGS}" LLAMA_VERSION=$(CPPLLAMA_VERSION) $(MAKE) -C backend/cpp/llama grpc-server
 else
 	echo "BUILD_GRPC_FOR_BACKEND_LLAMA is not defined."


### PR DESCRIPTION
**Description**

This PR fixes #1579

`BUILD_GRPC_FOR_BACKEND_LLAMA` didn't account for preinstalled packages related to protobuf/grpc compiler/generator and plugins. Fixing the issue by moving the build artifacts `installed_packages` to the beginning of the modified PATH.

If those packages were installed, the build fails as follows:
```
gmake[4]: Entering directory '/home/dionysius/Projects/github.com/mudler/LocalAI/backend/cpp/llama/llama.cpp/build'
[ 92%] Building CXX object examples/grpc-server/CMakeFiles/hw_grpc_proto.dir/backend.grpc.pb.cc.o
In file included from /home/dionysius/Projects/github.com/mudler/LocalAI/backend/cpp/llama/llama.cpp/build/examples/grpc-server/backend.grpc.pb.cc:5:
/home/dionysius/Projects/github.com/mudler/LocalAI/backend/cpp/llama/llama.cpp/build/examples/grpc-server/backend.pb.h:17:2: error: #error This file was generated by an older version of protoc which is
   17 | #error This file was generated by an older version of protoc which is
      |  ^~~~~
/home/dionysius/Projects/github.com/mudler/LocalAI/backend/cpp/llama/llama.cpp/build/examples/grpc-server/backend.pb.h:18:2: error: #error incompatible with your Protocol Buffer headers. Please
   18 | #error incompatible with your Protocol Buffer headers. Please
      |  ^~~~~
/home/dionysius/Projects/github.com/mudler/LocalAI/backend/cpp/llama/llama.cpp/build/examples/grpc-server/backend.pb.h:19:2: error: #error regenerate this file with a newer version of protoc.
   19 | #error regenerate this file with a newer version of protoc.
      |  ^~~~~
/home/dionysius/Projects/github.com/mudler/LocalAI/backend/cpp/llama/llama.cpp/build/examples/grpc-server/backend.pb.h:41:1: error: ‘PROTOBUF_NAMESPACE_OPEN’ does not name a type
   41 | PROTOBUF_NAMESPACE_OPEN
      | ^~~~~~~~~~~~~~~~~~~~~~~
/home/dionysius/Projects/github.com/mudler/LocalAI/backend/cpp/llama/llama.cpp/build/examples/grpc-server/backend.pb.h:45:1: error: ‘PROTOBUF_NAMESPACE_CLOSE’ does not name a type
   45 | PROTOBUF_NAMESPACE_CLOSE
      | ^~~~~~~~~~~~~~~~~~~~~~~~

...
```

**Notes for Reviewers**
- Tested on devuan daedalus (debian bookworm) with the following packages installed: `protobuf-compiler protobuf-compiler-grpc protobuf-c-compiler libprotobuf-c-dev libprotobuf-dev libprotoc-dev libgrpc-dev libgrpc++-dev`.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->