### PR TITLE
fix: temporarily remove `tests-diffusers` due to runwayml

### DIFF
--- a/.github/workflows/test-extra.yml
+++ b/.github/workflows/test-extra.yml
@@ -81,26 +81,26 @@ jobs:
            make --jobs=5 --output-sync=target -C backend/python/rerankers
            make --jobs=5 --output-sync=target -C backend/python/rerankers test
 
-  tests-diffusers:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone
-        uses: actions/checkout@v4
-        with:
-          submodules: true
-      - name: Dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y build-essential ffmpeg
-          sudo apt-get install -y ca-certificates cmake curl patch python3-pip
-          sudo apt-get install -y libopencv-dev
-          # Install UV
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          pip install --user --no-cache-dir grpcio-tools==1.64.1
-      - name: Test diffusers
-        run: |
-          make --jobs=5 --output-sync=target -C backend/python/diffusers
-          make --jobs=5 --output-sync=target -C backend/python/diffusers test
+  # tests-diffusers:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Clone
+  #       uses: actions/checkout@v4
+  #       with:
+  #         submodules: true
+  #     - name: Dependencies
+  #       run: |
+  #         sudo apt-get update
+  #         sudo apt-get install -y build-essential ffmpeg
+  #         sudo apt-get install -y ca-certificates cmake curl patch python3-pip
+  #         sudo apt-get install -y libopencv-dev
+  #         # Install UV
+  #         curl -LsSf https://astral.sh/uv/install.sh | sh
+  #         pip install --user --no-cache-dir grpcio-tools==1.64.1
+  #     - name: Test diffusers
+  #       run: |
+  #         make --jobs=5 --output-sync=target -C backend/python/diffusers
+  #         make --jobs=5 --output-sync=target -C backend/python/diffusers test
 
   tests-parler-tts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
runwayml deleted **all** their models from HuggingFace without warning. 
Temporarily remove our test-diffusers test until a new base model is selected - watch https://github.com/huggingface/diffusers/issues/9322, consider re-enabling the test once diffusers upstream selects a new "default test model" rather than making a random choice.
