### PR TITLE
fix(worker): use dynaload for single binaries

### DIFF
--- a/core/cli/worker/worker_llamacpp.go
+++ b/core/cli/worker/worker_llamacpp.go
@@ -7,6 +7,7 @@ import (
 
 	cliContext "github.com/go-skynet/LocalAI/core/cli/context"
 	"github.com/go-skynet/LocalAI/pkg/assets"
+	"github.com/go-skynet/LocalAI/pkg/library"
 	"github.com/rs/zerolog/log"
 )
 
@@ -27,17 +28,18 @@ func (r *LLamaCPP) Run(ctx *cliContext.Context) error {
 		return fmt.Errorf("usage: local-ai worker llama-cpp-rpc -- <llama-rpc-server-args>")
 	}
 
+	grpcProcess := assets.ResolvePath(
+		r.BackendAssetsPath,
+		"util",
+		"llama-cpp-rpc-server",
+	)
+
+	args := os.Args[4:]
+	args, grpcProcess = library.LoadLDSO(r.BackendAssetsPath, args, grpcProcess)
+
+	args = append([]string{grpcProcess}, args...)
 	return syscall.Exec(
-		assets.ResolvePath(
-			r.BackendAssetsPath,
-			"util",
-			"llama-cpp-rpc-server",
-		),
-		append([]string{
-			assets.ResolvePath(
-				r.BackendAssetsPath,
-				"util",
-				"llama-cpp-rpc-server",
-			)}, os.Args[4:]...),
+		grpcProcess,
+		args,
 		os.Environ())
 }

--- a/pkg/library/dynaload.go
+++ b/pkg/library/dynaload.go
@@ -49,7 +49,7 @@ func LoadLDSO(assetDir string, args []string, grpcProcess string) ([]string, str
 	if _, err := os.Stat(ldPath); err == nil {
 		log.Debug().Msgf("ld.so found")
 		// We need to run the grpc process with the ld.so
-		args = append(args, grpcProcess)
+		args = append([]string{grpcProcess}, args...)
 		grpcProcess = ldPath
 	}
 


### PR DESCRIPTION
**Description**

This PR fixes #2609 

 We didn't covered starting workers with the shared libs shipped within the binary. Now the main should start the bins as the other gRPC backends