### PR TITLE
NVIDIA GPU detection support for WSL2 environments

### DIFF
--- a/aio/entrypoint.sh
+++ b/aio/entrypoint.sh
@@ -33,6 +33,17 @@ function detect_gpu() {
                 else
                     echo "Intel GPU detected, but Intel GPU drivers are not installed. GPU acceleration will not be available."
                 fi
+            elif lspci | grep -E 'VGA|3D' | grep -iq "Microsoft Corporation Device 008e"; then
+                # We make the assumption this WSL2 cars is NVIDIA, then check for nvidia-smi
+                # Make sure the container was run with `--gpus all` as the only required parameter
+                echo "NVIDIA GPU detected via WSL2"
+                # nvidia-smi should be installed in the container
+                if nvidia-smi; then
+                    GPU_ACCELERATION=true
+                    GPU_VENDOR=nvidia
+                else
+                    echo "NVIDIA GPU detected via WSL2, but nvidia-smi is not installed. GPU acceleration will not be available."
+                fi
             fi
             ;;
         Darwin)


### PR DESCRIPTION
This change makes the assumption that "Microsoft Corporation Device 008e" is an NVIDIA CUDA device. If this is not the case, please update the hardware detection script here.

**Description**

This PR fixes #1890

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->