### PR TITLE
ci(arm64): fix gRPC build by adding googletest to CMakefile

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,16 @@ jobs:
             echo "set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)" >> $CMAKE_CROSS_TOOLCHAIN && \
             echo "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)" >> $CMAKE_CROSS_TOOLCHAIN
           GRPC_DIR=$PWD/grpc
+
+          # http://google.github.io/googletest/quickstart-cmake.html
+          # Seems otherwise cross-arch fails to find it
+          echo "include(FetchContent)" >> $GRPC_DIR/CMakeLists.txt
+          echo "FetchContent_Declare(" >> $GRPC_DIR/CMakeLists.txt
+          echo "  googletest" >> $GRPC_DIR/CMakeLists.txt
+          echo "  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip" >> $GRPC_DIR/CMakeLists.txt
+          echo ")" >> $GRPC_DIR/CMakeLists.txt
+          echo "FetchContent_MakeAvailable(googletest)" >> $GRPC_DIR/CMakeLists.txt
+
           cd grpc && cd cmake/build && sudo make --jobs 5 --output-sync=target install && \
           GRPC_CROSS_BUILD_DIR=$GRPC_DIR/cmake/cross_build && \
           mkdir -p $GRPC_CROSS_BUILD_DIR && \


### PR DESCRIPTION
**Description**

