### PR TITLE
feat: only keep the build artifacts from the grpc build

### DIFF
--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -201,26 +201,6 @@ jobs:
           username: ${{ secrets.quayUsername }}
           password: ${{ secrets.quayPassword }}
 
-      - name: Cache GRPC
-        uses: docker/build-push-action@v5
-        with:
-          builder: ${{ steps.buildx.outputs.name }}
-          # The build-args MUST be an EXACT match between the image cache and other workflow steps that want to use that cache.
-          # This means that even the MAKEFLAGS have to be an EXACT match.
-          # If the build-args are not an EXACT match, it will result in a cache miss, which will require GRPC to be built from scratch.
-          build-args: |
-            GRPC_BASE_IMAGE=${{ inputs.grpc-base-image || inputs.base-image }}
-            GRPC_MAKEFLAGS=--jobs=4 --output-sync=target
-            GRPC_VERSION=v1.58.0
-          context: .
-          file: ./Dockerfile
-          cache-from: type=gha
-          target: grpc
-          platforms: ${{ inputs.platforms }}
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -228,14 +228,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Inspect image
-        if: github.event_name != 'pull_request'
-        run: |
-          docker pull localai/localai:${{ steps.meta.outputs.version }}
-          docker image inspect localai/localai:${{ steps.meta.outputs.version }}
-          docker pull quay.io/go-skynet/local-ai:${{ steps.meta.outputs.version }}
-          docker image inspect quay.io/go-skynet/local-ai:${{ steps.meta.outputs.version }}
-
       - name: Build and push AIO image
         if: inputs.aio != ''
         uses: docker/build-push-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,16 +148,16 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN git clone --recurse-submodules --jobs 4 -b ${GRPC_VERSION} --depth 1 --shallow-submodules https://github.com/grpc/grpc
-
-WORKDIR /build/grpc/cmake/build
-
 # We install GRPC to a different prefix here so that we can copy in only the build artifacts later
 # saves several hundred MB on the final docker image size vs copying in the entire GRPC source tree
 # and running make install in the target container
-RUN cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX:PATH=/opt/grpc ../.. && \
+RUN git clone --recurse-submodules --jobs 4 -b ${GRPC_VERSION} --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
+    mkdir -p /build/grpc/cmake/build && \
+    cd /build/grpc/cmake/build && \
+    cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DCMAKE_INSTALL_PREFIX:PATH=/opt/grpc ../.. && \
     make && \
-    make install
+    make install && \
+    rm -rf /build
 
 ###################################
 ###################################


### PR DESCRIPTION
**Description**

As we are performing the `make install` in the grpc cache now, the only thing we actually need from that cache are the build artifacts, not the source, or the intermediate artifacts.

This PR updates the cache target so that it will clone, configure, build and install all in one step, and then remove the entire source tree, so that the only data left in the image layer are the final build artifacts that we need.

Looking at some current builds, pulling down that last layer, with ~2.5GB of data, only takes ~20 seconds on the github hosted runners to download and extract the GRPC cache, but they have a very fast connection to the GHA cache.  The self-hosted runners however have threads tied up for at least 4 minutes (and in some cases over 5 minutes) pulling down the cache, so anything we can do to make that cache smaller will have a direct impact on the self-hosted runner build time, and those runners tend to run some of the larger/longer builds anyway. 

In practical numbers, here is the expected size difference in the GRPC cache:

Before:
Uncompressed: 3.75GB
Compressed: 690MB

After:
Uncompressed: 1.36GB
Compressed: 257MB

So this should greatly reduce the download AND extraction time on the self-hosted runners.

This also removes the separate Cache GRPC build step as the GRPC cache is only generated from the master branch now to ensure that all PRs are able to use the same cached items.  The normal Build and Push step is able to pull from the cache on it's own in the same way that the previous Cache GRPC step did.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->