### PR TITLE
fix(stream): do not break channel consumption

### DIFF
--- a/core/http/endpoints/openai/chat.go
+++ b/core/http/endpoints/openai/chat.go
@@ -437,7 +437,6 @@ func ChatEndpoint(cl *config.BackendConfigLoader, ml *model.ModelLoader, startup
 					if err != nil {
 						log.Debug().Msgf("Sending chunk failed: %v", err)
 						input.Cancel()
-						break
 					}
 					w.Flush()
 				}


### PR DESCRIPTION
**Description**

Blocking the loop here leaves the channel unconsumed, finally ending by blocking the backend as keeping sending on a channel that is not consumed by a worker anymore.

We just need to cancel the context here, which is then released by the backend which finally closes the channel.

This buggy behavior can be reproduced by:

- Start a request with `stream: true`
- CTRL+C the request while the result is being streamed to the client
- The server now will be stuck as the channel isn't consumed anymore, as it is not buffered, go will make the producer sit there waiting for a consumer
- Try again to issue another request - now the backend is blocked for good. 