### PR TITLE
Accelerate docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,17 +119,17 @@ RUN if [ "${BUILD_TYPE}" = "clblas" ]; then \
     ; fi
 
 # stablediffusion does not tolerate a newer version of abseil, build it first
-RUN GRPC_BACKENDS=backend-assets/grpc/stablediffusion make build
+RUN GRPC_BACKENDS=backend-assets/grpc/stablediffusion make build -j $(nproc)
 
 RUN if [ "${BUILD_GRPC}" = "true" ]; then \
-    git clone --recurse-submodules --jobs 4 -b v1.58.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
+    git clone --recurse-submodules --jobs $(nproc) -b v1.58.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
     cd grpc && mkdir -p cmake/build && cd cmake/build && cmake -DgRPC_INSTALL=ON \
       -DgRPC_BUILD_TESTS=OFF \
-       ../.. && make install \
+       ../.. && make install -j $(nproc) \
     ; fi
 
 # Rebuild with defaults backends
-RUN make build
+RUN make build -j $(nproc)
 
 RUN if [ ! -d "/build/sources/go-piper/piper-phonemize/pi/lib/" ]; then \
     mkdir -p /build/sources/go-piper/piper-phonemize/pi/lib/ \
@@ -181,7 +181,7 @@ COPY . .
 COPY --from=builder /build/sources ./sources/
 COPY --from=builder /build/grpc ./grpc/
 
-RUN make prepare-sources && cd /build/grpc/cmake/build && make install && rm -rf grpc
+RUN make prepare-sources && cd /build/grpc/cmake/build && make install -j $(nproc) && rm -rf grpc
 
 # Copy the binary
 COPY --from=builder /build/local-ai ./
@@ -194,43 +194,43 @@ COPY --from=builder /build/backend-assets/grpc/stablediffusion ./backend-assets/
 
 ## Duplicated from Makefile to avoid having a big layer that's hard to push
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/autogptq \
+    make -C backend/python/autogptq -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/bark \
+    make -C backend/python/bark -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/diffusers \
+    make -C backend/python/diffusers -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/vllm \
+    make -C backend/python/vllm -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/mamba \
+    make -C backend/python/mamba -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/sentencetransformers \
+    make -C backend/python/sentencetransformers -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/transformers \
+    make -C backend/python/transformers -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/vall-e-x \
+    make -C backend/python/vall-e-x -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/exllama \
+    make -C backend/python/exllama -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/exllama2 \
+    make -C backend/python/exllama2 -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/petals \
+    make -C backend/python/petals -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/transformers-musicgen \
+    make -C backend/python/transformers-musicgen -j $(nproc) \
     ; fi
 RUN if [ "${IMAGE_TYPE}" = "extras" ]; then \
-    make -C backend/python/coqui \
+    make -C backend/python/coqui -j $(nproc) \
     ; fi
 
 # Make sure the models directory exists


### PR DESCRIPTION
**Description**
This should auto detect available threads on the system and utilize all threads to accelerate build.
This has been tested locally using a 12900k using "llama" backend.

This uses 
```
$(nproc)
```
alternatively this can be used for physical cores which would be optimal but simply "looks" overly complicated.
```
$(lscpu -p | grep -v "#" | sort -u -t, -k 2,4 | wc -l)
```

## WARNING ##
This will utilize ALL threads the cpu reports which may trigger a power limiter for some users (but should still be faster)

This PR fixes #
Slow build times.

**Notes for Reviewers**
Needs to be tested to verify that it does not break anything. 

I am also not sure that the current failures are due to this due to it correctly responding (?)
```
[127.0.0.1]:53416 200 - POST /v1/chat/completions
{"level":"debug","time":"2024-03-19T07:13:25Z","message":"Response: {\"created\":1710832396,\"object\":\"chat.completion\",\"id\":\"ba9a6016-d30d-4c1f-9558-dd75f62617ed\",\"model\":\"rwkv_test\",\"choices\":[{\"index\":0,\"finish_reason\":\"stop\",\"message\":{\"role\":\"assistant\",\"content\":\" No, I can't. My memory is not that good. Could you tell me the day of the week again?\"}}],\"usage\":{\"prompt_tokens\":0,\"completion_tokens\":0,\"total_tokens\":0}}"}
  [FAILED] in [It] - /home/runner/work/LocalAI/LocalAI/core/http/api_test.go:815 @ 03/19/24 07:13:25.193
• [FAILED] [52.557 seconds]
API test API query backends [It] runs rwkv chat completion
/home/runner/work/LocalAI/LocalAI/core/http/api_test.go:807

  [FAILED] Expected
      <string>:  No, I can't. My memory is not that good. Could you tell me the day of the week again?
  To satisfy at least one of these matchers: [%!s(*matchers.ContainSubstringMatcher=&{Sure []}) %!s(*matchers.ContainSubstringMatcher=&{five []})]
  In [It] at: /home/runner/work/LocalAI/LocalAI/core/http/api_test.go:815 @ 03/19/24 07:13:25.193
  ```

Env file for build tested:
```
BUILD_TYPE=cublas
THREADS=16
CMAKE_ARGS="-DLLAMA_F16C=ON -DLLAMA_AVX512=OFF -DLLAMA_AVX2=ON -DLLAMA_AVX=ON -DLLAMA_FMA=ON -Dcpu=x86_64"
GALLERIES=[{"name":"model-gallery", "url":"github:go-skynet/model-gallery/index.yaml"}, {"url": "github:go-skynet/model-gallery/huggingface.yaml","name":"huggingface"}]
DEBUG=true
SINGLE_ACTIVE_BACKEND=true
REBUILD=true
BUILD_GRPC_FOR_BACKEND_LLAMA=true
GO_TAGS=tts stablediffusion
PYTHON_GRPC_MAX_WORKERS=3
LLAMACPP_PARALLEL=1
PARALLEL_REQUESTS=true
MODELS_PATH=/build/models
HUGGINGFACE_HUB_CACHE=/build/models/huggingface
WATCHDOG_IDLE=true
WATCHDOG_IDLE_TIMEOUT=1m
IMAGE_PATH=images
SUNO_OFFLOAD_CPU=true
SUNO_USE_SMALL_MODELS=true
```

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ x ] Yes, I signed my commits.