### PR TITLE
feat(openai): add `json_schema` format type and strict mode

### DIFF
--- a/core/http/endpoints/openai/chat.go
+++ b/core/http/endpoints/openai/chat.go
@@ -195,14 +195,26 @@ func ChatEndpoint(cl *config.BackendConfigLoader, ml *model.ModelLoader, startup
 
 		if config.ResponseFormatMap != nil {
 			d := schema.ChatCompletionResponseFormat{}
-			dat, _ := json.Marshal(config.ResponseFormatMap)
-			_ = json.Unmarshal(dat, &d)
+			dat, err := json.Marshal(config.ResponseFormatMap)
+			if err != nil {
+				return err
+			}
+			err = json.Unmarshal(dat, &d)
+			if err != nil {
+				return err
+			}
 			if d.Type == "json_object" {
 				input.Grammar = functions.JSONBNF
 			} else if d.Type == "json_schema" {
 				d := schema.JsonSchemaRequest{}
-				dat, _ := json.Marshal(config.ResponseFormatMap)
-				_ = json.Unmarshal(dat, &d)
+				dat, err := json.Marshal(config.ResponseFormatMap)
+				if err != nil {
+					return err
+				}
+				err = json.Unmarshal(dat, &d)
+				if err != nil {
+					return err
+				}
 				fs := &functions.JSONFunctionStructure{
 					AnyOf: []functions.Item{d.JsonSchema.Schema},
 				}

--- a/core/schema/openai.go
+++ b/core/schema/openai.go
@@ -139,6 +139,17 @@ type ChatCompletionResponseFormat struct {
 	Type ChatCompletionResponseFormatType `json:"type,omitempty"`
 }
 
+type JsonSchemaRequest struct {
+	Type       string     `json:"type"`
+	JsonSchema JsonSchema `json:"json_schema"`
+}
+
+type JsonSchema struct {
+	Name   string         `json:"name"`
+	Strict bool           `json:"strict"`
+	Schema functions.Item `json:"schema"`
+}
+
 type OpenAIRequest struct {
 	PredictionOptions
 

--- a/pkg/functions/functions.go
+++ b/pkg/functions/functions.go
@@ -14,6 +14,7 @@ const (
 type Function struct {
 	Name        string                 `json:"name"`
 	Description string                 `json:"description"`
+	Strict      bool                   `json:"strict"`
 	Parameters  map[string]interface{} `json:"parameters"`
 }
 type Functions []Function


### PR DESCRIPTION
**Description**

This PR adds support for `strict` in the fields of the tools and support for response type to `json_schema`. Behind the hood, it hooks on the grammar support and forces the engine to generate BNF formula so the LLM stays strict on the JSON output.

Note:

- specifying `strict: true` to any of the tool from the API call, will enable grammar even if disabled by config
- if format_type is `json_schema`, the schema will be parsed and BNF grammars generated automatically from the schema.

Reference: https://openai.com/index/introducing-structured-outputs-in-the-api/