### PR TITLE
draft feat: roles for api keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ release/
 .idea
 
 # Generated during build
-backend-assets/*
+**/backend-assets/*
 !backend-assets/.keep
 prepare
 /ggml-metal.metal

--- a/configuration/roles.json
+++ b/configuration/roles.json
@@ -1,0 +1,12 @@
+{
+    "admin": ["*"],
+    "llm-user": ["POST|/chat/completions", "POST|/edits", "POST|/completions", "POST|/embeddings", "POST|/rerank", "GET|/models"],
+    "audio-user": ["POST|/audio/transcriptions", "POST|/audio/speech", "POST|/tts", "POST|/text-to-speech"],
+    "image-user": ["POST|/images/generations"],
+    "ui": ["GET|/", "GET|/browse",  "GET|/browse/", "POST|/browse/search/models", 
+        "GET|/browse/job/progress", "GET|/browse/job", 
+        "GET|/chat", "GET|/chat/", "GET|/chat/:model", 
+        "GET|/text2image", "GET|/text2image/", "GET|/text2image/:model", 
+        "GET|/tts", "GET|/tts/", "GET|/tts/:model"],
+    "user": ["ui", "llm-user", "audio-user", "image-user"]
+}

--- a/core/cli/run.go
+++ b/core/cli/run.go
@@ -37,12 +37,12 @@ type RunCMD struct {
 	Threads     int  `env:"LOCALAI_THREADS,THREADS" short:"t" default:"4" help:"Number of threads used for parallel computation. Usage of the number of physical cores in the system is suggested" group:"performance"`
 	ContextSize int  `env:"LOCALAI_CONTEXT_SIZE,CONTEXT_SIZE" default:"512" help:"Default context size for models" group:"performance"`
 
-	Address          string   `env:"LOCALAI_ADDRESS,ADDRESS" default:":8080" help:"Bind address for the API server" group:"api"`
-	CORS             bool     `env:"LOCALAI_CORS,CORS" help:"" group:"api"`
-	CORSAllowOrigins string   `env:"LOCALAI_CORS_ALLOW_ORIGINS,CORS_ALLOW_ORIGINS" group:"api"`
-	UploadLimit      int      `env:"LOCALAI_UPLOAD_LIMIT,UPLOAD_LIMIT" default:"15" help:"Default upload-limit in MB" group:"api"`
-	APIKeys          []string `env:"LOCALAI_API_KEY,API_KEY" help:"List of API Keys to enable API authentication. When this is set, all the requests must be authenticated with one of these API keys" group:"api"`
-	DisableWebUI     bool     `env:"LOCALAI_DISABLE_WEBUI,DISABLE_WEBUI" default:"false" help:"Disable webui" group:"api"`
+	Address          string              `env:"LOCALAI_ADDRESS,ADDRESS" default:":8080" help:"Bind address for the API server" group:"api"`
+	CORS             bool                `env:"LOCALAI_CORS,CORS" help:"" group:"api"`
+	CORSAllowOrigins string              `env:"LOCALAI_CORS_ALLOW_ORIGINS,CORS_ALLOW_ORIGINS" group:"api"`
+	UploadLimit      int                 `env:"LOCALAI_UPLOAD_LIMIT,UPLOAD_LIMIT" default:"15" help:"Default upload-limit in MB" group:"api"`
+	APIKeys          map[string][]string `env:"LOCALAI_API_KEY,API_KEY" help:"List of API Keys to enable API authentication. When this is set, all the requests must be authenticated with one of these API keys" group:"api"`
+	DisableWebUI     bool                `env:"LOCALAI_DISABLE_WEBUI,DISABLE_WEBUI" default:"false" help:"Disable webui" group:"api"`
 
 	ParallelRequests     bool     `env:"LOCALAI_PARALLEL_REQUESTS,PARALLEL_REQUESTS" help:"Enable backends to handle multiple requests in parallel if they support it (e.g.: llama.cpp or vllm)" group:"backends"`
 	SingleActiveBackend  bool     `env:"LOCALAI_SINGLE_ACTIVE_BACKEND,SINGLE_ACTIVE_BACKEND" help:"Allow only one backend to be run at a time" group:"backends"`

--- a/core/config/application_config.go
+++ b/core/config/application_config.go
@@ -28,7 +28,8 @@ type ApplicationConfig struct {
 	PreloadJSONModels                   string
 	PreloadModelsFromPath               string
 	CORSAllowOrigins                    string
-	ApiKeys                             []string
+	ApiKeys                             map[string][]string // ApiKeys maps the key itself to a list of endpoints [or roles] that the key should be permitted to access
+	Roles                               map[string][]string // Roles is a simple "shortcut" mapping a name to a list of endpoints
 
 	ModelLibraryURL string
 
@@ -271,7 +272,7 @@ func WithDynamicConfigDirPollInterval(interval time.Duration) AppOption {
 	}
 }
 
-func WithApiKeys(apiKeys []string) AppOption {
+func WithApiKeys(apiKeys map[string][]string) AppOption {
 	return func(o *ApplicationConfig) {
 		o.ApiKeys = apiKeys
 	}

--- a/core/http/app.go
+++ b/core/http/app.go
@@ -156,7 +156,7 @@ func App(cl *config.BackendConfigLoader, ml *model.ModelLoader, appConfig *confi
 		if apiKey != "" {
 			for key, endpoints := range appConfig.ApiKeys {
 				if apiKey == key {
-					log.Debug().Str("key", key).Str("fmtPath", fmtPath).Msg("found a matching api key, checking permissions for fmtPath")
+					log.Trace().Str("key", key).Str("fmtPath", fmtPath).Msg("found a matching api key, checking permissions for fmtPath")
 					if slices.Contains(endpoints, "*") || slices.Contains(endpoints, fmtPath) {
 						return c.Next()
 					}
@@ -166,7 +166,7 @@ func App(cl *config.BackendConfigLoader, ml *model.ModelLoader, appConfig *confi
 
 		// Check if this is a default-allow endpoint
 		if defaultCaseExists && slices.Contains(appConfig.ApiKeys["_"], fmtPath) {
-			log.Debug().Str("fmtPath", fmtPath).Msg("matching authorization key not found, but fmtPath is on the default allow list")
+			log.Trace().Str("fmtPath", fmtPath).Msg("matching authorization key not found, but fmtPath is on the default allow list")
 			return c.Next()
 		}
 

--- a/core/startup/config_file_watcher.go
+++ b/core/startup/config_file_watcher.go
@@ -152,6 +152,7 @@ func readApiKeysJson(startupAppConfig config.ApplicationConfig) fileHandler {
 					log.Error().Err(err).Msg("unable to parse api_keys.json as any known format")
 					return err
 				}
+				log.Warn().Msg("unable to parse api_keys.json in modern format, defaulting all api keys to [\"ui\", \"user\"]")
 				for _, k := range oldFileFormat {
 					fileKeys[k] = []string{"ui", "user"}
 				}

--- a/core/startup/config_file_watcher.go
+++ b/core/startup/config_file_watcher.go
@@ -145,7 +145,16 @@ func readApiKeysJson(startupAppConfig config.ApplicationConfig) fileHandler {
 			var fileKeys map[string][]string
 			err := json.Unmarshal(fileContent, &fileKeys)
 			if err != nil {
-				return err
+				// Try to deserialize the old, flat list format
+				var oldFileFormat []string
+				err := json.Unmarshal(fileContent, &oldFileFormat)
+				if err != nil {
+					log.Error().Err(err).Msg("unable to parse api_keys.json as any known format")
+					return err
+				}
+				for _, k := range oldFileFormat {
+					fileKeys[k] = []string{"ui", "user"}
+				}
 			}
 
 			appConfig.ApiKeys = startupAppConfig.ApiKeys


### PR DESCRIPTION
## Roles
This was prepared as a quick option in case we want a demo.
Currently working on an improved version using casbin for permanent version - will replace this PR when finished.

---

initial version of a role system for api keys, allowing users to be granted more finely grained access to specific parts of localai

Some notes:

* adds a new configuration file that is shipped by default named `roles.json` - exists to give sane combinations of endpoints easy names, though technically this can be skipped.

* changes how api_keys are interpreted. Now it's a map of api key ==> slice of endpoints 
whenever api_keys.json is evaluated (including at the initial program load) we shake out the endpoint slice - reducing roles to raw endpoints and deduplicating

* the old format for `api_keys.json` still works... and is interpreted as if all keys are `ui user`
* a fake api key of `"_"` represents the set of endpoints that should be authorized for unauthenticated users. Currently this also expands the access of all authenticated users - so `"_"` serves as the single default set of allowed to all endpoints. Let me know if anyone can think of a reason to have the complication of two distinct lists

I'd appreciate help testing every possible use case... as well as ideas for ways to improve `roles.json` such as different groupings or things I've missed


Docs will need to be updated to match this, but I want to do that in a separate PR for organizational reasons. 
