### PR TITLE
fix: arm builds via disabling abseil tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,15 +78,6 @@ jobs:
             echo "set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)" >> $CMAKE_CROSS_TOOLCHAIN
           GRPC_DIR=$PWD/grpc
 
-          # http://google.github.io/googletest/quickstart-cmake.html
-          # Seems otherwise cross-arch fails to find it
-          echo "include(FetchContent)" >> $GRPC_DIR/CMakeLists.txt
-          echo "FetchContent_Declare(" >> $GRPC_DIR/CMakeLists.txt
-          echo "  googletest" >> $GRPC_DIR/CMakeLists.txt
-          echo "  URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip" >> $GRPC_DIR/CMakeLists.txt
-          echo ")" >> $GRPC_DIR/CMakeLists.txt
-          echo "FetchContent_MakeAvailable(googletest)" >> $GRPC_DIR/CMakeLists.txt
-
           cd grpc && cd cmake/build && sudo make --jobs 5 --output-sync=target install && \
           GRPC_CROSS_BUILD_DIR=$GRPC_DIR/cmake/cross_build && \
           mkdir -p $GRPC_CROSS_BUILD_DIR && \

--- a/Makefile
+++ b/Makefile
@@ -701,6 +701,7 @@ backend/cpp/llama/llama.cpp:
 INSTALLED_PACKAGES=$(CURDIR)/backend/cpp/grpc/installed_packages
 INSTALLED_LIB_CMAKE=$(INSTALLED_PACKAGES)/lib/cmake
 ADDED_CMAKE_ARGS=-Dabsl_DIR=${INSTALLED_LIB_CMAKE}/absl \
+				 -DABSL_BUILD_TESTING=OFF \
 				 -DProtobuf_DIR=${INSTALLED_LIB_CMAKE}/protobuf \
 				 -Dutf8_range_DIR=${INSTALLED_LIB_CMAKE}/utf8_range \
 				 -DgRPC_DIR=${INSTALLED_LIB_CMAKE}/grpc \


### PR DESCRIPTION
This PR fixes the recurring build issues on ARM that have been happening lately by skipping Abseil's internal tests while building gRPC. We do not modify the library in any way, and many projects use this - I cannot see any reason why these tests need to be ran on every single invocation of our CI pipeline. 

Additionally, gRPC is tested, and exercises the relevant parts of Abseil that way!

The method I am using is documented here: https://github.com/abseil/abseil-cpp/blob/master/CMake/README.md