### PR TITLE
Using exec when starting a backend instead of spawning a new process

### DIFF
--- a/backend/python/common/libbackend.sh
+++ b/backend/python/common/libbackend.sh
@@ -148,13 +148,13 @@ function startBackend() {
     ensureVenv
 
     if [ ! -z ${BACKEND_FILE} ]; then
-        python ${BACKEND_FILE} $@
+        exec python ${BACKEND_FILE} $@
     elif [ -e "${MY_DIR}/server.py" ]; then
-        python ${MY_DIR}/server.py $@
+        exec python ${MY_DIR}/server.py $@
     elif [ -e "${MY_DIR}/backend.py" ]; then
-        python ${MY_DIR}/backend.py $@
+        exec python ${MY_DIR}/backend.py $@
     elif [ -e "${MY_DIR}/${BACKEND_NAME}.py" ]; then
-        python ${MY_DIR}/${BACKEND_NAME}.py $@
+        exec python ${MY_DIR}/${BACKEND_NAME}.py $@
     fi
 }
 


### PR DESCRIPTION
**Description**
Instead of spawning new processes when starting a new python backend, use exec to replace the shell process with the python process.

This PR fixes #

When using the transformers and derived custom backends I noticed the following behaviour when running localai with the flag `--single-active-backend`.

1. When calling a model, the specified transformers based backend was started.
2. When calling a model for a different model, the run.sh shell process was killed and the new backend started
3. The transformers python process stayed active (and did not receive a kill signal)

With the change the run.sh process is replaced with the python backend process, leading to that process being killed correctly and freeing its resources.


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
5. Sign your commits
6. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
7. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->