### PR TITLE
experiment: `-j4` for `build-linux:`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -102,7 +102,7 @@ jobs:
           export PATH=/usr/local/cuda/bin:$PATH
           export PATH=/opt/rocm/bin:$PATH
           source /opt/intel/oneapi/setvars.sh
-          GO_TAGS=p2p make dist
+          GO_TAGS=p2p make -j4 dist
       - uses: actions/upload-artifact@v4
         with:
           name: LocalAI-linux


### PR DESCRIPTION
`build-linux` CI step is now repaired, but quite slow.
---
experiment 1: set -j4 to see if things go faster, while we wait for a proper fix from mudler
