### PR TITLE
Enhance autogptq backend to support VL models

### DIFF
--- a/backend/python/autogptq/autogptq.py
+++ b/backend/python/autogptq/autogptq.py
@@ -5,6 +5,7 @@ import signal
 import sys
 import os
 import time
+import urllib.parse
 
 import grpc
 import backend_pb2
@@ -68,7 +69,8 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
 
         
         prompt_images = self.recompile_vl_prompt(request)
-        print(f"Prompt: {prompt_images[0]}", file=sys.stderr)
+        compiled_prompt = prompt_images[0]
+        print(f"Prompt: {compiled_prompt}", file=sys.stderr)
 
         # Implement Predict RPC
         pipeline = TextGenerationPipeline(
@@ -79,11 +81,11 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             top_p=top_p,
             repetition_penalty=penalty,
             )
-        t = pipeline(prompt_images[0])[0]["generated_text"]
-        # Remove prompt from response if present
+        t = pipeline(compiled_prompt)[0]["generated_text"]
         print(f"generated_text: {t}", file=sys.stderr)
-        if request.Prompt in t:
-            t = t.replace(request.Prompt, "")
+        
+        if compiled_prompt in t:
+            t = t.replace(compiled_prompt, "")
         # house keeping. Remove the image files from /tmp folder
         for img_path in prompt_images[1]:
             try:

--- a/backend/python/autogptq/autogptq.py
+++ b/backend/python/autogptq/autogptq.py
@@ -5,7 +5,7 @@ import signal
 import sys
 import os
 import time
-import urllib.parse
+import base64
 
 import grpc
 import backend_pb2
@@ -114,7 +114,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 timestamp = str(int(time.time() * 1000))  # Generate timestamp
                 img_path = f"/tmp/vl-{timestamp}.jpg"  # Use timestamp in filename
                 with open(img_path, "wb") as f:
-                    f.write(img)
+                    f.write(base64.b64decode(img))
                 image_paths.append(img_path)
                 prompt = prompt.replace(f"[img-{i}]", "<img>" + img_path + "</img>,")
         else:

--- a/backend/python/autogptq/autogptq.yml
+++ b/backend/python/autogptq/autogptq.yml
@@ -24,12 +24,12 @@ dependencies:
   - xz=5.4.2=h5eee18b_0
   - zlib=1.2.13=h5eee18b_0
   - pip:
-      - accelerate==0.23.0
+      - accelerate==0.27.0
       - aiohttp==3.8.5
       - aiosignal==1.3.1
       - async-timeout==4.0.3
       - attrs==23.1.0
-      - auto-gptq==0.4.2
+      - auto-gptq==0.7.1
       - certifi==2023.7.22
       - charset-normalizer==3.3.0
       - datasets==2.14.5
@@ -59,6 +59,7 @@ dependencies:
       - nvidia-nccl-cu12==2.18.1
       - nvidia-nvjitlink-cu12==12.2.140
       - nvidia-nvtx-cu12==12.1.105
+      - optimum==1.17.1
       - packaging==23.2
       - pandas==2.1.1
       - peft==0.5.0
@@ -75,9 +76,11 @@ dependencies:
       - six==1.16.0
       - sympy==1.12
       - tokenizers==0.14.0
-      - torch==2.1.0
       - tqdm==4.66.1
+      - torch==2.2.1
+      - torchvision==0.17.1
       - transformers==4.34.0
+      - transformers_stream_generator==0.0.5
       - triton==2.1.0
       - typing-extensions==4.8.0
       - tzdata==2023.3

--- a/backend/python/autogptq/autogptq.yml
+++ b/backend/python/autogptq/autogptq.yml
@@ -1,3 +1,7 @@
+####
+# Attention! This file is abandoned. 
+# Please use the ../common-env/transformers/transformers.yml file to manage dependencies.
+###
 name: autogptq
 channels:
   - defaults

--- a/backend/python/common-env/transformers/transformers-nvidia.yml
+++ b/backend/python/common-env/transformers/transformers-nvidia.yml
@@ -24,10 +24,11 @@ dependencies:
   - xz=5.4.2=h5eee18b_0
   - zlib=1.2.13=h5eee18b_0
   - pip:
-      - accelerate==0.23.0
+      - accelerate==0.27.0
       - aiohttp==3.8.5
       - aiosignal==1.3.1
       - async-timeout==4.0.3
+      - auto-gptq==0.7.1
       - attrs==23.1.0
       - bark==0.1.5
       - bitsandbytes==0.43.0
@@ -69,6 +70,7 @@ dependencies:
       - nvidia-nccl-cu12==2.18.1
       - nvidia-nvjitlink-cu12==12.2.140
       - nvidia-nvtx-cu12==12.1.105
+      - optimum==1.17.1
       - packaging==23.2
       - pandas
       - peft==0.5.0
@@ -87,7 +89,8 @@ dependencies:
       - six==1.16.0
       - sympy==1.12
       - tokenizers
