### PR TITLE
feat(embeddings): do not require to be configured

### DIFF
--- a/core/backend/embeddings.go
+++ b/core/backend/embeddings.go
@@ -10,10 +10,6 @@ import (
 )
 
 func ModelEmbedding(s string, tokens []int, loader *model.ModelLoader, backendConfig config.BackendConfig, appConfig *config.ApplicationConfig) (func() ([]float32, error), error) {
-	if !backendConfig.Embeddings {
-		return nil, fmt.Errorf("endpoint disabled for this model by API configuration")
-	}
-
 	modelFile := backendConfig.Model
 
 	grpcOpts := gRPCModelOpts(backendConfig)


### PR DESCRIPTION
Certain engines requires to know during model loading if the embedding feature has to be enabled, however, it is impractical to have to set it to ALL the backends that supports embeddings.

There are transformers and sentencentransformers that seamelessly handle both cases, without having this settings to be explicitly enabled.

The case sussist only for ggml-based models that needs to enable featuresets during model loading (and thus settings `embedding` is required), however most of the other engines does not require this.

This change disables the check done at code side, making easier to use embeddings by not having to specify explicitly `embeddings: true`.

Part of: https://github.com/mudler/LocalAI/issues/1373
