### PR TITLE
Revert "chore(deps): Bump setuptools from 69.5.1 to 75.1.0 in /backend/python/transformers"

### DIFF
--- a/backend/python/transformers/requirements.txt
+++ b/backend/python/transformers/requirements.txt
@@ -1,4 +1,4 @@
 grpcio==1.66.1
 protobuf
 certifi
-setuptools==75.1.0 # https://github.com/mudler/LocalAI/issues/2406
+setuptools==69.5.1 # https://github.com/mudler/LocalAI/issues/2406


### PR DESCRIPTION
Reverts mudler/LocalAI#3579

https://github.com/mudler/LocalAI/issues/2406