-      - torch==2.1.2
+      - torch==2.2.1
+      - torchvision==0.17.1
       - torchaudio==2.1.2
       - tqdm==4.66.1
       - triton==2.1.0
@@ -116,5 +119,6 @@ dependencies:
       - vocos
       - vllm==0.3.2
       - transformers>=4.38.2  # Updated Version
+      - transformers_stream_generator==0.0.5
       - xformers==0.0.23.post1  
 prefix: /opt/conda/envs/transformers

--- a/backend/python/common-env/transformers/transformers-nvidia.yml
+++ b/backend/python/common-env/transformers/transformers-nvidia.yml
@@ -98,7 +98,6 @@ dependencies:
       - tzdata==2023.3
       - urllib3==1.26.17
       - xxhash==3.4.1
-      - auto-gptq==0.6.0
       - yarl==1.9.2
       - soundfile
       - langid

--- a/backend/python/common-env/transformers/transformers-rocm.yml
+++ b/backend/python/common-env/transformers/transformers-rocm.yml
@@ -83,7 +83,6 @@ dependencies:
       - triton==2.1.0
       - typing-extensions==4.8.0
       - tzdata==2023.3
-      - auto-gptq==0.6.0
       - urllib3==1.26.17
       - xxhash==3.4.1
       - yarl==1.9.2

--- a/backend/python/common-env/transformers/transformers-rocm.yml
+++ b/backend/python/common-env/transformers/transformers-rocm.yml
@@ -26,7 +26,8 @@ dependencies:
   - pip:
       - --pre
       - --extra-index-url https://download.pytorch.org/whl/nightly/
-      - accelerate==0.23.0
+      - accelerate==0.27.0
+      - auto-gptq==0.7.1
       - aiohttp==3.8.5
       - aiosignal==1.3.1
       - async-timeout==4.0.3
@@ -90,6 +91,7 @@ dependencies:
       - langid
       - wget
       - unidecode
+      - optimum==1.17.1
       - pyopenjtalk-prebuilt
       - pypinyin
       - inflect
@@ -105,5 +107,6 @@ dependencies:
       - vocos
       - vllm==0.3.2
       - transformers>=4.38.2  # Updated Version
+      - transformers_stream_generator==0.0.5
       - xformers==0.0.23.post1
 prefix: /opt/conda/envs/transformers

--- a/backend/python/common-env/transformers/transformers.yml
+++ b/backend/python/common-env/transformers/transformers.yml
@@ -24,9 +24,10 @@ dependencies:
   - xz=5.4.2=h5eee18b_0
   - zlib=1.2.13=h5eee18b_0
   - pip:
-      - accelerate==0.23.0
+      - accelerate==0.27.0
       - aiohttp==3.8.5
       - aiosignal==1.3.1
+      - auto-gptq==0.7.1
       - async-timeout==4.0.3
       - attrs==23.1.0
       - bark==0.1.5
@@ -56,6 +57,7 @@ dependencies:
       - multiprocess==0.70.15
       - networkx
       - numpy==1.26.0
+      - optimum==1.17.1
       - packaging==23.2
       - pandas
       - peft==0.5.0
@@ -74,7 +76,8 @@ dependencies:
       - six==1.16.0
       - sympy==1.12
       - tokenizers
-      - torch==2.1.2
+      - torch==2.2.1
+      - torchvision==0.17.1
       - torchaudio==2.1.2
       - tqdm==4.66.1
       - triton==2.1.0
@@ -103,5 +106,6 @@ dependencies:
       - vocos
       - vllm==0.3.2
       - transformers>=4.38.2  # Updated Version
+      - transformers_stream_generator==0.0.5
       - xformers==0.0.23.post1  
 prefix: /opt/conda/envs/transformers

--- a/backend/python/common-env/transformers/transformers.yml
+++ b/backend/python/common-env/transformers/transformers.yml
@@ -83,7 +83,6 @@ dependencies:
       - triton==2.1.0
       - typing-extensions==4.8.0
       - tzdata==2023.3
-      - auto-gptq==0.6.0
       - urllib3==1.26.17
       - xxhash==3.4.1
       - yarl==1.9.2


### PR DESCRIPTION
**Description**

Due to prompt template incompatible with current prompt processing flow, I removed support for `internlm/internlm-xcomposer2-vl-7b-4bit` in this PR. I may add the support in a separate PR.

This PR fixes #1812, and enhanced AutoGPTQ to support `Qwen/Qwen-VL-Chat-Int4` ~~and `internlm/internlm-xcomposer2-vl-7b-4bit`~~ models. 
~~The AutoGPTQ version is updated to `v0.7.1`, and enables  `use_marlin` flag for `internlm/internlm-xcomposer2-vl-7b-4bit` by default. Please make sure you have the correct model in place. Ref: https://github.com/IST-DASLab/marlin~~

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
