### PR TITLE
Revert "chore(deps): Bump numpy from 1.26.4 to 2.0.0 in /backend/python/openvoice"

### DIFF
--- a/backend/python/openvoice/requirements-intel.txt
+++ b/backend/python/openvoice/requirements-intel.txt
@@ -8,7 +8,7 @@ librosa==0.9.1
 faster-whisper==1.0.3
 pydub==0.25.1
 wavmark==0.0.3
-numpy==2.0.0
+numpy==1.26.4
 eng_to_ipa==0.0.2
 inflect==7.0.0
 unidecode==1.3.7


### PR DESCRIPTION
Reverts mudler/LocalAI#2823