### PR TITLE
fix(apple): disable BUILD_TYPE metal on fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,7 +387,7 @@ ifeq ($(DETECT_LIBS),true)
 	scripts/prepare-libs.sh backend-assets/grpc/llama-cpp-avx2
 endif
 ifeq ($(OS),Darwin)
-	$(info ${GREEN}I Skip CUDA/hipblas build on MacOS${RESET})
+	BUILD_TYPE=none $(MAKE) backend-assets/grpc/llama-cpp-fallback
 else
 	$(MAKE) backend-assets/grpc/llama-cpp-cuda
 	$(MAKE) backend-assets/grpc/llama-cpp-hipblas


### PR DESCRIPTION
When compiling the single-binary on Apple, we enforce BUILD_TYPE=metal, however, we want still to have the fallback vanilla such as if llama.cpp fails to load metal (e.g. if Acceleration framework is missing, or MacOS version is too old) we can still run by offloading to the CPU. The default backend is still using metal as usual.
