### PR TITLE
fix(parler-tts): fix install with sycl

### DIFF
--- a/backend/python/parler-tts/install.sh
+++ b/backend/python/parler-tts/install.sh
@@ -15,5 +15,12 @@ installRequirements
 
 # https://github.com/descriptinc/audiotools/issues/101
 # incompatible protobuf versions.
-PYDIR=$(ls ${MY_DIR}/venv/lib)
-curl -L https://raw.githubusercontent.com/protocolbuffers/protobuf/main/python/google/protobuf/internal/builder.py -o ${MY_DIR}/venv/lib/${PYDIR}/site-packages/google/protobuf/internal/builder.py
+PYDIR=python3.10
+pyenv="${MY_DIR}/venv/lib/${PYDIR}/site-packages/google/protobuf/internal/"
+
+if [ ! -d ${pyenv} ]; then
+    echo "(parler-tts/install.sh): Error: ${pyenv} does not exist"
+    exit 1
+fi
+
+curl -L https://raw.githubusercontent.com/protocolbuffers/protobuf/main/python/google/protobuf/internal/builder.py -o ${pyenv}/builder.py


### PR DESCRIPTION
**Description**

This PR fixes  building issues with intel sycl images:

```

#62 103.4  + werkzeug==3.0.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  4015  100  4015    0     0  18525      0 --:--:-- --:--:-- --:--:-- 18587
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: __ocl_svml_h8.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: __ocl_svml_l9.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: __ocl_svml_z0.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: __ocl_svml_z1.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: ccl
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: cl.cfg
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: clbltfne9.rtl
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: clbltfnh8.rtl
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: clbltfnl9.rtl
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: clbltfnshared.rtl
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: clbltfnz0.rtl
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: clbltfnz1.rtl
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: cllibrary.rtl
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: cllibrarye9.o
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: cllibraryh8.o
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: cllibraryl9.o
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: cllibraryz0.o
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: cllibraryz1.o
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: icx-lto.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libOpenCL.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libOpenCL.so.1
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libOpenCL.so.1.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libarcher.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libarcher_static.a
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libccl.a
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libccl.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libccl.so.1
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libccl.so.1.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libcommon_clang.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libcommon_clang.so.2024.18.7.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libfabric
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libimf.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libintelocl.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libintelocl.so-gdb.py
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libintelocl.so.2024.18.7.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libintlc.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libintlc.so.5
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libiomp5.a
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libiomp5.dbg
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libiomp5.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libiomp5_db.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libiompstubs5.a
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libiompstubs5.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libirc.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libirng.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_avx2.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_avx512.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_blacs_intelmpi_ilp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_blacs_intelmpi_lp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_blacs_openmpi_ilp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_blacs_openmpi_lp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_cdft_core.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_core.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_def.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_gf_ilp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_gf_lp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_gnu_thread.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_intel_ilp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_intel_lp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_intel_thread.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_mc3.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_pgi_thread.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_rt.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_scalapack_ilp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_scalapack_lp64.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sequential.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sycl_blas.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sycl_data_fitting.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sycl_dft.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sycl_lapack.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sycl_rng.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sycl_sparse.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sycl_stats.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_sycl_vm.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_tbb_thread.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_vml_avx2.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_vml_avx512.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_vml_cmpt.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_vml_def.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmkl_vml_mc3.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   167  100   167    0     0   4026      0 --:--:-- --:--:-- --:--:--  3976
100   167  100   167    0     0   4015      0 --:--:-- --:--:-- --:--:--  3976
#62 103.4 
100  2014    0  2014    0     0  12622      0 --:--:-- --:--:-- --:--:-- 12622
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpi.so.12
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpi.so.12.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpi.so.12.0.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpi_ilp64.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpi_ilp64.so.4
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpi_ilp64.so.4.1
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpi_shm_heap_proxy.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpicxx.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpicxx.so.12
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpicxx.so.12.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpicxx.so.12.0.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpifort.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpifort.so.12
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpifort.so.12.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpifort.so.12.0.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpijava.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpijava.so.1
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libmpijava.so.1.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libomptarget.rtl.level0.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libomptarget.rtl.opencl.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libomptarget.rtl.unified_runtime.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libomptarget.rtl.x86_64.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libomptarget.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libomptarget.sycl.wrap.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libonnxruntime.1.12.22.721.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libpi_level_zero.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libpi_opencl.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libpi_unified_runtime.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libqkmalloc.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsvml.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-bfloat16.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-cassert.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-cmath-fp64.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-cmath.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-complex-fp64.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-complex.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-cstring.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-imf-bf16.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-imf-fp64.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-fallback-imf.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-imf-dl-fp64.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-imf-dl.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-native-bfloat16.spv
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-preview.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-preview.so.7
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl-preview.so.7.2.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl.so.7
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl.so.7.2.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl.so.7.2.0-gdb.py
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libsycl_pi_trace_collector.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbb.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbb.so.12
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbb.so.12.13
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind.so.3
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind.so.3.13
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind_2_0.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind_2_0.so.3
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind_2_0.so.3.13
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind_2_5.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind_2_5.so.3
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbbind_2_5.so.3.13
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbmalloc.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbmalloc.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbmalloc.so.2.13
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbmalloc_proxy.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbmalloc_proxy.so.2
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libtbbmalloc_proxy.so.2.13
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_adapter_level_zero.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_adapter_level_zero.so.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_adapter_level_zero.so.0.9.8
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_adapter_opencl.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_adapter_opencl.so.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_adapter_opencl.so.0.9.8
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_loader.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_loader.so.0
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libur_loader.so.0.9.8
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libxptifw.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: libze_trace_collector.so
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: locale
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: mpi
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: pkgconfig
#62 103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
#62 103.4                                  Dload  Upload   Total   Spent    Left  Speed
#62 103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: python3.10
#62 103.4 make: *** [Makefile:17: parler-tts] Error 6
#62 ERROR: process "/bin/bash -c if [[ ( \"${EXTRA_BACKENDS}\" =~ \"coqui\" || -z \"${EXTRA_BACKENDS}\" ) && \"$IMAGE_TYPE\" == \"extras\" ]]; then         make -C backend/python/coqui     ; fi &&     if [[ ( \"${EXTRA_BACKENDS}\" =~ \"parler-tts\" || -z \"${EXTRA_BACKENDS}\" ) && \"$IMAGE_TYPE\" == \"extras\" ]]; then         make -C backend/python/parler-tts     ; fi &&     if [[ ( \"${EXTRA_BACKENDS}\" =~ \"diffusers\" || -z \"${EXTRA_BACKENDS}\" ) && \"$IMAGE_TYPE\" == \"extras\" ]]; then         make -C backend/python/diffusers     ; fi &&     if [[ ( \"${EXTRA_BACKENDS}\" =~ \"transformers-musicgen\" || -z \"${EXTRA_BACKENDS}\" ) && \"$IMAGE_TYPE\" == \"extras\" ]]; then         make -C backend/python/transformers-musicgen     ; fi" did not complete successfully: exit code: 2
------
 > [stage-9 10/13] RUN if [[ ( "${EXTRA_BACKENDS}" =~ "coqui" || -z "${EXTRA_BACKENDS}" ) && "extras" == "extras" ]]; then         make -C backend/python/coqui     ; fi &&     if [[ ( "${EXTRA_BACKENDS}" =~ "parler-tts" || -z "${EXTRA_BACKENDS}" ) && "extras" == "extras" ]]; then         make -C backend/python/parler-tts     ; fi &&     if [[ ( "${EXTRA_BACKENDS}" =~ "diffusers" || -z "${EXTRA_BACKENDS}" ) && "extras" == "extras" ]]; then         make -C backend/python/diffusers     ; fi &&     if [[ ( "${EXTRA_BACKENDS}" =~ "transformers-musicgen" || -z "${EXTRA_BACKENDS}" ) && "extras" == "extras" ]]; then         make -C backend/python/transformers-musicgen     ; fi:
103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
103.4                                  Dload  Upload   Total   Spent    Left  Speed
103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: mpi
103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
103.4                                  Dload  Upload   Total   Spent    Left  Speed
103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: pkgconfig
103.4   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
103.4                                  Dload  Upload   Total   Spent    Left  Speed
103.4 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: python3.10
103.4 make: *** [Makefile:17: parler-tts] Error 6
```

See also CI failures in https://github.com/mudler/LocalAI/actions/runs/10971002445/job/30466824823