### PR TITLE
feat(gallery): display job status also during navigation

### DIFF
--- a/core/config/backend_config.go
+++ b/core/config/backend_config.go
@@ -238,7 +238,13 @@ func (cfg *BackendConfig) SetDefaults(opts ...ConfigLoaderOption) {
 
 	if cfg.MMap == nil {
 		// MMap is enabled by default
-		cfg.MMap = &trueV
+
+		// Only exception is for Intel GPUs
+		if os.Getenv("XPU") != "" {
+			cfg.MMap = &falseV
+		} else {
+			cfg.MMap = &trueV
+		}
 	}
 
 	if cfg.MMlock == nil {

--- a/core/http/elements/gallery.go
+++ b/core/http/elements/gallery.go
@@ -6,6 +6,7 @@ import (
 	"github.com/chasefleming/elem-go"
 	"github.com/chasefleming/elem-go/attrs"
 	"github.com/go-skynet/LocalAI/pkg/gallery"
+	"github.com/go-skynet/LocalAI/pkg/xsync"
 )
 
 const (
@@ -102,7 +103,7 @@ func cardSpan(text, icon string) elem.Node {
 	)
 }
 
-func ListModels(models []*gallery.GalleryModel, installing map[string]string) string {
+func ListModels(models []*gallery.GalleryModel, installing *xsync.SyncedMap[string, string]) string {
 	//StartProgressBar(uid, "0")
 	modelsElements := []elem.Node{}
 	span := func(s string) elem.Node {
@@ -155,10 +156,8 @@ func ListModels(models []*gallery.GalleryModel, installing map[string]string) st
 
 	actionDiv := func(m *gallery.GalleryModel) elem.Node {
 		galleryID := fmt.Sprintf("%s@%s", m.Gallery.Name, m.Name)
-		currentlyInstalling := false
-		if _, ok := installing[galleryID]; ok {
-			currentlyInstalling = true
-		}
+		currentlyInstalling := installing.Exists(galleryID)
+
 		nodes := []elem.Node{
 			cardSpan("Repository: "+m.Gallery.Name, "fa-brands fa-git-alt"),
 		}
@@ -203,7 +202,7 @@ func ListModels(models []*gallery.GalleryModel, installing map[string]string) st
 			elem.If(
 				currentlyInstalling,
 				elem.Node( // If currently installing, show progress bar
-					elem.Raw(StartProgressBar(installing[galleryID], "0")),
+					elem.Raw(StartProgressBar(installing.Get(galleryID), "0")),
 				), // Otherwise, show install button (if not installed) or display "Installed"
 				elem.If(m.Installed,
 					span("Installed"),

--- a/core/http/elements/gallery.go
+++ b/core/http/elements/gallery.go
@@ -102,7 +102,8 @@ func cardSpan(text, icon string) elem.Node {
 	)
 }
 
-func ListModels(models []*gallery.GalleryModel) string {
+func ListModels(models []*gallery.GalleryModel, installing map[string]string) string {
+	//StartProgressBar(uid, "0")
 	modelsElements := []elem.Node{}
 	span := func(s string) elem.Node {
 		return elem.Span(
@@ -118,6 +119,7 @@ func ListModels(models []*gallery.GalleryModel) string {
 				"data-twe-ripple-init":  "",
 				"data-twe-ripple-color": "light",
 				"class":                 "float-right inline-block rounded bg-primary px-6 pb-2.5 mb-3 pt-2.5 text-xs font-medium uppercase leading-normal text-white shadow-primary-3 transition duration-150 ease-in-out hover:bg-primary-accent-300 hover:shadow-primary-2 focus:bg-primary-accent-300 focus:shadow-primary-2 focus:outline-none focus:ring-0 active:bg-primary-600 active:shadow-primary-2 dark:shadow-black/30 dark:hover:shadow-dark-strong dark:focus:shadow-dark-strong dark:active:shadow-dark-strong",
+				"hx-swap":               "outerHTML",
 				// post the Model ID as param
 				"hx-post": "/browse/install/model/" + fmt.Sprintf("%s@%s", m.Gallery.Name, m.Name),
 			},
@@ -152,6 +154,11 @@ func ListModels(models []*gallery.GalleryModel) string {
 	}
 
 	actionDiv := func(m *gallery.GalleryModel) elem.Node {
+		galleryID := fmt.Sprintf("%s@%s", m.Gallery.Name, m.Name)
+		currentlyInstalling := false
+		if _, ok := installing[galleryID]; ok {
+			currentlyInstalling = true
+		}
 		nodes := []elem.Node{
 			cardSpan("Repository: "+m.Gallery.Name, "fa-brands fa-git-alt"),
 		}
@@ -193,7 +200,16 @@ func ListModels(models []*gallery.GalleryModel) string {
 				},
 				nodes...,
 			),
-			elem.If(m.Installed, span("Installed"), installButton(m)),
+			elem.If(
+				currentlyInstalling,
+				elem.Node( // If currently installing, show progress bar
+					elem.Raw(StartProgressBar(installing[galleryID], "0")),
+				), // Otherwise, show install button (if not installed) or display "Installed"
+				elem.If(m.Installed,
+					span("Installed"),
+					installButton(m),
+				),
+			),
 		)
 	}
 

--- a/pkg/xsync/map.go
+++ b/pkg/xsync/map.go
@@ -1,0 +1,77 @@
+package xsync
+
+import (
+	"sync"
+)
+
+type SyncedMap[K comparable, V any] struct {
+	mu sync.RWMutex
+	m  map[K]V
+}
+
+func NewSyncedMap[K comparable, V any]() *SyncedMap[K, V] {
+	return &SyncedMap[K, V]{
+		m: make(map[K]V),
+	}
+}
+
+func (m *SyncedMap[K, V]) Get(key K) V {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.m[key]
+}
+
+func (m *SyncedMap[K, V]) Keys() []K {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	keys := make([]K, 0, len(m.m))
+	for k := range m.m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func (m *SyncedMap[K, V]) Values() []V {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	values := make([]V, 0, len(m.m))
+	for _, v := range m.m {
+		values = append(values, v)
+	}
+	return values
+}
+
+func (m *SyncedMap[K, V]) Len() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return len(m.m)
+}
+
+func (m *SyncedMap[K, V]) Iterate(f func(key K, value V) bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for k, v := range m.m {
+		if !f(k, v) {
+			break
+		}
+	}
+}
+
+func (m *SyncedMap[K, V]) Set(key K, value V) {
+	m.mu.Lock()
+	m.m[key] = value
+	m.mu.Unlock()
+}
+
+func (m *SyncedMap[K, V]) Delete(key K) {
+	m.mu.Lock()
+	delete(m.m, key)
+	m.mu.Unlock()
+}
+
+func (m *SyncedMap[K, V]) Exists(key K) bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	_, ok := m.m[key]
+	return ok
+}

--- a/pkg/xsync/map_test.go
+++ b/pkg/xsync/map_test.go
@@ -1,0 +1,26 @@
+package xsync_test
+
+import (
+	. "github.com/go-skynet/LocalAI/pkg/xsync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SyncMap", func() {
+
+	Context("Syncmap", func() {
+		It("sets and gets", func() {
+			m := NewSyncedMap[string, string]()
+			m.Set("foo", "bar")
+			Expect(m.Get("foo")).To(Equal("bar"))
+		})
+		It("deletes", func() {
+			m := NewSyncedMap[string, string]()
+			m.Set("foo", "bar")
+			m.Delete("foo")
+			Expect(m.Get("foo")).To(Equal(""))
+			Expect(m.Exists("foo")).To(Equal(false))
+		})
+	})
+})

--- a/pkg/xsync/sync_suite_test.go
+++ b/pkg/xsync/sync_suite_test.go
@@ -1,0 +1,13 @@
+package xsync_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSync(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LocalAI sync test")
+}


### PR DESCRIPTION
**Description**

Previously, if you started installation of a model by clicking on the install button and you hit refresh or change page the progressbar  and the job status would be lost - this change make sure we keep showing the progressbar as long as the job is still running.