### PR TITLE
feat(functions): support models with no grammar and no regex

### DIFF
--- a/pkg/functions/parse_test.go
+++ b/pkg/functions/parse_test.go
@@ -82,4 +82,32 @@ var _ = Describe("LocalAI function parse tests", func() {
 			Expect(results[1].Arguments).To(Equal(`{"x":10,"y":7}`))
 		})
 	})
+
+	Context("without grammars and without regex", func() {
+		It("should parse the function name and arguments correctly with the name key", func() {
+			input := `{"name": "add", "arguments": {"x": 5, "y": 3}}`
+			functionConfig.ParallelCalls = false
+			functionConfig.NoGrammar = false
+			functionConfig.ResponseRegex = ""
+			functionConfig.FunctionName = true
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("add"))
+			Expect(results[0].Arguments).To(Equal(`{"x":5,"y":3}`))
+		})
+
+		It("should parse the function name and arguments correctly with the function key", func() {
+			input := `{"function": "add", "arguments": {"x": 5, "y": 3}}`
+			functionConfig.ParallelCalls = false
+			functionConfig.NoGrammar = false
+			functionConfig.ResponseRegex = ""
+			functionConfig.FunctionName = false
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("add"))
+			Expect(results[0].Arguments).To(Equal(`{"x":5,"y":3}`))
+		})
+	})
 })


### PR DESCRIPTION
This allows to forward directly what the LLM returns in JSON without specifying any regex or by disabling entirely grammar. It is of course, at this point all to the LLM to return the correct JSON that we can use in the response.