### PR TITLE
[Documentations] Removed invalid numberings from `troubleshooting mac`

### DIFF
--- a/docs/content/docs/getting-started/build.md
+++ b/docs/content/docs/getting-started/build.md
@@ -175,8 +175,9 @@ curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/jso
 
 #### Troublshooting mac
 
-1. If you encounter errors regarding a missing utility metal, install `Xcode` from the App Store.
-2. After the installation of Xcode, if you receive a xcrun error `'xcrun: error: unable to find utility "metal", not a developer tool or in PATH'`. You might have installed the Xcode command line tools before installing Xcode, the former one is pointing to an incomplete SDK.
+If you encounter errors regarding a missing utility metal, install `Xcode` from the App Store.
+
+After the installation of Xcode, if you receive a xcrun error `'xcrun: error: unable to find utility "metal", not a developer tool or in PATH'`. You might have installed the Xcode command line tools before installing Xcode, the former one is pointing to an incomplete SDK.
 
 ```
 # print /Library/Developer/CommandLineTools, if command line tools were installed in advance
@@ -186,8 +187,9 @@ xcode-select --print-path
 sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 ```
 
-3. If completions are slow, ensure that `gpu-layers` in your model yaml matches the number of layers from the model in use (or simply use a high number such as 256).
-4. If you a get a compile error: `error: only virtual member functions can be marked 'final'`, reinstall all the necessary brew packages, clean the build, and try again.
+If completions are slow, ensure that `gpu-layers` in your model yaml matches the number of layers from the model in use (or simply use a high number such as 256).
+
+If you a get a compile error: `error: only virtual member functions can be marked 'final'`, reinstall all the necessary brew packages, clean the build, and try again.
 
 ```
 # reinstall build dependencies

--- a/docs/content/docs/getting-started/build.md
+++ b/docs/content/docs/getting-started/build.md
@@ -173,11 +173,11 @@ curl http://localhost:8080/v1/chat/completions -H "Content-Type: application/jso
    }'
 ```
 
-#### Troublshooting mac
+#### Troubleshooting mac
 
-If you encounter errors regarding a missing utility metal, install `Xcode` from the App Store.
+- If you encounter errors regarding a missing utility metal, install `Xcode` from the App Store.
 
-After the installation of Xcode, if you receive a xcrun error `'xcrun: error: unable to find utility "metal", not a developer tool or in PATH'`. You might have installed the Xcode command line tools before installing Xcode, the former one is pointing to an incomplete SDK.
+- After the installation of Xcode, if you receive a xcrun error `'xcrun: error: unable to find utility "metal", not a developer tool or in PATH'`. You might have installed the Xcode command line tools before installing Xcode, the former one is pointing to an incomplete SDK.
 
 ```
 # print /Library/Developer/CommandLineTools, if command line tools were installed in advance
@@ -187,9 +187,9 @@ xcode-select --print-path
 sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 ```
 
-If completions are slow, ensure that `gpu-layers` in your model yaml matches the number of layers from the model in use (or simply use a high number such as 256).
+- If completions are slow, ensure that `gpu-layers` in your model yaml matches the number of layers from the model in use (or simply use a high number such as 256).
 
-If you a get a compile error: `error: only virtual member functions can be marked 'final'`, reinstall all the necessary brew packages, clean the build, and try again.
+- If you a get a compile error: `error: only virtual member functions can be marked 'final'`, reinstall all the necessary brew packages, clean the build, and try again.
 
 ```
 # reinstall build dependencies


### PR DESCRIPTION
The numbering [here ](https://localai.io/basics/build/#troublshooting-mac) was reset half way, so `1->2->code section->1->2`. 

I think it's likely due to the way HTML/CSS treats nested code sections, the numbering seems to got reset when there is a code section `<div>` in between. 

The [README](https://github.com/mudler/LocalAI/blob/master/docs/content/docs/getting-started/build.md) is fine, it properly displays 1, 2, 3, 4.

![1714328752(1)](https://github.com/mudler/LocalAI/assets/46901221/0f48e6d7-ed15-4af2-a735-6f8704be60ad)

We could think of a better way dealing with this type of question in the future, but sounds like an over-engineering to me. This PR will remove the numbers.

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->