### PR TITLE
feat(functions): mixed JSON BNF grammars

### DIFF
--- a/core/http/endpoints/openai/chat.go
+++ b/core/http/endpoints/openai/chat.go
@@ -219,15 +219,15 @@ func ChatEndpoint(cl *config.BackendConfigLoader, ml *model.ModelLoader, startup
 			// Handle if we should return "name" instead of "functions"
 			if config.FunctionsConfig.FunctionName {
 				jsStruct := funcs.ToJSONNameStructure()
-				config.Grammar = jsStruct.Grammar("", config.FunctionsConfig.ParallelCalls)
+				config.Grammar = jsStruct.Grammar(config.FunctionsConfig.GrammarPrefix, "", config.FunctionsConfig.ParallelCalls, config.FunctionsConfig.GrammarMessage)
 			} else {
 				jsStruct := funcs.ToJSONFunctionStructure()
-				config.Grammar = jsStruct.Grammar("", config.FunctionsConfig.ParallelCalls)
+				config.Grammar = jsStruct.Grammar(config.FunctionsConfig.GrammarPrefix, "", config.FunctionsConfig.ParallelCalls, config.FunctionsConfig.GrammarMessage)
 			}
 		case input.JSONFunctionGrammarObject != nil:
-			config.Grammar = input.JSONFunctionGrammarObject.Grammar("", config.FunctionsConfig.ParallelCalls)
+			config.Grammar = input.JSONFunctionGrammarObject.Grammar(config.FunctionsConfig.GrammarPrefix, "", config.FunctionsConfig.ParallelCalls, config.FunctionsConfig.GrammarMessage)
 		case input.JSONFunctionGrammarObjectName != nil:
-			config.Grammar = input.JSONFunctionGrammarObjectName.Grammar("", config.FunctionsConfig.ParallelCalls)
+			config.Grammar = input.JSONFunctionGrammarObjectName.Grammar(config.FunctionsConfig.GrammarPrefix, "", config.FunctionsConfig.ParallelCalls, config.FunctionsConfig.GrammarMessage)
 		default:
 			// Force picking one of the functions by the request
 			if config.FunctionToCall() != "" {

--- a/pkg/functions/grammar_json_schema_test.go
+++ b/pkg/functions/grammar_json_schema_test.go
@@ -8,6 +8,97 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var testFunctions = []ItemFunction{
+	{
+		Type: "object",
+		Properties: FunctionProperties{
+			Function: FunctionName{
+				Const: "create_event",
+			},
+			Arguments: Argument{ // this is OpenAI's parameter
+				Type: "object",
+				Properties: map[string]interface{}{
+					"title": map[string]string{"type": "string"},
+					"date":  map[string]string{"type": "string"},
+					"time":  map[string]string{"type": "string"},
+				},
+			},
+		},
+	},
+	{
+		Type: "object",
+		Properties: FunctionProperties{
+			Function: FunctionName{
+				Const: "search",
+			},
+			Arguments: Argument{
+				Type: "object",
+				Properties: map[string]interface{}{
+					"query": map[string]string{"type": "string"},
+				},
+			},
+		},
+	},
+}
+
+var testFunctionsName = []ItemName{
+	{
+		Type: "object",
+		Properties: NameProperties{
+			Function: FunctionName{
+				Const: "create_event",
+			},
+			Arguments: Argument{ // this is OpenAI's parameter
+				Type: "object",
+				Properties: map[string]interface{}{
+					"title": map[string]string{"type": "string"},
+					"date":  map[string]string{"type": "string"},
+					"time":  map[string]string{"type": "string"},
+				},
+			},
+		},
+	},
+	{
+		Type: "object",
+		Properties: NameProperties{
+			Function: FunctionName{
+				Const: "search",
+			},
+			Arguments: Argument{
+				Type: "object",
+				Properties: map[string]interface{}{
+					"query": map[string]string{"type": "string"},
+				},
+			},
+		},
+	},
+}
+
+func rootResult(s string) string {
+	return `root-0-name ::= "\"create_event\""
+freestring ::= (
+		[^"\\] |
+		"\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* space
+root-0 ::= "{" space "\"arguments\"" space ":" space root-0-arguments "," space "\"name\"" space ":" space root-0-name "}" space
+root-1-arguments ::= "{" space "\"query\"" space ":" space string "}" space
+realvalue ::= root-0 | root-1
+root ::= ` + s + `
+space ::= " "?
+root-0-arguments ::= "{" space "\"date\"" space ":" space string "," space "\"time\"" space ":" space string "," space "\"title\"" space ":" space string "}" space
+root-1 ::= "{" space "\"arguments\"" space ":" space root-1-arguments "," space "\"name\"" space ":" space root-1-name "}" space
+string ::= "\"" (
+[^"\\] |
+"\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+)* "\"" space
+arr  ::=
+"[\n"  (
+	realvalue
+(",\n"  realvalue)*
+)? "]"
+root-1-name ::= "\"search\""`
+}
+
 const (
 	testInput1 = `
 	{
@@ -42,6 +133,10 @@ const (
 	}`
 
 	inputResult1 = `root-0-function ::= "\"create_event\""
+freestring ::= (
+		[^"\\] |
+		"\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* space
 root-0 ::= "{" space "\"arguments\"" space ":" space root-0-arguments "," space "\"function\"" space ":" space root-0-function "}" space
 root-1-arguments ::= "{" space "\"query\"" space ":" space string "}" space
 root ::= root-0 | root-1
@@ -55,6 +150,10 @@ string ::= "\"" (
 root-1-function ::= "\"search\""`
 
 	inputResult2 = `root-0-function ::= "\"create_event\""
+freestring ::= (
+		[^"\\] |
+		"\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* space
 root-0 ::= "{" space "\"arguments\"" space ":" space root-0-arguments "," space "\"function\"" space ":" space root-0-function "}" space
 root-1-arguments ::= "{" space "\"query\"" space ":" space string "}" space
 realvalue ::= root-0 | root-1
@@ -106,6 +205,10 @@ root-1-function ::= "\"search\""`
 }`
 
 	inputResult3 = `root-0-name ::= "\"create_event\""
+freestring ::= (
+		[^"\\] |
+		"\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* space
 root-0 ::= "{" space "\"arguments\"" space ":" space root-0-arguments "," space "\"name\"" space ":" space root-0-name "}" space
 root-1-arguments ::= "{" space "\"query\"" space ":" space string "}" space
 root ::= root-0 | root-1
@@ -119,6 +222,10 @@ string ::= "\"" (
 root-1-name ::= "\"search\""`
 
 	inputResult4 = `root-0-name ::= "\"create_event\""
+freestring ::= (
+		[^"\\] |
+		"\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* space
 root-0 ::= "{" space "\"arguments\"" space ":" space root-0-arguments "," space "\"name\"" space ":" space root-0-name "}" space
 root-1-arguments ::= "{" space "\"query\"" space ":" space string "}" space
 realvalue ::= root-0 | root-1
@@ -141,7 +248,7 @@ root-1-name ::= "\"search\""`
 var _ = Describe("JSON schema grammar tests", func() {
 	Context("JSON", func() {
 		It("generates a valid grammar from JSON schema", func() {
-			grammar := NewJSONSchemaConverter("").GrammarFromBytes([]byte(testInput1), false)
+			grammar := NewJSONSchemaConverter("").GrammarFromBytes("", []byte(testInput1), false, false)
 			results := strings.Split(inputResult1, "\n")
 			for _, r := range results {
 				if r != "" {
@@ -151,7 +258,7 @@ var _ = Describe("JSON schema grammar tests", func() {
 			Expect(len(results)).To(Equal(len(strings.Split(grammar, "\n"))))
 		})
 		It("generates a valid grammar from JSON schema", func() {
-			grammar := NewJSONSchemaConverter("").GrammarFromBytes([]byte(testInput2), false)
+			grammar := NewJSONSchemaConverter("").GrammarFromBytes("", []byte(testInput2), false, false)
 			results := strings.Split(inputResult3, "\n")
 			for _, r := range results {
 				if r != "" {
@@ -163,40 +270,9 @@ var _ = Describe("JSON schema grammar tests", func() {
 		It("generates a valid grammar from JSON Objects", func() {
 
 			structuredGrammar := JSONFunctionStructureFunction{
-				OneOf: []ItemFunction{
-					{
-						Type: "object",
-						Properties: FunctionProperties{
-							Function: FunctionName{
-								Const: "create_event",
-							},
-							Arguments: Argument{ // this is OpenAI's parameter
-								Type: "object",
-								Properties: map[string]interface{}{
-									"title": map[string]string{"type": "string"},
-									"date":  map[string]string{"type": "string"},
-									"time":  map[string]string{"type": "string"},
-								},
-							},
-						},
-					},
-					{
-						Type: "object",
-						Properties: FunctionProperties{
-							Function: FunctionName{
-								Const: "search",
-							},
-							Arguments: Argument{
-								Type: "object",
-								Properties: map[string]interface{}{
-									"query": map[string]string{"type": "string"},
-								},
-							},
-						},
-					},
-				}}
+				OneOf: testFunctions}
 
-			grammar := structuredGrammar.Grammar("", false)
+			grammar := structuredGrammar.Grammar("", "", false, false)
 			results := strings.Split(inputResult1, "\n")
 			for _, r := range results {
 				if r != "" {
@@ -208,40 +284,9 @@ var _ = Describe("JSON schema grammar tests", func() {
 
 		It("generates a valid grammar from JSON Objects for multiple function return", func() {
 			structuredGrammar := JSONFunctionStructureFunction{
-				OneOf: []ItemFunction{
-					{
-						Type: "object",
-						Properties: FunctionProperties{
-							Function: FunctionName{
-								Const: "create_event",
-							},
-							Arguments: Argument{ // this is OpenAI's parameter
-								Type: "object",
-								Properties: map[string]interface{}{
-									"title": map[string]string{"type": "string"},
-									"date":  map[string]string{"type": "string"},
-									"time":  map[string]string{"type": "string"},
-								},
-							},
-						},
-					},
-					{
-						Type: "object",
-						Properties: FunctionProperties{
-							Function: FunctionName{
-								Const: "search",
-							},
-							Arguments: Argument{
-								Type: "object",
-								Properties: map[string]interface{}{
-									"query": map[string]string{"type": "string"},
-								},
-							},
-						},
-					},
-				}}
+				OneOf: testFunctions}
 
-			grammar := structuredGrammar.Grammar("", true)
+			grammar := structuredGrammar.Grammar("", "", true, false)
 			results := strings.Split(inputResult2, "\n")
 			for _, r := range results {
 				if r != "" {
@@ -253,41 +298,77 @@ var _ = Describe("JSON schema grammar tests", func() {
 
 		It("generates a valid grammar from JSON Objects for multiple function return", func() {
 			structuredGrammar := JSONFunctionStructureName{
-				OneOf: []ItemName{
-					{
-						Type: "object",
-						Properties: NameProperties{
-							Function: FunctionName{
-								Const: "create_event",
-							},
-							Arguments: Argument{ // this is OpenAI's parameter
-								Type: "object",
-								Properties: map[string]interface{}{
-									"title": map[string]string{"type": "string"},
-									"date":  map[string]string{"type": "string"},
-									"time":  map[string]string{"type": "string"},
-								},
-							},
-						},
-					},
-					{
-						Type: "object",
-						Properties: NameProperties{
-							Function: FunctionName{
-								Const: "search",
-							},
-							Arguments: Argument{
-								Type: "object",
-								Properties: map[string]interface{}{
-									"query": map[string]string{"type": "string"},
-								},
-							},
-						},
-					},
-				}}
+				OneOf: testFunctionsName}
 
-			grammar := structuredGrammar.Grammar("", true)
+			grammar := structuredGrammar.Grammar("", "", true, false)
 			results := strings.Split(inputResult4, "\n")
+			for _, r := range results {
+				if r != "" {
+					Expect(grammar).To(ContainSubstring(r))
+				}
+			}
+			Expect(len(results)).To(Equal(len(strings.Split(grammar, "\n"))), grammar)
+		})
+
+		It("generates a valid grammar from JSON Objects for multiple function return with a suffix and array", func() {
+			structuredGrammar := JSONFunctionStructureName{
+				OneOf: testFunctionsName}
+
+			grammar := structuredGrammar.Grammar("suffix", "", true, false)
+			results := strings.Split(rootResult(`"suffix" arr | realvalue`), "\n")
+			for _, r := range results {
+				if r != "" {
+					Expect(grammar).To(ContainSubstring(r))
+				}
+			}
+			Expect(len(results)).To(Equal(len(strings.Split(grammar, "\n"))), grammar)
+		})
+		It("generates a valid grammar from JSON Objects with a suffix", func() {
+			structuredGrammar := JSONFunctionStructureName{
+				OneOf: testFunctionsName}
+
+			grammar := structuredGrammar.Grammar("suffix", "", false, false)
+			results := strings.Split(rootResult(`"suffix" realvalue`), "\n")
+			for _, r := range results {
+				if r != "" {
+					Expect(grammar).To(ContainSubstring(r))
+				}
+			}
+			Expect(len(results)).To(Equal(len(strings.Split(grammar, "\n"))), grammar)
+		})
+		It("generates a valid grammar from JSON Objects with a suffix and could return string", func() {
+			structuredGrammar := JSONFunctionStructureName{
+				OneOf: testFunctionsName}
+
+			grammar := structuredGrammar.Grammar("suffix", "", false, true)
+			results := strings.Split(rootResult(`( "suffix" realvalue | freestring )`), "\n")
+			for _, r := range results {
+				if r != "" {
+					Expect(grammar).To(ContainSubstring(r))
+				}
+			}
+			Expect(len(results)).To(Equal(len(strings.Split(grammar, "\n"))), grammar)
+		})
+		It("generates a valid grammar from JSON Objects with a suffix that could return text or an array of tools", func() {
+			structuredGrammar := JSONFunctionStructureName{
+				OneOf: testFunctionsName}
+
+			grammar := structuredGrammar.Grammar("suffix", "", true, true)
+			results := strings.Split(rootResult(`( "suffix" (arr | realvalue) | freestring )`), "\n")
+			for _, r := range results {
+				if r != "" {
+					Expect(grammar).To(ContainSubstring(r))
+				}
+			}
+			Expect(len(results)).To(Equal(len(strings.Split(grammar, "\n"))), grammar)
+		})
+
+		It("generates a valid grammar from JSON Objects without a suffix that could return text or an array of tools or just string", func() {
+			structuredGrammar := JSONFunctionStructureName{
+				OneOf: testFunctionsName}
+
+			grammar := structuredGrammar.Grammar("", "", true, true)
+			results := strings.Split(rootResult(`freestring | arr | realvalue`), "\n")
 			for _, r := range results {
 				if r != "" {
 					Expect(grammar).To(ContainSubstring(r))

--- a/pkg/functions/parse.go
+++ b/pkg/functions/parse.go
@@ -4,20 +4,48 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/go-skynet/LocalAI/pkg/utils"
 	"github.com/rs/zerolog/log"
 )
 
+// FunctionsConfig is the configuration for the tool/function call.
+// It includes setting to map the function name and arguments from the response
+// and, for instance, also if processing the requests with BNF grammars.
 type FunctionsConfig struct {
-	DisableNoAction         bool   `yaml:"disable_no_action"`
-	NoActionFunctionName    string `yaml:"no_action_function_name"`
-	NoActionDescriptionName string `yaml:"no_action_description_name"`
-	ParallelCalls           bool   `yaml:"parallel_calls"`
-	NoGrammar               bool   `yaml:"no_grammar"`
-	ResponseRegex           string `yaml:"response_regex"`
+	// DisableNoAction disables the "no action" tool
+	// By default we inject a tool that does nothing and is used to return an answer from the LLM
+	DisableNoAction bool `yaml:"disable_no_action"`
 
+	// NoActionFunctionName is the name of the function that does nothing. It defaults to "answer"
+	NoActionFunctionName string `yaml:"no_action_function_name"`
+
+	// NoActionDescriptionName is the name of the function that returns the description of the no action function
+	NoActionDescriptionName string `yaml:"no_action_description_name"`
+
+	// ParallelCalls enables the LLM to return multiple function calls in the same response
+	ParallelCalls bool `yaml:"parallel_calls"`
+
+	// GrammarMessage enables the LLM to return strings and not only JSON objects
+	// This is useful for models to not constraing returning only JSON and also messages back to the user
+	GrammarMessage bool `yaml:"grammar_message"`
+
+	// NoGrammar disables the grammar parsing and parses the responses directly from the LLM
+	NoGrammar bool `yaml:"no_grammar"`
+
+	// ResponseRegex is a named regex to extract the function name and arguments from the response
+	ResponseRegex string `yaml:"response_regex"`
+
+	// JSONRegexMatch is a regex to extract the JSON object from the response
 	JSONRegexMatch string `yaml:"json_regex_match"`
+
+	// GrammarPrefix is the suffix to append to the grammar when being generated
+	// This is useful when models prepend a tag before returning JSON
+	GrammarPrefix string `yaml:"grammar_prefix"`
+
+	// ReplaceResults allow to replace strings in the results before parsing them
+	ReplaceResults map[string]string `yaml:"replace_results"`
 
 	// FunctionName enable the LLM to return { "name": "function_name", "arguments": { "arg1": "value1", "arg2": "value2" } }
 	// instead of { "function": "function_name", "arguments": { "arg1": "value1", "arg2": "value2" } }.
@@ -31,6 +59,15 @@ type FuncCallResults struct {
 }
 
 func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncCallResults {
+	log.Debug().Msgf("LLM result: %s", llmresult)
+
+	for k, v := range functionConfig.ReplaceResults {
+		log.Debug().Msgf("Replacing %s with %s", k, v)
+		llmresult = strings.ReplaceAll(llmresult, k, v)
+	}
+
+	log.Debug().Msgf("LLM result(processed): %s", llmresult)
+
 	multipleResults := functionConfig.ParallelCalls
 	useGrammars := !functionConfig.NoGrammar
 
@@ -48,7 +85,7 @@ func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncC
 		s = utils.EscapeNewLines(s)
 		err := json.Unmarshal([]byte(s), &ss)
 		if err != nil {
-			log.Error().Err(err).Str("escapedLLMResult", s).Msg("unable to unmarshal llm result")
+			log.Warn().Err(err).Str("escapedLLMResult", s).Msg("unable to unmarshal llm result")
 		}
 		log.Debug().Msgf("Function return: %s %+v", s, ss)
 
@@ -132,7 +169,7 @@ func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncC
 		s := utils.EscapeNewLines(llmresult)
 		err := json.Unmarshal([]byte(s), &ss)
 		if err != nil {
-			log.Error().Err(err).Str("escapedLLMResult", s).Msg("multiple results: unable to unmarshal llm result")
+			log.Warn().Err(err).Str("escapedLLMResult", s).Msg("multiple results: unable to unmarshal llm result")
 		}
 		log.Debug().Msgf("Function return: %s %+v", s, ss)
 


### PR DESCRIPTION
This PR provides new options to control how functions are extracted from the LLM, and also provides more control on how JSON grammars can be used (also in conjunction).

New YAML settings introduced:

- `grammar_message`: when enabled, the generated grammar can also decide to push strings and not only JSON objects. This allows the LLM to pick to either respond freely or using JSON constrained by BNF rules (which are generated on the fly by the parser).
- `grammar_prefix`: Allows to prefix a string to the JSON grammar definition.
- `replace_results`: Is a map that allows to replace strings in the LLM result.

As an example, consider the following settings for Hermes-2-Pro-Mistral, which allow extracting **both** JSON results coming from the model, and the ones coming from the grammar:

```yaml
function:
  # disable injecting the "answer" tool
  disable_no_action: true
  # This allows the grammar to also return messages
  grammar_message: true
  # Suffix to add to the grammar
  grammar_prefix: '<tool_call>\n'
  return_name_in_function_response: true
  # Without grammar uncomment the lines below
  # Warning: this is relying only on the capability of the
  # LLM model to generate the correct function call.
  # no_grammar: true
  # json_regex_match: "(?s)<tool_call>(.*?)</tool_call>"
  replace_results:
    "<tool_call>": ""
    "\'": "\""
# Note: make sure to not have </tool_call> as a stopword if disabling grammars
```

Note: To disable entirely grammars usage in the example above, uncomment the `no_grammar` and `json_regex_match` and make sure to not have  `</tool_call>` as a stopword.

## Implementation details

To achieve this - I've tweaked the already existing code that generates BNF grammars from JSON Schema objects on-the-fly, now, when `grammar_message` is set, it will inject a new rule of the form (pseudocode to simplify) along the other options:

```
result = string | JSON
```

The JSON responses are of the form `{ "name": "function_name", "arguments": <JSON parameters map> }`.

The parser is then more flexible and tolerates non-JSON in responses, which are directly forwarded as LLM result. If the JSON is correctly parsed, the tool response is appended to the request.

## Notes

This isn't a breaking change - configs needs to explicitly enable these options for now. When things are proven to be more stable with this methodology I plan to start to move defaults over this setup.

A full example of hermes that I've tested locally with:

```yaml
context_size: 4096
f16: true
mmap: true
name: hermes-2-pro-llama-3-8b
parameters:
  model: Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
stopwords:
- <|im_end|>
# Note: comment this below if disabling grammars
- </tool_call>

function:
  # disable injecting the "answer" tool
  disable_no_action: true
  # This allows the grammar to also return messages
  grammar_message: true
  # Suffix to add to the grammar
  grammar_prefix: '<tool_call>\n'
  return_name_in_function_response: true
  # Without grammar uncomment the lines below
  # Warning: this is relying only on the capability of the
  # LLM model to generate the correct function call.
  # no_grammar: true
  # json_regex_match: "(?s)<tool_call>(.*?)</tool_call>"
  replace_results: 
    "<tool_call>": ""
    "\'": "\""


template:
  chat: |
    {{.Input -}}
    <|im_start|>assistant
  chat_message: |
    <|im_start|>{{if eq .RoleName "assistant"}}assistant{{else if eq .RoleName "system"}}system{{else if eq .RoleName "tool"}}tool{{else if eq .RoleName "user"}}user{{end}}
    {{- if .FunctionCall }}
    <tool_call>
    {{- else if eq .RoleName "tool" }}
    <tool_response>
    {{- end }}
    {{- if .Content}}
    {{.Content }}
    {{- end }}
    {{- if .FunctionCall}}
    {{toJson .FunctionCall}}
    {{- end }}
    {{- if .FunctionCall }}
    </tool_call>
    {{- else if eq .RoleName "tool" }}
    </tool_response>
    {{- end }}<|im_end|>
  completion: |
    {{.Input}}
  function: |
    <|im_start|>system
    You are a function calling AI model. You are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:
    <tools>
    {{range .Functions}}
    {'type': 'function', 'function': {'name': '{{.Name}}', 'description': '{{.Description}}', 'parameters': {{toJson .Parameters}} }}
    {{end}}
    </tools>
    Use the following pydantic model json schema for each tool call you will make:
    {'title': 'FunctionCall', 'type': 'object', 'properties': {'arguments': {'title': 'Arguments', 'type': 'object'}, 'name': {'title': 'Name', 'type': 'string'}}, 'required': ['arguments', 'name']}
    For each function call return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:
    <tool_call>
    {'arguments': <args-dict>, 'name': <function-name>}
    </tool_call><|im_end|>
    {{.Input -}}
    <|im_start|>assistant
```
