### PR TITLE
fix: reduce chmod permissions for created files and directories

### DIFF
--- a/core/backend/options.go
+++ b/core/backend/options.go
@@ -109,7 +109,7 @@ func gRPCPredictOpts(c config.BackendConfig, modelPath string) *pb.PredictOption
 	promptCachePath := ""
 	if c.PromptCachePath != "" {
 		p := filepath.Join(modelPath, c.PromptCachePath)
-		os.MkdirAll(filepath.Dir(p), 0755)
+		os.MkdirAll(filepath.Dir(p), 0750)
 		promptCachePath = p
 	}
 

--- a/core/backend/tts.go
+++ b/core/backend/tts.go
@@ -53,7 +53,7 @@ func ModelTTS(backend, text, modelFile, voice string, loader *model.ModelLoader,
 		return "", nil, fmt.Errorf("could not load piper model")
 	}
 
-	if err := os.MkdirAll(appConfig.AudioDir, 0755); err != nil {
+	if err := os.MkdirAll(appConfig.AudioDir, 0750); err != nil {
 		return "", nil, fmt.Errorf("failed creating audio directory: %s", err)
 	}
 

--- a/core/http/app.go
+++ b/core/http/app.go
@@ -175,11 +175,11 @@ func App(cl *config.BackendConfigLoader, ml *model.ModelLoader, appConfig *confi
 	}
 
 	// Make sure directories exists
-	os.MkdirAll(appConfig.ImageDir, 0755)
-	os.MkdirAll(appConfig.AudioDir, 0755)
-	os.MkdirAll(appConfig.UploadDir, 0755)
-	os.MkdirAll(appConfig.ConfigsDir, 0755)
-	os.MkdirAll(appConfig.ModelPath, 0755)
+	os.MkdirAll(appConfig.ImageDir, 0750)
+	os.MkdirAll(appConfig.AudioDir, 0750)
+	os.MkdirAll(appConfig.UploadDir, 0750)
+	os.MkdirAll(appConfig.ConfigsDir, 0750)
+	os.MkdirAll(appConfig.ModelPath, 0750)
 
 	// Load config jsons
 	utils.LoadConfig(appConfig.UploadDir, openai.UploadedFilesFile, &openai.UploadedFiles)

--- a/core/http/app_test.go
+++ b/core/http/app_test.go
@@ -222,7 +222,7 @@ var _ = Describe("API test", func() {
 
 			modelDir = filepath.Join(tmpdir, "models")
 			backendAssetsDir := filepath.Join(tmpdir, "backend-assets")
-			err = os.Mkdir(backendAssetsDir, 0755)
+			err = os.Mkdir(backendAssetsDir, 0750)
 			Expect(err).ToNot(HaveOccurred())
 
 			c, cancel = context.WithCancel(context.Background())
@@ -241,7 +241,7 @@ var _ = Describe("API test", func() {
 			}
 			out, err := yaml.Marshal(g)
 			Expect(err).ToNot(HaveOccurred())
-			err = os.WriteFile(filepath.Join(tmpdir, "gallery_simple.yaml"), out, 0644)
+			err = os.WriteFile(filepath.Join(tmpdir, "gallery_simple.yaml"), out, 0600)
 			Expect(err).ToNot(HaveOccurred())
 
 			galleries := []gallery.Gallery{
@@ -595,7 +595,7 @@ var _ = Describe("API test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			modelDir = filepath.Join(tmpdir, "models")
 			backendAssetsDir := filepath.Join(tmpdir, "backend-assets")
-			err = os.Mkdir(backendAssetsDir, 0755)
+			err = os.Mkdir(backendAssetsDir, 0750)
 			Expect(err).ToNot(HaveOccurred())
 
 			c, cancel = context.WithCancel(context.Background())

--- a/core/http/endpoints/openai/assistant_test.go
+++ b/core/http/endpoints/openai/assistant_test.go
@@ -3,10 +3,6 @@ package openai
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/go-skynet/LocalAI/core/config"
-	"github.com/go-skynet/LocalAI/pkg/model"
-	"github.com/gofiber/fiber/v2"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +12,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-skynet/LocalAI/core/config"
+	"github.com/go-skynet/LocalAI/pkg/model"
+	"github.com/gofiber/fiber/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 var configsDir string = "/tmp/localai/configs"
@@ -49,8 +50,8 @@ func TestAssistantEndpoints(t *testing.T) {
 	}
 
 	_ = os.RemoveAll(appConfig.ConfigsDir)
-	_ = os.MkdirAll(appConfig.ConfigsDir, 0755)
-	_ = os.MkdirAll(modelPath, 0755)
+	_ = os.MkdirAll(appConfig.ConfigsDir, 0750)
+	_ = os.MkdirAll(modelPath, 0750)
 	os.Create(filepath.Join(modelPath, "ggml-gpt4all-j"))
 
 	app := fiber.New(fiber.Config{

--- a/core/http/endpoints/openai/files_test.go
+++ b/core/http/endpoints/openai/files_test.go
@@ -251,7 +251,7 @@ func newMultipartFile(filePath, tag, purpose string) (*strings.Reader, *multipar
 
 // Helper to create test files
 func createTestFile(t *testing.T, name string, sizeMB int, option *config.ApplicationConfig) *os.File {
-	err := os.MkdirAll(option.UploadDir, 0755)
+	err := os.MkdirAll(option.UploadDir, 0750)
 	if err != nil {
 
 		t.Fatalf("Error MKDIR: %v", err)

--- a/core/startup/startup.go
+++ b/core/startup/startup.go
@@ -23,24 +23,24 @@ func Startup(opts ...config.AppOption) (*config.BackendConfigLoader, *model.Mode
 	if options.ModelPath == "" {
 		return nil, nil, nil, fmt.Errorf("options.ModelPath cannot be empty")
 	}
-	err := os.MkdirAll(options.ModelPath, 0755)
+	err := os.MkdirAll(options.ModelPath, 0750)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("unable to create ModelPath: %q", err)
 	}
 	if options.ImageDir != "" {
-		err := os.MkdirAll(options.ImageDir, 0755)
+		err := os.MkdirAll(options.ImageDir, 0750)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("unable to create ImageDir: %q", err)
 		}
 	}
 	if options.AudioDir != "" {
-		err := os.MkdirAll(options.AudioDir, 0755)
+		err := os.MkdirAll(options.AudioDir, 0750)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("unable to create AudioDir: %q", err)
 		}
 	}
 	if options.UploadDir != "" {
-		err := os.MkdirAll(options.UploadDir, 0755)
+		err := os.MkdirAll(options.UploadDir, 0750)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("unable to create UploadDir: %q", err)
 		}

--- a/pkg/assets/extract.go
+++ b/pkg/assets/extract.go
@@ -10,7 +10,7 @@ import (
 
 func ExtractFiles(content embed.FS, extractDir string) error {
 	// Create the target directory if it doesn't exist
-	err := os.MkdirAll(extractDir, 0755)
+	err := os.MkdirAll(extractDir, 0750)
 	if err != nil {
 		return fmt.Errorf("failed to create directory: %v", err)
 	}
@@ -25,7 +25,7 @@ func ExtractFiles(content embed.FS, extractDir string) error {
 		targetFile := filepath.Join(extractDir, path)
 		if d.IsDir() {
 			// Create the directory in the target directory
-			err := os.MkdirAll(targetFile, 0755)
+			err := os.MkdirAll(targetFile, 0750)
 			if err != nil {
 				return fmt.Errorf("failed to create directory: %v", err)
 			}
@@ -39,7 +39,7 @@ func ExtractFiles(content embed.FS, extractDir string) error {
 		}
 
 		// Create the file in the target directory
-		err = os.WriteFile(targetFile, fileData, 0644)
+		err = os.WriteFile(targetFile, fileData, 0600)
 		if err != nil {
 			return fmt.Errorf("failed to write file: %v", err)
 		}

--- a/pkg/downloader/uri.go
+++ b/pkg/downloader/uri.go
@@ -184,7 +184,7 @@ func DownloadFile(url string, filePath, sha string, fileN, total int, downloadSt
 	}
 
 	// Create parent directory
-	err = os.MkdirAll(filepath.Dir(filePath), 0755)
+	err = os.MkdirAll(filepath.Dir(filePath), 0750)
 	if err != nil {
 		return fmt.Errorf("failed to create parent directory for file %q: %v", filePath, err)
 	}

--- a/pkg/gallery/models.go
+++ b/pkg/gallery/models.go
@@ -92,7 +92,7 @@ func ReadConfigFile(filePath string) (*Config, error) {
 
 func InstallModel(basePath, nameOverride string, config *Config, configOverrides map[string]interface{}, downloadStatus func(string, string, string, float64)) error {
 	// Create base path if it doesn't exist
-	err := os.MkdirAll(basePath, 0755)
+	err := os.MkdirAll(basePath, 0750)
 	if err != nil {
 		return fmt.Errorf("failed to create base path: %v", err)
 	}
@@ -125,12 +125,12 @@ func InstallModel(basePath, nameOverride string, config *Config, configOverrides
 		filePath := filepath.Join(basePath, template.Name+".tmpl")
 
 		// Create parent directory
-		err := os.MkdirAll(filepath.Dir(filePath), 0755)
+		err := os.MkdirAll(filepath.Dir(filePath), 0750)
 		if err != nil {
 			return fmt.Errorf("failed to create parent directory for prompt template %q: %v", template.Name, err)
 		}
 		// Create and write file content
-		err = os.WriteFile(filePath, []byte(template.Content), 0644)
+		err = os.WriteFile(filePath, []byte(template.Content), 0600)
 		if err != nil {
 			return fmt.Errorf("failed to write prompt template %q: %v", template.Name, err)
 		}
@@ -170,7 +170,7 @@ func InstallModel(basePath, nameOverride string, config *Config, configOverrides
 			return fmt.Errorf("failed to marshal updated config YAML: %v", err)
 		}
 
-		err = os.WriteFile(configFilePath, updatedConfigYAML, 0644)
+		err = os.WriteFile(configFilePath, updatedConfigYAML, 0600)
 		if err != nil {
 			return fmt.Errorf("failed to write updated config file: %v", err)
 		}

--- a/pkg/gallery/models_test.go
+++ b/pkg/gallery/models_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Model test", func() {
 			}}
 			out, err := yaml.Marshal(gallery)
 			Expect(err).ToNot(HaveOccurred())
-			err = os.WriteFile(filepath.Join(tempdir, "gallery_simple.yaml"), out, 0644)
+			err = os.WriteFile(filepath.Join(tempdir, "gallery_simple.yaml"), out, 0600)
 			Expect(err).ToNot(HaveOccurred())
 
 			galleries := []Gallery{

--- a/pkg/model/process.go
+++ b/pkg/model/process.go
@@ -65,7 +65,7 @@ func (ml *ModelLoader) GetGRPCPID(id string) (int, error) {
 
 func (ml *ModelLoader) startProcess(grpcProcess, id string, serverAddress string) error {
 	// Make sure the process is executable
-	if err := os.Chmod(grpcProcess, 0755); err != nil {
+	if err := os.Chmod(grpcProcess, 0700); err != nil {
 		return err
 	}
 

--- a/pkg/templates/cache_test.go
+++ b/pkg/templates/cache_test.go
@@ -21,9 +21,9 @@ var _ = Describe("TemplateCache", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Writing example template files
-		err = os.WriteFile(filepath.Join(tempDir, "example.tmpl"), []byte("Hello, {{.Name}}!"), 0644)
+		err = os.WriteFile(filepath.Join(tempDir, "example.tmpl"), []byte("Hello, {{.Name}}!"), 0600)
 		Expect(err).NotTo(HaveOccurred())
-		err = os.WriteFile(filepath.Join(tempDir, "empty.tmpl"), []byte(""), 0644)
+		err = os.WriteFile(filepath.Join(tempDir, "empty.tmpl"), []byte(""), 0600)
 		Expect(err).NotTo(HaveOccurred())
 
 		templateCache = templates.NewTemplateCache(tempDir)

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -15,7 +15,7 @@ func SaveConfig(filePath, fileName string, obj any) {
 	}
 
 	absolutePath := filepath.Join(filePath, fileName)
-	err = os.WriteFile(absolutePath, file, 0644)
+	err = os.WriteFile(absolutePath, file, 0600)
 	if err != nil {
 		log.Error().Err(err).Str("filepath", absolutePath).Msg("failed to save configuration file")
 	}

--- a/tests/integration/stores_test.go
+++ b/tests/integration/stores_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Integration tests for the stores backend(s) and internal APIs"
 			tmpdir, err = os.MkdirTemp("", "")
 			Expect(err).ToNot(HaveOccurred())
 			backendAssetsDir := filepath.Join(tmpdir, "backend-assets")
-			err = os.Mkdir(backendAssetsDir, 0755)
+			err = os.Mkdir(backendAssetsDir, 0750)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = assets.ExtractFiles(backendAssets, backendAssetsDir)


### PR DESCRIPTION
quiet more security scanner issues: pass one of chmod restriction to remove group and other permissions

This PR should remove a number of noisy scanner issues like https://github.com/mudler/LocalAI/security/code-scanning/28

@cryptk if you have a minute, please check that the permissions I've picked here will work in all docker scenarios you're aware of. As far as I know, we shouldn't be depending on group or other permissions in any environment, but after the windows + docker mount file event issue... I want to make sure that nothing funky is going on there.