### PR TITLE
fix(llama.cpp-ggml): fixup `max_tokens` for old backend

### DIFF
--- a/core/config/backend_config.go
+++ b/core/config/backend_config.go
@@ -210,7 +210,7 @@ func (cfg *BackendConfig) SetDefaults(opts ...ConfigLoaderOption) {
 	defaultMirostatETA := 0.1
 	defaultTypicalP := 1.0
 	defaultTFZ := 1.0
-	defaultInfinity := -1
+	defaultZero := 0
 
 	// Try to offload all GPU layers (if GPU is found)
 	defaultHigh := 99999999
@@ -254,7 +254,7 @@ func (cfg *BackendConfig) SetDefaults(opts ...ConfigLoaderOption) {
 	}
 
 	if cfg.Maxtokens == nil {
-		cfg.Maxtokens = &defaultInfinity
+		cfg.Maxtokens = &defaultZero
 	}
 
 	if cfg.Mirostat == nil {


### PR DESCRIPTION
**Description**

likely caused by #2087. The old binding does not recognize -1, and tries to allocate a slice of length of -1.

llama.cpp instead is already configured to set infinite tokens if a value of 0 of max_tokens is specified.