### PR TITLE
fix: downgrade torch

### DIFF
--- a/backend/python/common-env/transformers/transformers-nvidia.yml
+++ b/backend/python/common-env/transformers/transformers-nvidia.yml
@@ -89,8 +89,8 @@ dependencies:
       - six==1.16.0
       - sympy==1.12
       - tokenizers
-      - torch==2.2.1
-      - torchvision==0.17.1
+      - torch==2.1.2
+      - torchvision==0.16.2
       - torchaudio==2.1.2
       - tqdm==4.66.1
       - triton==2.1.0

--- a/backend/python/common-env/transformers/transformers.yml
+++ b/backend/python/common-env/transformers/transformers.yml
@@ -76,8 +76,8 @@ dependencies:
       - six==1.16.0
       - sympy==1.12
       - tokenizers
-      - torch==2.2.1
-      - torchvision==0.17.1
+      - torch==2.1.2
+      - torchvision==0.16.2
       - torchaudio==2.1.2
       - tqdm==4.66.1
       - triton==2.1.0


### PR DESCRIPTION
**Description**

This PR downgrades torch - auto-gptq does not need new torch and not all the libs we use in the transformer environment are ready for the bump.

follow up of #1860 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->