### PR TITLE
fix(swagger): do not specify a host

### DIFF
--- a/core/http/api.go
+++ b/core/http/api.go
@@ -51,7 +51,6 @@ func readAuthHeader(c *fiber.Ctx) string {
 // @contact.url https://localai.io
 // @license.name MIT
 // @license.url https://raw.githubusercontent.com/mudler/LocalAI/master/LICENSE
-// @host localhost:8080
 // @BasePath /
 // @securityDefinitions.apikey BearerAuth
 // @in header

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -785,7 +785,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "2.0.0",
-	Host:             "localhost:8080",
+	Host:             "",
 	BasePath:         "/",
 	Schemes:          []string{},
 	Title:            "LocalAI API",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -13,7 +13,6 @@
         },
         "version": "2.0.0"
     },
-    "host": "localhost:8080",
     "basePath": "/",
     "paths": {
         "/v1/assistants": {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -365,7 +365,6 @@ definitions:
       type:
         type: string
     type: object
-host: localhost:8080
 info:
   contact:
     name: LocalAI


### PR DESCRIPTION
In this way the requests are redirected to the host used by the client to perform the request.
