### PR TITLE
fix(watcher): do not emit fatal errors

### DIFF
--- a/core/startup/config_file_watcher.go
+++ b/core/startup/config_file_watcher.go
@@ -71,8 +71,7 @@ func (c *configFileHandler) Watch() error {
 	configWatcher, err := fsnotify.NewWatcher()
 	c.watcher = configWatcher
 	if err != nil {
-		log.Fatal().Err(err).Str("configdir", c.appConfig.DynamicConfigsDir).Msg("unable to create a watcher for configuration directory")
-
+		return err
 	}
 
 	if c.appConfig.DynamicConfigsDirPollInterval > 0 {


### PR DESCRIPTION
**Description**

Watchers shouldn't be fatal - we handle the error already, so we should just return here. See also: https://github.com/mudler/LocalAI/discussions/2407