### PR TITLE
feat(autogpt/transformers): consume `trust_remote_code`

### DIFF
--- a/backend/python/autogptq/autogptq.py
+++ b/backend/python/autogptq/autogptq.py
@@ -33,7 +33,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             model = AutoGPTQForCausalLM.from_quantized(request.Model,
                     model_basename=request.ModelBaseName,
                     use_safetensors=True,
-                    trust_remote_code=True,
+                    trust_remote_code=request.TrustRemoteCode,
                     device=device,
                     use_triton=request.UseTriton,
                     quantize_config=None)

--- a/backend/python/transformers/transformers_server.py
+++ b/backend/python/transformers/transformers_server.py
@@ -69,9 +69,9 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         model_name = request.Model
         try:
             if request.Type == "AutoModelForCausalLM":
-                self.model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
+                self.model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=request.TrustRemoteCode)
             else:
-                self.model = AutoModel.from_pretrained(model_name, trust_remote_code=True)
+                self.model = AutoModel.from_pretrained(model_name, trust_remote_code=request.TrustRemoteCode)
 
             self.tokenizer = AutoTokenizer.from_pretrained(model_name)
             self.CUDA = False


### PR DESCRIPTION
Discussion in our help channel pointed me at the `trust_remote_code` parameter used in Transformers backends.

Currently, this is enabled on default... while convenient, I do not feel that it is wise to expose our users to pickle supply chain attack s, especially since many of them are trying out AI generation for the first time and may not fully understand the risks this option exposes them to.

Down the line, it will make sense to detect the error raised by these backends when they encounter a model that simply doesn't work without custom code so that we can give a clear error message to the user explaining both the solution and the risks involved, but I wanted to get a "quick fix" out stopping the problem while we investigate that.

Luckily, vLLM was already doing the right thing - so we even have a parameter already plumbed through gRPC and it's a simple matter of modifying the python gRPC servers to _actually read it_