### PR TITLE
feat(functions): Enable true regex replacement for the regexReplacement option

### DIFF
--- a/pkg/functions/parse.go
+++ b/pkg/functions/parse.go
@@ -60,10 +60,11 @@ type FuncCallResults struct {
 func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncCallResults {
 	log.Debug().Msgf("LLM result: %s", llmresult)
 
-	for k, v := range functionConfig.ReplaceResults {
-		log.Debug().Msgf("Replacing %s with %s", k, v)
-		llmresult = strings.ReplaceAll(llmresult, k, v)
-	}
+    for k, v := range functionConfig.ReplaceResults {
+    	log.Debug().Msgf("Replacing %s with %s", k, v)
+    	re := regexp.MustCompile(k)
+    	llmresult = re.ReplaceAllString(llmresult, v)
+    }
 
 	log.Debug().Msgf("LLM result(processed): %s", llmresult)
 

--- a/pkg/functions/parse.go
+++ b/pkg/functions/parse.go
@@ -3,10 +3,10 @@ package functions
 import (
 	"encoding/json"
 	"regexp"
-	"strings"
 
 	"github.com/go-skynet/LocalAI/pkg/utils"
 	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v2"
 )
 
 // FunctionsConfig is the configuration for the tool/function call.
@@ -44,7 +44,7 @@ type FunctionsConfig struct {
 	GrammarPrefix string `yaml:"grammar_prefix"`
 
 	// ReplaceResults allow to replace strings in the results before parsing them
-	ReplaceResults map[string]string `yaml:"replace_results"`
+	ReplaceResults yaml.MapSlice `yaml:"replace_results"`
 
 	// FunctionName enable the LLM to return { "name": "function_name", "arguments": { "arg1": "value1", "arg2": "value2" } }
 	// instead of { "function": "function_name", "arguments": { "arg1": "value1", "arg2": "value2" } }.
@@ -60,11 +60,12 @@ type FuncCallResults struct {
 func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncCallResults {
 	log.Debug().Msgf("LLM result: %s", llmresult)
 
-    for k, v := range functionConfig.ReplaceResults {
-    	log.Debug().Msgf("Replacing %s with %s", k, v)
-    	re := regexp.MustCompile(k)
-    	llmresult = re.ReplaceAllString(llmresult, v)
-    }
+	for _, item := range functionConfig.ReplaceResults {
+		k, v := item.Key.(string), item.Value.(string)
+		log.Debug().Msgf("Replacing %s with %s", k, v)
+		re := regexp.MustCompile(k)
+		llmresult = re.ReplaceAllString(llmresult, v)
+	}
 
 	log.Debug().Msgf("LLM result(processed): %s", llmresult)
 

--- a/pkg/functions/parse_test.go
+++ b/pkg/functions/parse_test.go
@@ -110,4 +110,45 @@ var _ = Describe("LocalAI function parse tests", func() {
 			Expect(results[0].Arguments).To(Equal(`{"x":5,"y":3}`))
 		})
 	})
+
+	Context("when using ReplaceResults to clean up input", func() {
+		It("should replace text before and after JSON blob", func() {
+			input := `
+Some text before the JSON
+{"function": "add", "arguments": {"x": 5, "y": 3}}
+Some text after the JSON
+`
+			functionConfig.ReplaceResults = map[string]string{
+				`(?s)^[^\\{]*(?=\\{)`: "",
+				`(?s)\\}[^{}]+$`:      "",
+			}
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("add"))
+			Expect(results[0].Arguments).To(Equal(`{"x":5,"y":3}`))
+		})
+
+	Context("when using ReplaceResults to clean up input from JSON array", func() {
+		It("should replace text before and after array JSON array", func() {
+			input := `
+Some text before the JSON
+[{"function": "add", "arguments": {"x": 5, "y": 3}}, {"function": "subtract", "arguments": {"x": 10, "y": 7}}]
+Some text after the JSON
+`
+			functionConfig.FunctionName = true
+			functionConfig.ReplaceResults = map[string]string{
+				`(?s)^[^\\[]{*(?=\\[)`: "",
+				`(?s)\\][^]]+$`:         "",
+			}
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(2))
+			Expect(results[0].Name).To(Equal("add"))
+			Expect(results[0].Arguments).To(Equal(`{"x":5,"y":3}`))
+			Expect(results[1].Name).To(Equal("subtract"))
+			Expect(results[1].Arguments).To(Equal(`{"x":10,"y":7}`))
+		})
+	})
+	})
 })


### PR DESCRIPTION
**Description**

This PR fixes #2340

It allows using true regexs in the regex replacement. Current implementation of strings.repalceall treats any regex statement as a plain string. 

**Notes for Reviewers**

None

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 