This PR fixes:
```
Run git clone --recurse-submodules -b v1.64.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc && \
Cloning into 'grpc'...
Note: switching to 'b8a04acbbf18fd1c805e5d53d62ed9fa4721a4d1'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

Submodule 'third_party/abseil-cpp' (https://github.com/abseil/abseil-cpp.git) registered for path 'third_party/abseil-cpp'
Submodule 'third_party/benchmark' (https://github.com/google/benchmark) registered for path 'third_party/benchmark'
Submodule 'third_party/bloaty' (https://github.com/google/bloaty.git) registered for path 'third_party/bloaty'
Submodule 'third_party/boringssl-with-bazel' (https://github.com/google/boringssl.git) registered for path 'third_party/boringssl-with-bazel'
Submodule 'third_party/cares/cares' (https://github.com/c-ares/c-ares.git) registered for path 'third_party/cares/cares'
Submodule 'third_party/envoy-api' (https://github.com/envoyproxy/data-plane-api.git) registered for path 'third_party/envoy-api'
Submodule 'third_party/googleapis' (https://github.com/googleapis/googleapis.git) registered for path 'third_party/googleapis'
Submodule 'third_party/googletest' (https://github.com/google/googletest.git) registered for path 'third_party/googletest'
Submodule 'third_party/opencensus-proto' (https://github.com/census-instrumentation/opencensus-proto.git) registered for path 'third_party/opencensus-proto'
Submodule 'third_party/opentelemetry' (https://github.com/open-telemetry/opentelemetry-proto.git) registered for path 'third_party/opentelemetry'
Submodule 'third_party/opentelemetry-cpp' (https://github.com/open-telemetry/opentelemetry-cpp) registered for path 'third_party/opentelemetry-cpp'
Submodule 'third_party/protobuf' (https://github.com/protocolbuffers/protobuf.git) registered for path 'third_party/protobuf'
Submodule 'third_party/protoc-gen-validate' (https://github.com/envoyproxy/protoc-gen-validate.git) registered for path 'third_party/protoc-gen-validate'
Submodule 'third_party/re2' (https://github.com/google/re2.git) registered for path 'third_party/re2'
Submodule 'third_party/xds' (https://github.com/cncf/xds.git) registered for path 'third_party/xds'
Submodule 'third_party/zlib' (https://github.com/madler/zlib) registered for path 'third_party/zlib'
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/abseil-cpp'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/benchmark'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/boringssl-with-bazel'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/cares/cares'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/envoy-api'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/googleapis'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/googletest'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opencensus-proto'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/protobuf'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/protoc-gen-validate'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/re2'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/xds'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/zlib'...
From https://github.com/abseil/abseil-cpp
 * branch            4a2c63365eff8823a5221db86ef490e828306f9d -> FETCH_HEAD
Submodule path 'third_party/abseil-cpp': checked out '4a2c63365eff8823a5221db86ef490e828306f9d'
From https://github.com/google/benchmark
 * branch            344117638c8ff7e239044fd0fa7085839fc03021 -> FETCH_HEAD
Submodule path 'third_party/benchmark': checked out '344117638c8ff7e239044fd0fa7085839fc03021'
From https://github.com/google/bloaty
 * branch            60209eb1ccc34d5deefb002d1b7f37545204f7f2 -> FETCH_HEAD
Submodule path 'third_party/bloaty': checked out '60209eb1ccc34d5deefb002d1b7f37545204f7f2'
Submodule 'third_party/abseil-cpp' (https://github.com/abseil/abseil-cpp.git) registered for path 'third_party/bloaty/third_party/abseil-cpp'
Submodule 'third_party/capstone' (https://github.com/aquynh/capstone.git) registered for path 'third_party/bloaty/third_party/capstone'
Submodule 'third_party/demumble' (https://github.com/nico/demumble.git) registered for path 'third_party/bloaty/third_party/demumble'
Submodule 'third_party/googletest' (https://github.com/google/googletest.git) registered for path 'third_party/bloaty/third_party/googletest'
Submodule 'third_party/protobuf' (https://github.com/protocolbuffers/protobuf.git) registered for path 'third_party/bloaty/third_party/protobuf'
Submodule 'third_party/re2' (https://github.com/google/re2) registered for path 'third_party/bloaty/third_party/re2'
Submodule 'third_party/zlib' (https://github.com/madler/zlib) registered for path 'third_party/bloaty/third_party/zlib'
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/abseil-cpp'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/capstone'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/demumble'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/googletest'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/protobuf'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/re2'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/zlib'...
From https://github.com/abseil/abseil-cpp
 * branch            5dd240724366295970c613ed23d0092bcf392f18 -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/abseil-cpp': checked out '5dd240724366295970c613ed23d0092bcf392f18'
From https://github.com/aquynh/capstone
 * branch            852f46a467cb37559a1f3a18bd45d5ca8c6fc5e7 -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/capstone': checked out '852f46a467cb37559a1f3a18bd45d5ca8c6fc5e7'
From https://github.com/nico/demumble
 * branch            01098eab821b33bd31b9778aea38565cd796aa85 -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/demumble': checked out '01098eab821b33bd31b9778aea38565cd796aa85'
From https://github.com/google/googletest
 * branch            565f1b848215b77c3732bca345fe76a0431d8b34 -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/googletest': checked out '565f1b848215b77c3732bca345fe76a0431d8b34'
From https://github.com/protocolbuffers/protobuf
 * branch            bc1773c42c9c3c522145a3119e989e0dff2a8d54 -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/protobuf': checked out 'bc1773c42c9c3c522145a3119e989e0dff2a8d54'
Submodule 'third_party/benchmark' (https://github.com/google/benchmark.git) registered for path 'third_party/bloaty/third_party/protobuf/third_party/benchmark'
Submodule 'third_party/googletest' (https://github.com/google/googletest.git) registered for path 'third_party/bloaty/third_party/protobuf/third_party/googletest'
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/protobuf/third_party/benchmark'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/bloaty/third_party/protobuf/third_party/googletest'...
From https://github.com/google/benchmark
 * branch            5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8 -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/protobuf/third_party/benchmark': checked out '5b7683f49e1e9223cf9927b24f6fd3d6bd82e3f8'
From https://github.com/google/googletest
 * branch            5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081 -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/protobuf/third_party/googletest': checked out '5ec7f0c4a113e2f18ac2c6cc7df51ad6afc24081'
From https://github.com/google/re2
 * branch            5bd613749fd530b576b890283bfb6bc6ea6246cb -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/re2': checked out '5bd613749fd530b576b890283bfb6bc6ea6246cb'
From https://github.com/madler/zlib
 * branch            cacf7f1d4e3d44d871b605da3b647f07d718623f -> FETCH_HEAD
Submodule path 'third_party/bloaty/third_party/zlib': checked out 'cacf7f1d4e3d44d871b605da3b647f07d718623f'
From https://github.com/google/boringssl
 * branch            5a2bca2124800f2861263959b72bc35cdf18949b -> FETCH_HEAD
Submodule path 'third_party/boringssl-with-bazel': checked out '5a2bca2124800f2861263959b72bc35cdf18949b'
From https://github.com/c-ares/c-ares
 * branch            6360e96b5cf8e5980c887ce58ef727e53d77243a -> FETCH_HEAD
Submodule path 'third_party/cares/cares': checked out '6360e96b5cf8e5980c887ce58ef727e53d77243a'
From https://github.com/envoyproxy/data-plane-api
 * branch            78f198cf96ecdc7120ef640406770aa01af775c4 -> FETCH_HEAD
Submodule path 'third_party/envoy-api': checked out '78f198cf96ecdc7120ef640406770aa01af775c4'
From https://github.com/googleapis/googleapis
 * branch            2f9af297c84c55c8b871ba4495e01ade42476c92 -> FETCH_HEAD
Submodule path 'third_party/googleapis': checked out '2f9af297c84c55c8b871ba4495e01ade42476c92'
From https://github.com/google/googletest
 * branch            2dd1c131950043a8ad5ab0d2dda0e0970596586a -> FETCH_HEAD
Submodule path 'third_party/googletest': checked out '2dd1c131950043a8ad5ab0d2dda0e0970596586a'
From https://github.com/census-instrumentation/opencensus-proto
 * branch            4aa53e15cbf1a47bc9087e6cfdca214c1eea4e89 -> FETCH_HEAD
Submodule path 'third_party/opencensus-proto': checked out '4aa53e15cbf1a47bc9087e6cfdca214c1eea4e89'
From https://github.com/open-telemetry/opentelemetry-proto
 * branch            60fa8754d890b5c55949a8c68dcfd7ab5c2395df -> FETCH_HEAD
Submodule path 'third_party/opentelemetry': checked out '60fa8754d890b5c55949a8c68dcfd7ab5c2395df'
From https://github.com/open-telemetry/opentelemetry-cpp
 * branch            4bd64c9a336fd438d6c4c9dad2e6b61b0585311f -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp': checked out '4bd64c9a336fd438d6c4c9dad2e6b61b0585311f'
Submodule 'third_party/benchmark' (https://github.com/google/benchmark) registered for path 'third_party/opentelemetry-cpp/third_party/benchmark'
Submodule 'third_party/googletest' (https://github.com/google/googletest) registered for path 'third_party/opentelemetry-cpp/third_party/googletest'
Submodule 'third_party/ms-gsl' (https://github.com/microsoft/GSL) registered for path 'third_party/opentelemetry-cpp/third_party/ms-gsl'
Submodule 'third_party/nlohmann-json' (https://github.com/nlohmann/json) registered for path 'third_party/opentelemetry-cpp/third_party/nlohmann-json'
Submodule 'third_party/opentelemetry-proto' (https://github.com/open-telemetry/opentelemetry-proto) registered for path 'third_party/opentelemetry-cpp/third_party/opentelemetry-proto'
Submodule 'third_party/opentracing-cpp' (https://github.com/opentracing/opentracing-cpp.git) registered for path 'third_party/opentelemetry-cpp/third_party/opentracing-cpp'
Submodule 'third_party/prometheus-cpp' (https://github.com/jupp0r/prometheus-cpp) registered for path 'third_party/opentelemetry-cpp/third_party/prometheus-cpp'
Submodule 'tools/vcpkg' (https://github.com/Microsoft/vcpkg) registered for path 'third_party/opentelemetry-cpp/tools/vcpkg'
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/benchmark'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/googletest'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/ms-gsl'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/nlohmann-json'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/opentelemetry-proto'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/opentracing-cpp'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/prometheus-cpp'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/tools/vcpkg'...
From https://github.com/google/benchmark
 * branch            d572f4777349d43653b21d6c2fc63020ab326db2 -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/benchmark': checked out 'd572f4777349d43653b21d6c2fc63020ab326db2'
From https://github.com/google/googletest
 * branch            b796f7d44681514f58a683a3a71ff17c94edb0c1 -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/googletest': checked out 'b796f7d44681514f58a683a3a71ff17c94edb0c1'
From https://github.com/microsoft/GSL
 * branch            6f4529395c5b7c2d661812257cd6780c67e54afa -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/ms-gsl': checked out '6f4529395c5b7c2d661812257cd6780c67e54afa'
From https://github.com/nlohmann/json
 * branch            bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/nlohmann-json': checked out 'bc889afb4c5bf1c0d8ee29ef35eaaf4c8bef8a5d'
From https://github.com/open-telemetry/opentelemetry-proto
 * branch            c4dfbc51f3cd4089778555a2ac5d9bc093ed2956 -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/opentelemetry-proto': checked out 'c4dfbc51f3cd4089778555a2ac5d9bc093ed2956'
From https://github.com/opentracing/opentracing-cpp
 * branch            06b57f48ded1fa3bdd3d4346f6ef29e40e08eaf5 -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/opentracing-cpp': checked out '06b57f48ded1fa3bdd3d4346f6ef29e40e08eaf5'
From https://github.com/jupp0r/prometheus-cpp
 * branch            c9ffcdda9086ffd9e1283ea7a0276d831f3c8a8d -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/prometheus-cpp': checked out 'c9ffcdda9086ffd9e1283ea7a0276d831f3c8a8d'
Submodule 'civetweb' (https://github.com/civetweb/civetweb.git) registered for path 'third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb'
Submodule 'googletest' (https://github.com/google/googletest.git) registered for path 'third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/googletest'
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/googletest'...
From https://github.com/civetweb/civetweb
 * branch            eefb26f82b233268fc98577d265352720d477ba4 -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/civetweb': checked out 'eefb26f82b233268fc98577d265352720d477ba4'
From https://github.com/google/googletest
 * branch            e2239ee6043f73722e7aa812a459f54a28552929 -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/third_party/prometheus-cpp/3rdparty/googletest': checked out 'e2239ee6043f73722e7aa812a459f54a28552929'
From https://github.com/Microsoft/vcpkg
 * branch              8eb57355a4ffb410a2e94c07b4dca2dffbee8e50 -> FETCH_HEAD
Submodule path 'third_party/opentelemetry-cpp/tools/vcpkg': checked out '8eb57355a4ffb410a2e94c07b4dca2dffbee8e50'
From https://github.com/protocolbuffers/protobuf
 * branch            2434ef2adf0c74149b9d547ac5fb545a1ff8b6b5 -> FETCH_HEAD
Submodule path 'third_party/protobuf': checked out '2434ef2adf0c74149b9d547ac5fb545a1ff8b6b5'
Submodule 'third_party/abseil-cpp' (https://github.com/abseil/abseil-cpp.git) registered for path 'third_party/protobuf/third_party/abseil-cpp'
Submodule 'third_party/googletest' (https://github.com/google/googletest.git) registered for path 'third_party/protobuf/third_party/googletest'
Submodule 'third_party/jsoncpp' (https://github.com/open-source-parsers/jsoncpp.git) registered for path 'third_party/protobuf/third_party/jsoncpp'
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/protobuf/third_party/abseil-cpp'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/protobuf/third_party/googletest'...
Cloning into '/home/runner/work/LocalAI/LocalAI/grpc/third_party/protobuf/third_party/jsoncpp'...
From https://github.com/abseil/abseil-cpp
 * branch            4a2c63365eff8823a5221db86ef490e828306f9d -> FETCH_HEAD
Submodule path 'third_party/protobuf/third_party/abseil-cpp': checked out '4a2c63365eff8823a5221db86ef490e828306f9d'
From https://github.com/google/googletest
 * branch            4c9a3bb62bf3ba1f1010bf96f9c8ed767b363774 -> FETCH_HEAD
Submodule path 'third_party/protobuf/third_party/googletest': checked out '4c9a3bb62bf3ba1f1010bf96f9c8ed767b363774'
From https://github.com/open-source-parsers/jsoncpp
 * branch            9059f5cad030ba11d37818847443a53918c327b1 -> FETCH_HEAD
Submodule path 'third_party/protobuf/third_party/jsoncpp': checked out '9059f5cad030ba11d37818847443a53918c327b1'
From https://github.com/envoyproxy/protoc-gen-validate
 * branch            fab737efbb4b4d03e7c771393708f75594b121e4 -> FETCH_HEAD
Submodule path 'third_party/protoc-gen-validate': checked out 'fab737efbb4b4d03e7c771393708f75594b121e4'
From https://github.com/google/re2
 * branch            0c5616df9c0aaa44c9440d87422012423d91c7d1 -> FETCH_HEAD
Submodule path 'third_party/re2': checked out '0c5616df9c0aaa44c9440d87422012423d91c7d1'
From https://github.com/cncf/xds
 * branch            3a472e524827f72d1ad621c4983dd5af54c46776 -> FETCH_HEAD
Submodule path 'third_party/xds': checked out '3a472e524827f72d1ad621c4983dd5af54c46776'
From https://github.com/madler/zlib
 * branch            09155eaa2f9270dc4ed1fa13e2b4b2613e6e4851 -> FETCH_HEAD
Submodule path 'third_party/zlib': checked out '09155eaa2f9270dc4ed1fa13e2b4b2613e6e4851'
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Performing Test HAVE_STDC_FORMAT_MACROS
-- Performing Test HAVE_STDC_FORMAT_MACROS - Success
CMake Warning at third_party/abseil-cpp/CMakeLists.txt:82 (message):
  A future Abseil release will default ABSL_PROPAGATE_CXX_STD to ON for CMake
  3.8 and up.  We recommend enabling this option to ensure your project still
  builds correctly.


-- Performing Test ABSL_INTERNAL_AT_LEAST_CXX17
-- Performing Test ABSL_INTERNAL_AT_LEAST_CXX17 - Success
-- Performing Test ABSL_INTERNAL_AT_LEAST_CXX20
-- Performing Test ABSL_INTERNAL_AT_LEAST_CXX20 - Failed
CMake Deprecation Warning at third_party/cares/cares/CMakeLists.txt:1 (CMAKE_MINIMUM_REQUIRED):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Looking for res_servicename
-- Looking for res_servicename - not found
-- Looking for res_servicename in resolv
-- Looking for res_servicename in resolv - not found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for socket
-- Looking for socket - found
-- Looking for clock_gettime
-- Looking for clock_gettime - found
-- Looking for include file sys/types.h
-- Looking for include file sys/types.h - found
-- Looking for include file sys/socket.h
-- Looking for include file sys/socket.h - found
-- Looking for include file sys/sockio.h
-- Looking for include file sys/sockio.h - not found
-- Looking for include file arpa/inet.h
-- Looking for include file arpa/inet.h - found
-- Looking for include file arpa/nameser_compat.h
-- Looking for include file arpa/nameser_compat.h - found
-- Looking for include file arpa/nameser.h
-- Looking for include file arpa/nameser.h - found
-- Looking for include file assert.h
-- Looking for include file assert.h - found
-- Looking for include file errno.h
-- Looking for include file errno.h - found
-- Looking for include file fcntl.h
-- Looking for include file fcntl.h - found
-- Looking for include file inttypes.h
-- Looking for include file inttypes.h - found
-- Looking for include file limits.h
-- Looking for include file limits.h - found
-- Looking for include file malloc.h
-- Looking for include file malloc.h - found
-- Looking for include file memory.h
-- Looking for include file memory.h - found
-- Looking for include file netdb.h
-- Looking for include file netdb.h - found
-- Looking for include file netinet/in.h
-- Looking for include file netinet/in.h - found
-- Looking for include file net/if.h
-- Looking for include file net/if.h - found
-- Looking for include file signal.h
-- Looking for include file signal.h - found
-- Looking for include file socket.h
-- Looking for include file socket.h - not found
-- Looking for include file stdbool.h
-- Looking for include file stdbool.h - found
-- Looking for include file stdint.h
-- Looking for include file stdint.h - found
-- Looking for include file stdlib.h
-- Looking for include file stdlib.h - found
-- Looking for include file strings.h
-- Looking for include file strings.h - found
-- Looking for include file string.h
-- Looking for include file string.h - found
-- Looking for include file stropts.h
-- Looking for include file stropts.h - not found
-- Looking for include file sys/ioctl.h
-- Looking for include file sys/ioctl.h - found
-- Looking for include file sys/param.h
-- Looking for include file sys/param.h - found
-- Looking for include file sys/select.h
-- Looking for include file sys/select.h - found
-- Looking for include file sys/stat.h
-- Looking for include file sys/stat.h - found
-- Looking for include file sys/time.h
-- Looking for include file sys/time.h - found
-- Looking for include file sys/uio.h
-- Looking for include file sys/uio.h - found
-- Looking for include file time.h
-- Looking for include file time.h - found
-- Looking for include file dlfcn.h
-- Looking for include file dlfcn.h - found
-- Looking for include file unistd.h
-- Looking for include file unistd.h - found
-- Looking for include files sys/types.h, netinet/tcp.h
-- Looking for include files sys/types.h, netinet/tcp.h - found
-- Performing Test HAVE_SOCKLEN_T
-- Performing Test HAVE_SOCKLEN_T - Success
-- Performing Test HAVE_TYPE_SOCKET
-- Performing Test HAVE_TYPE_SOCKET - Failed
-- Performing Test HAVE_BOOL_T
-- Performing Test HAVE_BOOL_T - Success
-- Performing Test HAVE_SSIZE_T
-- Performing Test HAVE_SSIZE_T - Success
-- Performing Test HAVE_LONGLONG
-- Performing Test HAVE_LONGLONG - Success
-- Performing Test HAVE_SIG_ATOMIC_T
-- Performing Test HAVE_SIG_ATOMIC_T - Success
-- Performing Test HAVE_STRUCT_ADDRINFO
-- Performing Test HAVE_STRUCT_ADDRINFO - Success
-- Performing Test HAVE_STRUCT_IN6_ADDR
-- Performing Test HAVE_STRUCT_IN6_ADDR - Success
-- Performing Test HAVE_STRUCT_SOCKADDR_IN6
-- Performing Test HAVE_STRUCT_SOCKADDR_IN6 - Success
-- Performing Test HAVE_STRUCT_SOCKADDR_STORAGE
-- Performing Test HAVE_STRUCT_SOCKADDR_STORAGE - Success
-- Performing Test HAVE_STRUCT_TIMEVAL
-- Performing Test HAVE_STRUCT_TIMEVAL - Success
-- Looking for AF_INET6
-- Looking for AF_INET6 - found
-- Looking for O_NONBLOCK
-- Looking for O_NONBLOCK - found
-- Looking for FIONBIO
-- Looking for FIONBIO - found
-- Looking for SIOCGIFADDR
-- Looking for SIOCGIFADDR - found
-- Looking for MSG_NOSIGNAL
-- Looking for MSG_NOSIGNAL - found
-- Looking for PF_INET6
-- Looking for PF_INET6 - found
-- Looking for SO_NONBLOCK
-- Looking for SO_NONBLOCK - not found
-- Looking for CLOCK_MONOTONIC
-- Looking for CLOCK_MONOTONIC - found
-- Performing Test HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
-- Performing Test HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID - Success
-- Performing Test HAVE_LL
-- Performing Test HAVE_LL - Success
-- Looking for bitncmp
-- Looking for bitncmp - not found
-- Looking for closesocket
-- Looking for closesocket - not found
-- Looking for CloseSocket
-- Looking for CloseSocket - not found
-- Looking for connect
-- Looking for connect - found
-- Looking for fcntl
-- Looking for fcntl - found
-- Looking for freeaddrinfo
-- Looking for freeaddrinfo - found
-- Looking for getaddrinfo
-- Looking for getaddrinfo - found
-- Looking for getenv
-- Looking for getenv - found
-- Looking for gethostbyaddr
-- Looking for gethostbyaddr - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for gethostname
-- Looking for gethostname - found
-- Looking for getnameinfo
-- Looking for getnameinfo - found
-- Looking for getservbyport_r
-- Looking for getservbyport_r - found
-- Looking for getservbyname_r
-- Looking for getservbyname_r - found
-- Looking for gettimeofday
-- Looking for gettimeofday - found
-- Looking for if_indextoname
-- Looking for if_indextoname - found
-- Looking for inet_net_pton
-- Looking for inet_net_pton - not found
-- Looking for inet_ntop
-- Looking for inet_ntop - found
-- Looking for inet_pton
-- Looking for inet_pton - found
-- Looking for ioctl
-- Looking for ioctl - found
-- Looking for ioctlsocket
-- Looking for ioctlsocket - not found
-- Looking for IoctlSocket
-- Looking for IoctlSocket - not found
-- Looking for recv
-- Looking for recv - found
-- Looking for recvfrom
-- Looking for recvfrom - found
-- Looking for send
-- Looking for send - found
-- Looking for setsockopt
-- Looking for setsockopt - found
-- Looking for socket
-- Looking for socket - found
-- Looking for strcasecmp
-- Looking for strcasecmp - found
-- Looking for strcmpi
-- Looking for strcmpi - not found
-- Looking for strdup
-- Looking for strdup - found
-- Looking for stricmp
-- Looking for stricmp - not found
-- Looking for strncasecmp
-- Looking for strncasecmp - found
-- Looking for strncmpi
-- Looking for strncmpi - not found
-- Looking for strnicmp
-- Looking for strnicmp - not found
-- Looking for writev
-- Looking for writev - found
-- Looking for arc4random_buf
-- Looking for arc4random_buf - not found
-- Looking for __system_property_get
-- Looking for __system_property_get - not found
-- 
-- 26.1.0
-- Performing Test protobuf_HAVE_LD_VERSION_SCRIPT
-- Performing Test protobuf_HAVE_LD_VERSION_SCRIPT - Success
-- Performing Test protobuf_HAVE_BUILTIN_ATOMICS
-- Performing Test protobuf_HAVE_BUILTIN_ATOMICS - Success
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of off64_t
-- Check size of off64_t - done
-- Looking for fseeko
-- Looking for fseeko - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Renaming
--     /home/runner/work/LocalAI/LocalAI/grpc/third_party/zlib/zconf.h
-- to 'zconf.h.included' because this file is included with zlib
-- but CMake generates it automatically in the build directory.
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.8.0")
-- Checking for module 'libsystemd>=233'
--   Package 'libsystemd', required by 'virtual:world', not found
-- Configuring done (11.9s)
CMake Error at third_party/abseil-cpp/CMake/AbseilHelpers.cmake:317 (target_link_libraries):
  The link interface of target "test_allocator" contains:

    GTest::gmock

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  third_party/abseil-cpp/absl/container/CMakeLists.txt:206 (absl_cc_library)


CMake Generate step failed.  Build files cannot be regenerated correctly.
-- Generating done (0.8s)
Error: Process completed with exit code 1.
```

This seems to happen only on cross-arch arm builds - and started to happen all of a sudden. Seems that gmock can't be found, so I've adapted slightly the Cmake file coming from gRPC to add it with CMake rather then relying on the system to ship it (probably it was before, and now not part anymore of the runners environment?) 

For context:  http://google.github.io/googletest/quickstart-cmake.html

