### PR TITLE
fix(diffusers): use nightly rocm for hipblas builds

### DIFF
--- a/backend/python/diffusers/requirements-hipblas.txt
+++ b/backend/python/diffusers/requirements-hipblas.txt
@@ -1,4 +1,5 @@
---extra-index-url https://download.pytorch.org/whl/rocm6.0
+--pre
+--extra-index-url https://download.pytorch.org/whl/nightly/
 torch
 torchvision
 diffusers


### PR DESCRIPTION
Hopefully the last piece (see https://github.com/mudler/LocalAI/issues/1592#issuecomment-2275890287 )