### PR TITLE
ci: bump parallel jobs

### DIFF
--- a/.github/workflows/image-pr.yml
+++ b/.github/workflows/image-pr.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       # Pushing with all jobs in parallel
       # eats the bandwidth of all the nodes
-      max-parallel: ${{ github.event_name != 'pull_request' && 2 || 4 }}
+      max-parallel: ${{ github.event_name != 'pull_request' && 4 || 8 }}
       matrix:
         include:
           - build-type: ''

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       # Pushing with all jobs in parallel
       # eats the bandwidth of all the nodes
-      max-parallel: ${{ github.event_name != 'pull_request' && 2 || 4 }}
+      max-parallel: ${{ github.event_name != 'pull_request' && 4 || 8 }}
       matrix:
         include:
           # Extra images


### PR DESCRIPTION
**Description**

As now we have a new sponsor (Prem) and access to more resources :partying_face: , I've just finished setting up the cluster and x2 the current number of nodes! I think we can handle more than what's currently set - however - I'll be on the safe side now and see how the loads spreads across the cluster and see if we can bump this further more later on.

