### PR TITLE
Accelerate docker build utilizing available threads (Universal)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ ARG MAKEFLAGS
 
 ENV GRPC_BACKENDS=${GRPC_BACKENDS}
 ENV GO_TAGS=${GO_TAGS}
-ENV MAKEFLAGS=${MAKEFLAGS}
+ENV MAKEFLAGS=${MAKEFLAGS} 
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV NVIDIA_REQUIRE_CUDA="cuda>=${CUDA_MAJOR_VERSION}.0"
 ENV NVIDIA_VISIBLE_DEVICES=all
@@ -108,7 +108,6 @@ WORKDIR /build
 
 COPY . .
 COPY .git .
-RUN echo "GO_TAGS: $GO_TAGS"
 RUN make prepare
 
 # If we are building with clblas support, we need the libraries for the builds
@@ -119,17 +118,17 @@ RUN if [ "${BUILD_TYPE}" = "clblas" ]; then \
     ; fi
 
 # stablediffusion does not tolerate a newer version of abseil, build it first
-RUN GRPC_BACKENDS=backend-assets/grpc/stablediffusion make build
+RUN GRPC_BACKENDS=backend-assets/grpc/stablediffusion make build -j $(nproc)
 
 RUN if [ "${BUILD_GRPC}" = "true" ]; then \
-    git clone --recurse-submodules --jobs 4 -b v1.58.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
+    git clone --recurse-submodules --jobs $(nproc) -b v1.58.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
     cd grpc && mkdir -p cmake/build && cd cmake/build && cmake -DgRPC_INSTALL=ON \
       -DgRPC_BUILD_TESTS=OFF \
-       ../.. && make install \
+       ../.. && make install -j $(nproc) \
     ; fi
 
 # Rebuild with defaults backends
-RUN make build
+RUN make build -j $(nproc)
 
 RUN if [ ! -d "/build/sources/go-piper/piper-phonemize/pi/lib/" ]; then \
     mkdir -p /build/sources/go-piper/piper-phonemize/pi/lib/ \
@@ -181,7 +180,7 @@ COPY . .
 COPY --from=builder /build/sources ./sources/
 COPY --from=builder /build/grpc ./grpc/
 
-RUN make prepare-sources && cd /build/grpc/cmake/build && make install && rm -rf grpc
+RUN make prepare-sources && cd /build/grpc/cmake/build && make install -j $(nproc) && rm -rf grpc
 
 # Copy the binary
 COPY --from=builder /build/local-ai ./
@@ -194,43 +193,43 @@ COPY --from=builder /build/backend-assets/grpc/stablediffusion ./backend-assets/
 
 ## Duplicated from Makefile to avoid having a big layer that's hard to push
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/autogptq \
+    make -C backend/python/autogptq -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/bark \
+    make -C backend/python/bark -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/diffusers \
+    make -C backend/python/diffusers -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/vllm \
+    make -C backend/python/vllm -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/mamba \
+    make -C backend/python/mamba -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/sentencetransformers \
+    make -C backend/python/sentencetransformers -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/transformers \
+    make -C backend/python/transformers -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/vall-e-x \
+    make -C backend/python/vall-e-x -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/exllama \
+    make -C backend/python/exllama -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/exllama2 \
+    make -C backend/python/exllama2 -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/petals \
+    make -C backend/python/petals -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/transformers-musicgen \
+    make -C backend/python/transformers-musicgen -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/coqui \
+    make -C backend/python/coqui -j $(nproc) \
     ; fi
 
 # Make sure the models directory exists


### PR DESCRIPTION
**Description**
This should auto detect available threads on the system and utilize all threads to accelerate build.
This has been tested locally using a 12900k using "llama" backend.

## WARNING ##
This will utilize ALL threads the cpu reports which may trigger a power limiter for some users (but should still be faster)

This PR fixes #
Slow build times.

**Notes for Reviewers**
Needs to be tested to verify that it does not break anything. 

Env file for build tested:
```
BUILD_TYPE=cuBLAS
THREADS=16
CMAKE_ARGS="-DLLAMA_F16C=ON -DLLAMA_AVX512=OFF -DLLAMA_AVX2=ON -DLLAMA_AVX=ON -DLLAMA_FMA=ON -Dcpu=x86_64"
GALLERIES=[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index.yaml"}, {"url": "github:go-skynet/model-gallery/huggingface.yaml","name":"huggingface"}]
DEBUG=true
SINGLE_ACTIVE_BACKEND=true
REBUILD=true
BUILD_GRPC_FOR_BACKEND_LLAMA=true
GO_TAGS=tts stablediffusion
PYTHON_GRPC_MAX_WORKERS=3
LLAMACPP_PARALLEL=1
PARALLEL_REQUESTS=true
MODELS_PATH=/build/models
HUGGINGFACE_HUB_CACHE=/build/models/huggingface
WATCHDOG_IDLE=true
WATCHDOG_IDLE_TIMEOUT=1m
IMAGE_PATH=images
SUNO_OFFLOAD_CPU=true
SUNO_USE_SMALL_MODELS=true
```

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ x ] Yes, I signed my commits.