### PR TITLE
fix: use exec in entrypoint scripts to fix signal handling

### DIFF
--- a/aio/entrypoint.sh
+++ b/aio/entrypoint.sh
@@ -135,4 +135,4 @@ check_vars
 
 echo "===> Starting LocalAI[$PROFILE] with the following models: $MODELS"
 
-/build/entrypoint.sh "$@"
+exec /build/entrypoint.sh "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,4 +47,4 @@ else
 	echo "@@@@@"
 fi
 
-./local-ai "$@"
+exec ./local-ai "$@"


### PR DESCRIPTION
**Description**

The Docker entrypoint scripts should use exec so that the process they call gets PID 1.  This will ensure that when docker/kubernetes/etc sends a signal to the container, it is received by local-ai.  This fixes localai pods/containers taking a long time to exit when you request the pod to stop.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->