### PR TITLE
feat(grammar): mark grammar disabled by default

### DIFF
--- a/core/http/endpoints/openai/chat.go
+++ b/core/http/endpoints/openai/chat.go
@@ -201,7 +201,7 @@ func ChatEndpoint(cl *config.BackendConfigLoader, ml *model.ModelLoader, startup
 		}
 
 		switch {
-		case !config.FunctionsConfig.GrammarConfig.NoGrammar && shouldUseFn:
+		case config.FunctionsConfig.GrammarConfig.EnableGrammar && shouldUseFn:
 			noActionGrammar := functions.Function{
 				Name:        noActionName,
 				Description: noActionDescription,

--- a/gallery/mudler.yaml
+++ b/gallery/mudler.yaml
@@ -10,7 +10,8 @@ config_file: |-
     - <|end_of_text|>
 
   function:
-    return_name_in_function_response: true
+    grammar:
+      enable: true
 
   template:
     chat: |

--- a/pkg/functions/parse.go
+++ b/pkg/functions/parse.go
@@ -25,8 +25,8 @@ type GrammarConfig struct {
 	// In this way if the LLM selects a free string, it won't be mixed necessarly with JSON objects
 	NoMixedFreeString bool `yaml:"no_mixed_free_string"`
 
-	// NoGrammar disables the grammar parsing and parses the responses directly from the LLM
-	NoGrammar bool `yaml:"disable"`
+	// EnableGrammar disables the grammar parsing and parses the responses directly from the LLM
+	EnableGrammar bool `yaml:"enable"`
 
 	// Prefix is the suffix to append to the grammar when being generated
 	// This is useful when models prepend a tag before returning JSON


### PR DESCRIPTION
**Description**

This PR disable grammar by default and make that opt-in. More and more models now support function calling, and grammar support is better to be enabled on these model that fits this logic, or alternatively enabled when want to constrain models that doesn't support function calls directly.