### PR TITLE
feat: allow setting trust_remote_code for sentencetransformers backend

### DIFF
--- a/backend/python/sentencetransformers/backend.py
+++ b/backend/python/sentencetransformers/backend.py
@@ -55,7 +55,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         """
         model_name = request.Model
         try:
-            self.model = SentenceTransformer(model_name)
+            self.model = SentenceTransformer(model_name, trust_remote_code=request.TrustRemoteCode)
         except Exception as err:
             return backend_pb2.Result(success=False, message=f"Unexpected {err=}, {type(err)=}")
 

--- a/backend/python/sentencetransformers/requirements.txt
+++ b/backend/python/sentencetransformers/requirements.txt
@@ -1,3 +1,5 @@
 grpcio==1.66.1
 protobuf
 certifi
+datasets
+einops


### PR DESCRIPTION
**Description**
Allow setting trust_remote_code for SentenceTransformers backend for loading models such as nvidia/NV-Embed-v2 as described in issue: #3544

This PR fixes #3544

**Notes for Reviewers**
Added datasets and einops to requirements because nvidia/NV-Embed-v2 asked for it on loading.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.