### PR TITLE
feat(p2p): allow to disable DHT and use only LAN

### DIFF
--- a/core/p2p/p2p.go
+++ b/core/p2p/p2p.go
@@ -348,11 +348,15 @@ func newNodeOpts(token string) ([]node.Option, error) {
 	llger := logger.New(log.LevelFatal)
 	defaultInterval := 10 * time.Second
 
+	// TODO: move this up, expose more config options when creating a node
+	noDHT := os.Getenv("LOCALAI_P2P_DISABLE_DHT") == "true"
+	noLimits := os.Getenv("LOCALAI_P2P_DISABLE_LIMITS") == "true"
+
 	loglevel := "info"
 
 	c := config.Config{
 		Limit: config.ResourceLimit{
-			Enable:   true,
+			Enable:   !noLimits,
 			MaxConns: 100,
 		},
 		NetworkToken:   token,
@@ -372,7 +376,7 @@ func newNodeOpts(token string) ([]node.Option, error) {
 			RateLimitInterval: defaultInterval,
 		},
 		Discovery: config.Discovery{
-			DHT:      true,
+			DHT:      noDHT,
 			MDNS:     true,
 			Interval: 30 * time.Second,
 		},

--- a/docs/content/docs/features/distributed_inferencing.md
+++ b/docs/content/docs/features/distributed_inferencing.md
@@ -98,3 +98,14 @@ The server logs should indicate that new workers are being discovered.
 - If running in p2p mode with container images, make sure you start the container with `--net host` or `network_mode: host` in the docker-compose file.
 - Only a single model is supported currently.
 - Ensure the server detects new workers before starting inference. Currently, additional workers cannot be added once inference has begun.
+
+
+## Environment Variables
+
+There are options that can be tweaked or parameters that can be set using environment variables
+
+| Environment Variable | Description |
+|----------------------|-------------|
+| **LOCALAI_P2P_DISABLE_DHT** | Set to "true" to disable DHT and enable p2p layer to be local only (mDNS) |
+| **LOCALAI_P2P_DISABLE_LIMITS** | Set to "true" to disable connection limits and resources management |
+| **LOCALAI_P2P_TOKEN** | Set the token for the p2p network |


### PR DESCRIPTION
This allows LocalAI to be less noisy avoiding to connect outside. Needed if e.g. there is no plan into using p2p across separate networks.

There is room for optimization here - options needs to be passed by and I don't like hooking into env vars directly, but I want to have quick route to it now, we can optimize later.