### PR TITLE
feat: OpenVINO acceleration for embeddings in transformer backend

### DIFF
--- a/backend/python/transformers/transformers_server.py
+++ b/backend/python/transformers/transformers_server.py
@@ -153,6 +153,21 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                                                                 ov_config={"PERFORMANCE_HINT": "CUMULATIVE_THROUGHPUT"}, 
                                                                 device=device_map)
                 self.OV = True
+            elif request.Type == "OVModelForFeatureExtraction":
+                from optimum.intel.openvino import OVModelForFeatureExtraction
+                from openvino.runtime import Core
+
+                if "GPU" in Core().available_devices:
+                    device_map="GPU"
+                else:
+                    device_map="CPU"
+                self.model = OVModelForFeatureExtraction.from_pretrained(model_name, 
+                                                                compile=True,
+                                                                trust_remote_code=request.TrustRemoteCode,
+                                                                ov_config={"PERFORMANCE_HINT": "CUMULATIVE_THROUGHPUT"}, 
+                                                                export=True,
+                                                                device=device_map)
+                self.OV = True
             else:
                 self.model = AutoModel.from_pretrained(model_name, 
                                                        trust_remote_code=request.TrustRemoteCode,  


### PR DESCRIPTION
**Description**

This PR fixes implement OpenVINO acceleration for embeddings in transformer backend.
Like for Text Generation the GPU is automatically used if present.

Acceleration is enabled with new argument for `type: OVModelForFeatureExtraction`

example:
```
name: transformer-embedding
backend: transformers
embeddings: true
parameters:
  model: intfloat/multilingual-e5-base
type: OVModelForFeatureExtraction
```

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 
