### PR TITLE
feat(functions): allow to set JSON matcher

### DIFF
--- a/core/http/endpoints/openai/chat.go
+++ b/core/http/endpoints/openai/chat.go
@@ -81,7 +81,7 @@ func ChatEndpoint(cl *config.BackendConfigLoader, ml *model.ModelLoader, startup
 			}
 			responses <- initialMessage
 
-			result, err := handleQuestion(config, req, ml, startupOptions, results, prompt)
+			result, err := handleQuestion(config, req, ml, startupOptions, results, result, prompt)
 			if err != nil {
 				log.Error().Err(err).Msg("error handling question")
 				return
@@ -470,7 +470,7 @@ func ChatEndpoint(cl *config.BackendConfigLoader, ml *model.ModelLoader, startup
 
 				switch {
 				case noActionsToRun:
-					result, err := handleQuestion(config, input, ml, startupOptions, results, predInput)
+					result, err := handleQuestion(config, input, ml, startupOptions, results, s, predInput)
 					if err != nil {
 						log.Error().Err(err).Msg("error handling question")
 						return
@@ -550,7 +550,14 @@ func ChatEndpoint(cl *config.BackendConfigLoader, ml *model.ModelLoader, startup
 	}
 }
 
-func handleQuestion(config *config.BackendConfig, input *schema.OpenAIRequest, ml *model.ModelLoader, o *config.ApplicationConfig, funcResults []functions.FuncCallResults, prompt string) (string, error) {
+func handleQuestion(config *config.BackendConfig, input *schema.OpenAIRequest, ml *model.ModelLoader, o *config.ApplicationConfig, funcResults []functions.FuncCallResults, result, prompt string) (string, error) {
+
+	if len(funcResults) == 0 && result != "" {
+		log.Debug().Msgf("nothing function results but we had a message from the LLM")
+
+		return result, nil
+	}
+
 	log.Debug().Msgf("nothing to do, computing a reply")
 	arg := ""
 	if len(funcResults) > 0 {

--- a/pkg/functions/parse_test.go
+++ b/pkg/functions/parse_test.go
@@ -87,7 +87,7 @@ var _ = Describe("LocalAI function parse tests", func() {
 		It("should parse the function name and arguments correctly with the name key", func() {
 			input := `{"name": "add", "arguments": {"x": 5, "y": 3}}`
 			functionConfig.ParallelCalls = false
-			functionConfig.NoGrammar = false
+			functionConfig.NoGrammar = true
 			functionConfig.ResponseRegex = ""
 			functionConfig.FunctionName = true
 
@@ -100,7 +100,40 @@ var _ = Describe("LocalAI function parse tests", func() {
 		It("should parse the function name and arguments correctly with the function key", func() {
 			input := `{"function": "add", "arguments": {"x": 5, "y": 3}}`
 			functionConfig.ParallelCalls = false
-			functionConfig.NoGrammar = false
+			functionConfig.NoGrammar = true
+			functionConfig.ResponseRegex = ""
+			functionConfig.FunctionName = false
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("add"))
+			Expect(results[0].Arguments).To(Equal(`{"x":5,"y":3}`))
+		})
+
+		It("Should parse the result by matching the JSONRegexMatch", func() {
+			input := `
+<tool_call>
+{"function": "add", "arguments": {"x": 5, "y": 3}}
+</tool_call>`
+			functionConfig.ParallelCalls = false
+			functionConfig.NoGrammar = true
+			functionConfig.JSONRegexMatch = `(?s)<tool_call>(.*?)</tool_call>`
+			functionConfig.ResponseRegex = ""
+			functionConfig.FunctionName = false
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("add"))
+			Expect(results[0].Arguments).To(Equal(`{"x":5,"y":3}`))
+		})
+
+		It("Should parse the result by matching the JSONRegexMatch", func() {
+			input := `
+{"function": "add", "arguments": {"x": 5, "y": 3}}
+</tool_call>`
+			functionConfig.ParallelCalls = false
+			functionConfig.NoGrammar = true
+			functionConfig.JSONRegexMatch = `(?s)(.*?)</tool_call>`
 			functionConfig.ResponseRegex = ""
 			functionConfig.FunctionName = false
 


### PR DESCRIPTION
**Description**

This PR allow to set JSON matcher in the response coming from the LLM, for example:

```yaml
function:
  no_grammar: true
  json_regex_match: "(?s)<tool_call>(.*?)</tool_call>"
```

Should be able to parse responses from hermes pro without JSON grammars
