### PR TITLE
fix: `gallery/index.yaml` comment spacing

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -1281,7 +1281,7 @@
 - !!merge <<: *mistral03
   name: "mn-12b-lyra-v4-iq-imatrix"
   icon: https://cdn-uploads.huggingface.co/production/uploads/65d4cf2693a0a3744a27536c/dVoru83WOpwVjMlgZ_xhA.png
-  #chatml
+  # chatml
   url: "github:mudler/LocalAI/gallery/chatml.yaml@master"
   urls:
     - https://huggingface.co/Lewdiculous/MN-12B-Lyra-v4-GGUF-IQ-Imatrix


### PR DESCRIPTION
extremely minor fix: add a space to index.yaml for the scanner

This should prevent it from showing up on entirely unrelated PRs.