### PR TITLE
feat: update ROCM and use smaller image

### DIFF
--- a/.github/workflows/image-pr.yml
+++ b/.github/workflows/image-pr.yml
@@ -61,7 +61,7 @@ jobs:
             tag-suffix: '-hipblas'
             ffmpeg: 'false'
             image-type: 'extras'
-            base-image: "rocm/dev-ubuntu-22.04:6.0-complete"
+            base-image: "rocm/dev-ubuntu-22.04:6.1"
             grpc-base-image: "ubuntu:22.04"
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -129,7 +129,7 @@ jobs:
             ffmpeg: 'true'
             image-type: 'extras'
             aio: "-aio-gpu-hipblas"
-            base-image: "rocm/dev-ubuntu-22.04:6.0-complete"
+            base-image: "rocm/dev-ubuntu-22.04:6.1"
             grpc-base-image: "ubuntu:22.04"
             latest-image: 'latest-gpu-hipblas'
             latest-image-aio: 'latest-aio-gpu-hipblas'
@@ -141,7 +141,7 @@ jobs:
             tag-suffix: '-hipblas'
             ffmpeg: 'false'
             image-type: 'extras'
-            base-image: "rocm/dev-ubuntu-22.04:6.0-complete"
+            base-image: "rocm/dev-ubuntu-22.04:6.1"
             grpc-base-image: "ubuntu:22.04"
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
@@ -218,7 +218,7 @@ jobs:
             tag-suffix: '-hipblas-ffmpeg-core'
             ffmpeg: 'true'
             image-type: 'core'
-            base-image: "rocm/dev-ubuntu-22.04:6.0-complete"
+            base-image: "rocm/dev-ubuntu-22.04:6.1"
             grpc-base-image: "ubuntu:22.04"
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
@@ -228,7 +228,7 @@ jobs:
             tag-suffix: '-hipblas-core'
             ffmpeg: 'false'
             image-type: 'core'
-            base-image: "rocm/dev-ubuntu-22.04:6.0-complete"
+            base-image: "rocm/dev-ubuntu-22.04:6.1"
             grpc-base-image: "ubuntu:22.04"
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"

--- a/Dockerfile
+++ b/Dockerfile
@@ -140,6 +140,15 @@ RUN if [ "${BUILD_TYPE}" = "clblas" ]; then \
         rm -rf /var/lib/apt/lists/* \
     ; fi
 
+RUN if [ "${BUILD_TYPE}" = "hipblas" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            hipblas-dev \
+            rocblas-dev && \
+        apt-get clean && \
+        rm -rf /var/lib/apt/lists/* \
+    ; fi
+
 ###################################
 ###################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,7 +146,10 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ]; then \
             hipblas-dev \
             rocblas-dev && \
         apt-get clean && \
-        rm -rf /var/lib/apt/lists/* \
+        rm -rf /var/lib/apt/lists/* && \
+        # I have no idea why, but the ROCM lib packages don't trigger ldconfig after they install, which results in local-ai and others not being able
+        # to locate the libraries. We run ldconfig ourselves to work around this packaging deficiency
+        ldconfig \
     ; fi
 
 ###################################


### PR DESCRIPTION
**Description**

This is an attempt to not only update ROCM to 6.1, which according to the release notes should be compatible with every card that 6.0 is compatible with, but also to move away from the very very large -complete images and instead use the smaller rocm "base" images, while only pulling in the few individual things that we need from the -complete image.

This should save a couple of GB on the resulting images, as well as considerably speed up builds as we won't need to download an ~4.2GB image, but instead an ~970MB image.

**Notes for Reviewers**

I did some local testing, and I was able to build images, but I don't have a ROCM compatible GPU to do any in-depth testing/validation with.

Below is the complete list of packages that are installed in the -complete image that are not installed in the "base" image.

```
half
hipblas
hipblas-dev
hipblaslt
hipblaslt-dev
hipcub-dev
hipfft
hipfft-dev
hiprand
hiprand-dev
hipsolver
hipsolver-dev
hipsparse
hipsparse-dev
hipsparselt
hipsparselt-dev
hiptensor
hiptensor-dev
libamd2
libblas3
libcamd2
libccolamd2
libcholmod3
libcolamd2
libgfortran5
liblapack3
libmetis5
libsuitesparseconfig5
miopen-hip
miopen-hip-dev
rccl
rccl-dev
rocalution
rocalution-dev
rocblas
rocblas-dev
rocfft
rocfft-dev
rocm-libs
rocprim-dev
rocrand
rocrand-dev
rocsolver
rocsolver-dev
rocsparse
rocsparse-dev
rocthrust-dev
rocwmma-dev
```

Of those, the only ones I found that were required for the build to succeed are hipblas-dev and rocblas-dev which pulls in the following package set including dependencies:

```
hipblas
hipblas-dev
rocblas
rocblas-dev
rocsolver
rocsolver-dev
rocsparse
rocsparse-dev
```

We should do some testing and validation on this change in case there are other packages that are somehow needed at runtime but not needed at build time.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->