### PR TITLE
Fix Command Injection Vulnerability

### DIFF
--- a/backend/go/transcribe/transcript.go
+++ b/backend/go/transcribe/transcript.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-skynet/LocalAI/core/schema"
 )
 
-func sh(command []string) (string, error) {
+func runCommand(command []string) (string, error) {
 	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Env = os.Environ()
 	out, err := cmd.CombinedOutput()
@@ -22,7 +22,7 @@ func sh(command []string) (string, error) {
 // TODO: use https://github.com/mccoyst/ogg?
 func audioToWav(src, dst string) error {
     command := []string{"ffmpeg", "-i", src, "-format", "s16le", "-ar", "16000", "-ac", "1", "-acodec", "pcm_s16le", dst}
-	out, err := sh(command)
+	out, err := runCommand(command)
 	if err != nil {
 		return fmt.Errorf("error: %w out: %s", err, out)
 	}

--- a/backend/go/transcribe/transcript.go
+++ b/backend/go/transcribe/transcript.go
@@ -11,21 +11,21 @@ import (
 	"github.com/go-skynet/LocalAI/core/schema"
 )
 
-func sh(c string) (string, error) {
-	cmd := exec.Command("/bin/sh", "-c", c)
+func sh(command []string) (string, error) {
+	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Env = os.Environ()
-	o, err := cmd.CombinedOutput()
-	return string(o), err
+	out, err := cmd.CombinedOutput()
+	return string(out), err
 }
 
-// AudioToWav converts audio to wav for transcribe. It bashes out to ffmpeg
+// AudioToWav converts audio to wav for transcribe.
 // TODO: use https://github.com/mccoyst/ogg?
 func audioToWav(src, dst string) error {
-	out, err := sh(fmt.Sprintf("ffmpeg -i %s -format s16le -ar 16000 -ac 1 -acodec pcm_s16le %s", src, dst))
+    command := []string{"ffmpeg", "-i", src, "-format", "s16le", "-ar", "16000", "-ac", "1", "-acodec", "pcm_s16le", dst}
+	out, err := sh(command)
 	if err != nil {
 		return fmt.Errorf("error: %w out: %s", err, out)
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
**Description**

This PR provide a fix for the command injection in transcript endpoint which has been stated in this [issue](https://github.com/mudler/LocalAI/issues/1777) ( @m0kr4n3 and I  worked together on this vulnerability ).

In the fix, I changed the `sh` function to `runCommand`, and instead of using `/bin/sh` as the program to execute, I directly put the command name  (in this case, ffmpeg) and the rest as arguments. This way, the arguments will only be considered as options, and special characters such as `$, ;, ||` won't have any effect.

@mudler 

Twitter Accounts: @ouxs11, @m0kr4n3



**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 