### PR TITLE
fix(gallery) Correct llama3-8b-instruct model file

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -81,7 +81,7 @@
     - llama3
   overrides:
     parameters:
-      model: Meta-Llama-3-8B-Instruct-Q5_K_M.gguf
+      model: Meta-Llama-3-8B-Instruct.Q4_0.gguf
   files:
     - filename: Meta-Llama-3-8B-Instruct.Q4_0.gguf
       sha256: 19ded996fe6c60254dc7544d782276eff41046ed42aa5f2d0005dc457e5c0895


### PR DESCRIPTION
**Description**

This must be a mistake because the config tries to use a model file that is different from the one actually being downloaded. I assumed the downloaded file is what should be used so I corrected the specified model file to that

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
