### PR TITLE
feat(explorer): relax token deletion with error threshold

### DIFF
--- a/core/cli/explorer.go
+++ b/core/cli/explorer.go
@@ -10,9 +10,10 @@ import (
 )
 
 type ExplorerCMD struct {
-	Address           string `env:"LOCALAI_ADDRESS,ADDRESS" default:":8080" help:"Bind address for the API server" group:"api"`
-	PoolDatabase      string `env:"LOCALAI_POOL_DATABASE,POOL_DATABASE" default:"explorer.json" help:"Path to the pool database" group:"api"`
-	ConnectionTimeout string `env:"LOCALAI_CONNECTION_TIMEOUT,CONNECTION_TIMEOUT" default:"2m" help:"Connection timeout for the explorer" group:"api"`
+	Address                  string `env:"LOCALAI_ADDRESS,ADDRESS" default:":8080" help:"Bind address for the API server" group:"api"`
+	PoolDatabase             string `env:"LOCALAI_POOL_DATABASE,POOL_DATABASE" default:"explorer.json" help:"Path to the pool database" group:"api"`
+	ConnectionTimeout        string `env:"LOCALAI_CONNECTION_TIMEOUT,CONNECTION_TIMEOUT" default:"2m" help:"Connection timeout for the explorer" group:"api"`
+	ConnectionErrorThreshold int    `env:"LOCALAI_CONNECTION_ERROR_THRESHOLD,CONNECTION_ERROR_THRESHOLD" default:"3" help:"Connection failure threshold for the explorer" group:"api"`
 }
 
 func (e *ExplorerCMD) Run(ctx *cliContext.Context) error {
@@ -26,7 +27,7 @@ func (e *ExplorerCMD) Run(ctx *cliContext.Context) error {
 	if err != nil {
 		return err
 	}
-	ds := explorer.NewDiscoveryServer(db, dur)
+	ds := explorer.NewDiscoveryServer(db, dur, e.ConnectionErrorThreshold)
 
 	go ds.Start(context.Background())
 	appHTTP := http.Explorer(db, ds)


### PR DESCRIPTION
## Problem

The explorer currently removes entries that fails to connect or have offline workers. However, if connection fails for other reasons entries are deleted instantly and lost from the explorer view.

## Description

This changeset give chances to network in case of connection failures.

If a Network can't be reached, it will be recorded and kept attempting - when it hits the error threshold the entry is definitely removed