### PR TITLE
TEMPORARY: Pause Intel Image Builds

### DIFF
--- a/.github/workflows/image-pr.yml
+++ b/.github/workflows/image-pr.yml
@@ -65,16 +65,16 @@ jobs:
             grpc-base-image: "ubuntu:22.04"
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
-          - build-type: 'sycl_f16'
-            platforms: 'linux/amd64'
-            tag-latest: 'false'
-            base-image: "intel/oneapi-basekit:2024.1.0-devel-ubuntu22.04"
-            grpc-base-image: "ubuntu:22.04"
-            tag-suffix: 'sycl-f16-ffmpeg'
-            ffmpeg: 'true'
-            image-type: 'extras'
-            runs-on: 'arc-runner-set'
-            makeflags: "--jobs=3 --output-sync=target"
+          #- build-type: 'sycl_f16'
+          #  platforms: 'linux/amd64'
+          #  tag-latest: 'false'
+          #  base-image: "intel/oneapi-basekit:2024.1.0-devel-ubuntu22.04"
+          #  grpc-base-image: "ubuntu:22.04"
+          #  tag-suffix: 'sycl-f16-ffmpeg'
+          #  ffmpeg: 'true'
+          #  image-type: 'extras'
+          #  runs-on: 'arc-runner-set'
+          #  makeflags: "--jobs=3 --output-sync=target"
   core-image-build:
     uses: ./.github/workflows/image_build.yml
     with:


### PR DESCRIPTION
```
3.805 W: GPG error: https://repositories.intel.com/gpu/ubuntu jammy/lts/2350 InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 28DA432DAAC8BAEA
3.805 E: The repository 'https://repositories.intel.com/gpu/ubuntu jammy/lts/2350 InRelease' is not signed.
```
This sure looks like a temporary Intel issue - so this PR temporarily pauses building those images to allow CI to proceed for now.
