### PR TITLE
fix(ci): pin to llvmlite 0.43

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get update && \
         espeak \
         python3-pip \
         python-is-python3 \
-        python3-dev llvm-10* \
+        python3-dev llvm \
         python3-venv && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/backend/python/parler-tts/requirements.txt
+++ b/backend/python/parler-tts/requirements.txt
@@ -1,3 +1,4 @@
 grpcio==1.65.5
 protobuf
 certifi
+llvmlite==0.43.0


### PR DESCRIPTION
**Description**

This PR tries to fix the CI issues we are having with llvm+parler-tts.

It seems parler-tts started to fail now because llvmlite can't be installed - and apparently needs llvm 14