### PR TITLE
fix: missing OpenCL libraries from docker containers during clblas docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ models
 examples/chatbot-ui/models
 examples/rwkv/models
 examples/**/models
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -105,6 +105,13 @@ COPY . .
 COPY .git .
 RUN make prepare
 
+# If we are building with clblas support, we need the libraries for the builds
+RUN if [ "${BUILD_TYPE}" = "clblas" ]; then \
+    apt-get update && \
+    apt-get install -y libclblast-dev && \
+    apt-get clean \
+    ; fi
+
 # stablediffusion does not tolerate a newer version of abseil, build it first
 RUN GRPC_BACKENDS=backend-assets/grpc/stablediffusion make build
 
@@ -146,6 +153,13 @@ ENV PIP_CACHE_PURGE=true
 # Add FFmpeg
 RUN if [ "${FFMPEG}" = "true" ]; then \
     apt-get install -y ffmpeg && apt-get clean \
+    ; fi
+
+# Add OpenCL
+RUN if [ "${BUILD_TYPE}" = "clblas" ]; then \
+    apt-get update && \
+    apt-get install -y libclblast1 && \
+    apt-get clean \
     ; fi
 
 WORKDIR /build


### PR DESCRIPTION
**Description**

This PR fixes #1829

**Notes for Reviewers**
This fixes the errors during a `make BUILD_TYPE=clblas docker` run.  This combined with the other fix in #1828 has allowed me to have a functional OpenCL docker image with the following command:

`make BASE_IMAGE=rocm/dev-ubuntu-22.04:6.0-complete BUILD_TYPE=clblas GO_TAGS="tts" docker`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->