### PR TITLE
Fix NVIDIA VRAM detection on WSL2 environments

### DIFF
--- a/aio/entrypoint.sh
+++ b/aio/entrypoint.sh
@@ -73,7 +73,7 @@ function detect_gpu_size() {
             #fi
         else
             echo "Unable to determine NVIDIA GPU memory size. Falling back to CPU."
-            GPU_SIZE=cpu
+            GPU_SIZE=gpu-8g
         fi
 
     # Default to a generic GPU size until we implement GPU size detection for non NVIDIA GPUs

--- a/aio/entrypoint.sh
+++ b/aio/entrypoint.sh
@@ -57,29 +57,33 @@ function detect_gpu() {
 }
 
 function detect_gpu_size() {
-    if [ "$GPU_ACCELERATION" = true ]; then
-        GPU_SIZE=gpu-8g
-    fi
-
     # Attempting to find GPU memory size for NVIDIA GPUs
-    if echo "$gpu_model" | grep -iq nvidia; then
+    if [ "$GPU_ACCELERATION" = true ] && [ "$GPU_VENDOR" = "nvidia" ]; then
         echo "NVIDIA GPU detected. Attempting to find memory size..."
-        nvidia_sm=($(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits))
+        # Using head -n 1 to get the total memory of the 1st NVIDIA GPU detected.
+        # If handling multiple GPUs is required in the future, this is the place to do it
+        nvidia_sm=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits | head -n 1)
         if [ ! -z "$nvidia_sm" ]; then
-            echo "Total GPU Memory: ${nvidia_sm[0]} MiB"
+            echo "Total GPU Memory: $nvidia_sm MiB"
+            # if bigger than 8GB, use 16GB
+            #if [ "$nvidia_sm" -gt 8192 ]; then
+            #    GPU_SIZE=gpu-16g
+            #else
+            GPU_SIZE=gpu-8g
+            #fi
         else
-            echo "Unable to determine NVIDIA GPU memory size."
+            echo "Unable to determine NVIDIA GPU memory size. Falling back to CPU."
+            GPU_SIZE=cpu
         fi
-        # if bigger than 8GB, use 16GB
-        #if [ "$nvidia_sm" -gt 8192 ]; then
-        #    GPU_SIZE=gpu-16g
-        #fi
-    else
-        echo "Non-NVIDIA GPU detected. GPU memory size detection for non-NVIDIA GPUs is not supported in this script."
-    fi
+
+    # Default to a generic GPU size until we implement GPU size detection for non NVIDIA GPUs
+    elif [ "$GPU_ACCELERATION" = true ]; then
+        echo "Non-NVIDIA GPU detected. Specific GPU memory size detection is not implemented."
+        GPU_SIZE=gpu-8g
 
     # default to cpu if GPU_SIZE is not set
-    if [ -z "$GPU_SIZE" ]; then
+    else
+        echo "GPU acceleration is not enabled or supported. Defaulting to CPU."
         GPU_SIZE=cpu
     fi
 }


### PR DESCRIPTION
More robust single NVIDIA GPU memory detection, following the improved NVIDIA WSL2 detection patch yesterday #1891.

Tested and working on WSL2, Linux.

**Description**

This PR fixes #1893

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->