### PR TITLE
feat(functions): allow to use JSONRegexMatch unconditionally

### DIFF
--- a/pkg/functions/parse.go
+++ b/pkg/functions/parse.go
@@ -37,7 +37,7 @@ type FunctionsConfig struct {
 	ResponseRegex string `yaml:"response_regex"`
 
 	// JSONRegexMatch is a regex to extract the JSON object from the response
-	JSONRegexMatch string `yaml:"json_regex_match"`
+	JSONRegexMatch []string `yaml:"json_regex_match"`
 
 	// GrammarPrefix is the suffix to append to the grammar when being generated
 	// This is useful when models prepend a tag before returning JSON
@@ -124,12 +124,15 @@ func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncC
 	// the response is a string that we have to parse
 	result := make(map[string]string)
 
-	if functionConfig.JSONRegexMatch != "" {
-		// We use a regex to extract the JSON object from the response
-		var respRegex = regexp.MustCompile(functionConfig.JSONRegexMatch)
-		match := respRegex.FindStringSubmatch(llmresult)
-		if len(match) >= 2 {
-			llmresult = match[1]
+	if len(functionConfig.JSONRegexMatch) != 0 {
+		for _, r := range functionConfig.JSONRegexMatch {
+			// We use a regex to extract the JSON object from the response
+			var respRegex = regexp.MustCompile(r)
+			match := respRegex.FindStringSubmatch(llmresult)
+			if len(match) >= 2 {
+				llmresult = match[1]
+				break
+			}
 		}
 	}
 

--- a/pkg/functions/parse.go
+++ b/pkg/functions/parse.go
@@ -124,6 +124,15 @@ func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncC
 	// the response is a string that we have to parse
 	result := make(map[string]string)
 
+	if functionConfig.JSONRegexMatch != "" {
+		// We use a regex to extract the JSON object from the response
+		var respRegex = regexp.MustCompile(functionConfig.JSONRegexMatch)
+		match := respRegex.FindStringSubmatch(llmresult)
+		if len(match) >= 2 {
+			llmresult = match[1]
+		}
+	}
+
 	if functionConfig.ResponseRegex != "" {
 		// We use named regexes here to extract the function name and arguments
 		// obviously, this expects the LLM to be stable and return correctly formatted JSON
@@ -143,16 +152,6 @@ func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncC
 			return results
 		}
 		results = append(results, FuncCallResults{Name: result[functionNameKey], Arguments: result["arguments"]})
-	} else if functionConfig.JSONRegexMatch != "" {
-
-		// We use a regex to extract the JSON object from the response
-		var respRegex = regexp.MustCompile(functionConfig.JSONRegexMatch)
-		match := respRegex.FindStringSubmatch(llmresult)
-		if len(match) < 2 {
-			return results
-		}
-
-		results, _ = returnResult(match[1])
 	} else {
 		results, _ = returnResult(llmresult)
 	}

--- a/pkg/functions/parse_test.go
+++ b/pkg/functions/parse_test.go
@@ -157,6 +157,41 @@ Some text before the JSON
 {'function': '"add"', 'arguments': {'x': 5, 'z': '"v"', 'y': 'v"value"'}}
 Some text after the JSON
 `
+			functionConfig.JSONRegexMatch = `(?s)<tool_call>(.*?)</tool_call>`
+
+			// Regex to match non-JSON characters before the JSON structure
+			//reBefore := regexp.MustCompile(`(?s)^.*?(?=\{|\[)`)
+			// Regex to match non-JSON characters after the JSON structure
+			//reAfter := regexp.MustCompile(`(?s)(?<=\}|\]).*$`)
+
+			functionConfig.ReplaceResults = yaml.MapSlice{
+				{Key: `(?s)^[^{\[]*`, Value: ""},
+				{Key: `(?s)[^}\]]*$`, Value: ""},
+				// Regex pattern to match single quotes around keys and values
+				// Step 1: Replace single quotes around keys and values with double quotes
+				{Key: `'([^']*?)'`, Value: `_DQUOTE_${1}_DQUOTE_`},
+				// Step 2: Replace double quotes inside values with placeholders
+				{Key: `\\"`, Value: `__TEMP_QUOTE__`},
+				{Key: `"`, Value: `\"`},
+				{Key: `\'`, Value: `'`},
+				{Key: `_DQUOTE_`, Value: `"`},
+				{Key: `__TEMP_QUOTE__`, Value: `"`},
+			}
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("\"add\""))
+			Expect(results[0].Arguments).To(Equal(`{"x":5,"y":"v\"value\"","z":"\"v\""}`))
+		})
+
+		It("should convert single-quoted key-value pairs to double-quoted and escape double quotes within values", func() {
+			input := `
+Some text before the JSON
+<tool_call>{'function': '"add"', 'arguments': {'x': 5, 'z': '"v"', 'y': 'v"value"'}}</tool_call>
+Some text after the JSON
+`
+			functionConfig.JSONRegexMatch = `(?s)<tool_call>(.*?)</tool_call>`
+
 			// Regex to match non-JSON characters before the JSON structure
 			//reBefore := regexp.MustCompile(`(?s)^.*?(?=\{|\[)`)
 			// Regex to match non-JSON characters after the JSON structure

--- a/pkg/functions/parse_test.go
+++ b/pkg/functions/parse_test.go
@@ -91,7 +91,7 @@ var _ = Describe("LocalAI function parse tests", func() {
 {"function": "add", "arguments": {"x": 5, "y": 3}}
 </tool_call>`
 
-			functionConfig.JSONRegexMatch = `(?s)<tool_call>(.*?)</tool_call>`
+			functionConfig.JSONRegexMatch = []string{`(?s)<tool_call>(.*?)</tool_call>`}
 
 			results := ParseFunctionCall(input, functionConfig)
 			Expect(results).To(HaveLen(1))
@@ -104,7 +104,7 @@ var _ = Describe("LocalAI function parse tests", func() {
 {"function": "add", "arguments": {"x": 5, "y": 3}}
 </tool_call>`
 
-			functionConfig.JSONRegexMatch = `(?s)(.*?)</tool_call>`
+			functionConfig.JSONRegexMatch = []string{`(?s)(.*?)</tool_call>`}
 
 			results := ParseFunctionCall(input, functionConfig)
 			Expect(results).To(HaveLen(1))
@@ -157,7 +157,7 @@ Some text before the JSON
 {'function': '"add"', 'arguments': {'x': 5, 'z': '"v"', 'y': 'v"value"'}}
 Some text after the JSON
 `
-			functionConfig.JSONRegexMatch = `(?s)<tool_call>(.*?)</tool_call>`
+			functionConfig.JSONRegexMatch = []string{`(?s)<tool_call>(.*?)</tool_call>`}
 
 			// Regex to match non-JSON characters before the JSON structure
 			//reBefore := regexp.MustCompile(`(?s)^.*?(?=\{|\[)`)
@@ -190,7 +190,7 @@ Some text before the JSON
 <tool_call>{'function': '"add"', 'arguments': {'x': 5, 'z': '"v"', 'y': 'v"value"'}}</tool_call>
 Some text after the JSON
 `
-			functionConfig.JSONRegexMatch = `(?s)<tool_call>(.*?)</tool_call>`
+			functionConfig.JSONRegexMatch = []string{`(?s)<tool_call>(.*?)</tool_call>`}
 
 			// Regex to match non-JSON characters before the JSON structure
 			//reBefore := regexp.MustCompile(`(?s)^.*?(?=\{|\[)`)


### PR DESCRIPTION
**Description**

This PR lets use JSONRegexMatch regardless before processing further, allowing it to use both in grammar and no-grammar environment - this is especially useful if used in conjunction with `grammar_message`.

This PR also changes `json_regex_match` to be a list instead of a string. First match wins.

Example

```yaml
context_size: 4096
f16: true
mmap: true
name: hermes-2-pro-llama-3-8b
parameters:
  model: Hermes-2-Pro-Llama-3-8B-Q4_K_M.gguf
stopwords:
- <|im_end|>
- </tool_call>

function:
  # disable injecting the "answer" tool
  disable_no_action: true
  # This allows the grammar to also return messages
  grammar_message: true
  # Suffix to add to the grammar
  grammar_prefix: '<tool_call>\n'
  return_name_in_function_response: true
  # Without grammar uncomment the lines below
  # Warning: this is relying only on the capability of the
  # LLM model to generate the correct function call.
  # no_grammar: true
  json_regex_match: 
   - "(?s)<tool_call>(.*?)</tool_call>"
   - "(?s)<tool_call>(.*?)"
  replace_results: 
    "(?s)^[^{\[]*": ""
    "(?s)[^}\]]*$": ""
    "'([^']*?)'": "_DQUOTE_${1}_DQUOTE_"
    '\\"': "__TEMP_QUOTE__"
    "\'": "'"
    "_DQUOTE_": '"'
    "__TEMP_QUOTE__": '"'

template:
  chat: |
    {{.Input -}}
    <|im_start|>assistant
  chat_message: |
    <|im_start|>{{if eq .RoleName "assistant"}}assistant{{else if eq .RoleName "system"}}system{{else if eq .RoleName "tool"}}tool{{else if eq .RoleName "user"}}user{{end}}
    {{- if .FunctionCall }}
    <tool_call>
    {{- else if eq .RoleName "tool" }}
    <tool_response>
    {{- end }}
    {{- if .Content}}
    {{.Content }}
    {{- end }}
    {{- if .FunctionCall}}
    {{toJson .FunctionCall}}
    {{- end }}
    {{- if .FunctionCall }}
    </tool_call>
    {{- else if eq .RoleName "tool" }}
    </tool_response>
    {{- end }}<|im_end|>
  completion: |
    {{.Input}}
  function: |
    <|im_start|>system
    You are a function calling AI model. You are provided with function signatures within <tools></tools> XML tags. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:
    <tools>
    {{range .Functions}}
    {'type': 'function', 'function': {'name': '{{.Name}}', 'description': '{{.Description}}', 'parameters': {{toJson .Parameters}} }}
    {{end}}
    </tools>
    Use the following pydantic model json schema for each tool call you will make:
    {'title': 'FunctionCall', 'type': 'object', 'properties': {'arguments': {'title': 'Arguments', 'type': 'object'}, 'name': {'title': 'Name', 'type': 'string'}}, 'required': ['arguments', 'name']}
    For each function call return a json object with function name and arguments within <tool_call></tool_call> XML tags as follows:
    <tool_call>
    {'arguments': <args-dict>, 'name': <function-name>}
    </tool_call><|im_end|>
    {{.Input -}}
    <|im_start|>assistant
```