### PR TITLE
fix(talk): identify the model by ID instead of name

### DIFF
--- a/core/http/views/talk.html
+++ b/core/http/views/talk.html
@@ -76,7 +76,7 @@
             <option value="" disabled class="text-gray-400" >Select a model</option>
 
             {{ range .ModelsConfig }}
-            <option value="{{.Name}}"  class="bg-gray-700 text-white">{{.Name}}</option>
+            <option value="{{.ID}}"  class="bg-gray-700 text-white">{{.ID}}</option>
             {{ end }}
           </select>
       </div>
@@ -89,7 +89,7 @@
         >
           <option value="" disabled class="text-gray-400" >Select a model</option>
           {{ range .ModelsConfig }}
-          <option value="{{.Name}}"  class="bg-gray-700 text-white">{{.Name}}</option>
+          <option value="{{.ID}}"  class="bg-gray-700 text-white">{{.ID}}</option>
           {{ end }}
         </select>
       </div>


### PR DESCRIPTION
This fixes a breakage in rendering the template. Now the models passed by to the renderer have the ID field rather then Name
