### PR TITLE
fix: multiplicative backoff for shutdown

### DIFF
--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -154,7 +154,7 @@ func (ml *ModelLoader) ShutdownModel(modelName string) error {
 	retries := 1
 	for ml.models[modelName].GRPC(false, ml.wd).IsBusy() {
 		log.Debug().Msgf("%s busy. Waiting.", modelName)
-		time.Sleep(retries * 2 * time.Second)
+		time.Sleep(time.Duration(retries * 2) * time.Second)
 		retries++
 	}
 

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -69,6 +69,8 @@ var knownModelsNameSuffixToSkip []string = []string{
 	".tar.gz",
 }
 
+const retryTimeout = time.Duration(2 * time.Minute)
+
 func (ml *ModelLoader) ListFilesInModelPath() ([]string, error) {
 	files, err := os.ReadDir(ml.ModelPath)
 	if err != nil {
@@ -154,7 +156,11 @@ func (ml *ModelLoader) ShutdownModel(modelName string) error {
 	retries := 1
 	for ml.models[modelName].GRPC(false, ml.wd).IsBusy() {
 		log.Debug().Msgf("%s busy. Waiting.", modelName)
-		time.Sleep(time.Duration(retries * 2) * time.Second)
+		dur := time.Duration(retries*2) * time.Second
+		if dur > retryTimeout {
+			dur = retryTimeout
+		}
+		time.Sleep(dur)
 		retries++
 	}
 

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -151,9 +151,11 @@ func (ml *ModelLoader) ShutdownModel(modelName string) error {
 		return fmt.Errorf("model %s not found", modelName)
 	}
 
+	retries := 1
 	for ml.models[modelName].GRPC(false, ml.wd).IsBusy() {
 		log.Debug().Msgf("%s busy. Waiting.", modelName)
-		time.Sleep(2 * time.Second)
+		time.Sleep(retries * 2 * time.Second)
+		retries++
 	}
 
 	return ml.deleteProcess(modelName)


### PR DESCRIPTION
Rather than always retry every two seconds, back off the shutdown attempt rate?

**Description**

This PR fixes #3543 

**Notes for Reviewers**
Suggesting this as a PR-to-PR since it may or may not be necessary. I don't think we need to go all the way to exponential backoff for this situation.