### PR TITLE
fix(explorer): reset counter when network is active

### DIFF
--- a/core/explorer/discovery.go
+++ b/core/explorer/discovery.go
@@ -118,6 +118,7 @@ func (s *DiscoveryServer) runBackground() {
 			s.networkState.Networks[token] = Network{
 				Clusters: ledgerK,
 			}
+			delete(s.failures, token)
 			s.Unlock()
 		} else {
 			s.failedToken(token)


### PR DESCRIPTION
When a connection is established and we have detected some workers, we want to reset the failure counter for the entry, if it has any