### PR TITLE
fix: add llvm to extra images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN apt-get update && \
         espeak \
         python3-pip \
         python-is-python3 \
+        llvm \
         python3-dev \
         python3-venv && \
     apt-get clean && \


### PR DESCRIPTION
**Description**

This PR fixes 

```
#52 112.4 Traceback (most recent call last):
#52 112.4   File "/root/.cache/uv/built-wheels-v3/pypi/llvmlite/0.34.0/z7opmFvAdzkqfYFex8UU_/llvmlite-0.34.0.tar.gz/ffi/build.py", line 105, in main_posix
#52 112.4     out = subprocess.check_output([llvm_config, '--version'])
#52 112.4   File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
#52 112.4     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
#52 112.4   File "/usr/lib/python3.10/subprocess.py", line 503, in run
#52 112.4     with Popen(*popenargs, **kwargs) as process:
#52 112.4   File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
#52 112.4     self._execute_child(args, executable, preexec_fn, close_fds,
#52 112.4   File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
#52 112.4     raise child_exception_type(errno_num, err_msg, err_filename)
#52 112.4 FileNotFoundError: [Errno 2] No such file or directory: 'llvm-config'
#52 112.4 
#52 112.4 During handling of the above exception, another exception occurred:
#52 112.4 
#52 112.4 Traceback (most recent call last):
#52 112.4   File "/root/.cache/uv/built-wheels-v3/pypi/llvmlite/0.34.0/z7opmFvAdzkqfYFex8UU_/llvmlite-0.34.0.t
```