### PR TITLE
Revert "chore(deps): Bump inflect from 7.0.0 to 7.3.1 in /backend/python/openvoice"

### DIFF
--- a/backend/python/openvoice/requirements-intel.txt
+++ b/backend/python/openvoice/requirements-intel.txt
@@ -10,7 +10,7 @@ pydub==0.25.1
 wavmark==0.0.3
 numpy==2.0.0
 eng_to_ipa==0.0.2
-inflect==7.3.1
+inflect==7.0.0
 unidecode==1.3.7
 whisper-timestamped==1.15.4
 openai


### PR DESCRIPTION
Reverts mudler/LocalAI#2796

```
 #54 107.6  + wrapt==1.16.0
#54 107.6   × No solution found when resolving dependencies:
#54 107.6   ╰─▶ Because only melotts==0.1.2 is available and melotts==0.1.2 depends
#54 107.6       on inflect==7.0.0, we can conclude that all versions of melotts depend
#54 107.6       on inflect==7.0.0.
#54 107.6       And because you require inflect==7.3.1 and melotts, we can conclude that
#54 107.6       the requirements are unsatisfiable.
#54 107.6 make: *** [Makefile:5: install] Error 1
```