### PR TITLE
fix(install.sh): correctly handle systemd service installation

### DIFF
--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -9,7 +9,7 @@
 
 set -e
 set -o noglob
-set -x
+#set -x
 
 # --- helper functions for logs ---
 info()
@@ -538,7 +538,7 @@ install_binary() {
     $SUDO install -o0 -g0 -m755 $TEMP_DIR/local-ai $BINDIR/local-ai
 
     verify_system
-    if [ "$HAS_SYSTEMD" == "true" ]; then
+    if [ "$HAS_SYSTEMD" = true ]; then
         configure_systemd
     fi
 


### PR DESCRIPTION
**Description**

This PR fixes `install.sh` as such now the systemd service is correctly installed and started