### PR TITLE
fix(hipblas): do not push all variants to hipblas builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -297,10 +297,10 @@ COPY .git .
 RUN make prepare
 
 ## Build the binary
-## If it's CUDA, we want to skip some of the llama-compat backends to save space
-## We only leave the most CPU-optimized variant and the fallback for the cublas build
-## (both will use CUDA for the actual computation)
-RUN if [ "${BUILD_TYPE}" = "cublas" ]; then \
+## If it's CUDA or hipblas, we want to skip some of the llama-compat backends to save space
+## We only leave the most CPU-optimized variant and the fallback for the cublas/hipblas build
+## (both will use CUDA or hipblas for the actual computation)
+RUN if [ "${BUILD_TYPE}" = "cublas" ] || [ "${BUILD_TYPE}" = "hipblas" ]; then \
         SKIP_GRPC_BACKEND="backend-assets/grpc/llama-cpp-avx backend-assets/grpc/llama-cpp-avx2" make build; \
     else \
         make build; \


### PR DESCRIPTION
**Description**

Like with CUDA builds, we don't need all the variants when we are compiling against the accelerated variants - in this way we save space and we avoid to exceed embedFS golang size limits.

**Notes for Reviewers**

logs:
```
 #55 14460.3  2362 |     grpc::Status Predict(ServerContext* context, const backend::PredictOptions* request, backend::Reply* reply) {
#55 14460.3       |                  ^
#55 14460.3 /build/backend/cpp/llama-grpc/llama.cpp/build/examples/grpc-server/backend.grpc.pb.h:444:28: note: overridden virtual function is here
#55 14460.3   444 |     virtual ::grpc::Status Predict(::grpc::ServerContext* context, const ::backend::PredictOptions* request, ::backend::Reply* response);
#55 14460.3       |                            ^
#55 14460.3 /build/backend/cpp/llama-grpc/llama.cpp/examples/grpc-server/grpc-server.cpp:2386:18: warning: 'Embedding' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
#55 14460.3  2386 |     grpc::Status Embedding(ServerContext* context, const backend::PredictOptions* request, backend::EmbeddingResult* embeddingResult) {
#55 14460.3       |                  ^
#55 14460.3 /build/backend/cpp/llama-grpc/llama.cpp/build/examples/grpc-server/backend.grpc.pb.h:447:28: note: overridden virtual function is here
#55 14460.3   447 |     virtual ::grpc::Status Embedding(::grpc::ServerContext* context, const ::backend::PredictOptions* request, ::backend::EmbeddingResult* response);
#55 14460.3       |                            ^
#55 14460.3 5 warnings generated.
#55 14460.3 # github.com/mudler/LocalAI
#55 14460.3 too much data, last section SGOSTRING (2162971000, over 2e+09 bytes)
#55 14460.3 too much data, last section SGOFUNC (2165083954, over 2e+09 bytes)
#55 14460.3 too much data, last section SGCBITS (2165107976, over 2e+09 bytes)
#55 14460.3 too much data, last section SRODATA (2166055221, over 2e+09 bytes)
#55 14460.3 too much data, last section SFUNCTAB (2166055221, over 2e+09 bytes)
#55 14460.3 too much data, last section SELFROSECT (2166058744, over 2e+09 bytes)
#55 14460.3 too much data, last section STYPELINK (2166125032, over 2e+09 bytes)
#55 14460.3 too much data, last section SITABLINK (2166151200, over 2e+09 bytes)
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12f22
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12f24
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12f22
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12f1a
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12f12
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12f0a
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12f02
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12efa
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12ef2
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12eea
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12ee2
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12eda
#55 14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12ed2
#55 14460.3 /root/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.1.linux-amd64/pkg/tool/linux_amd64/link: too many errors
#55 14460.3 reflect.(*rtype).CanSeq: pc-relative relocation address for go:itab.*reflect.rtype,reflect.Type is too big: 0x824b7f92
#55 14460.3 make: *** [Makefile:369: build] Error 1
#55 ERROR: process "/bin/sh -c if [ \"${BUILD_TYPE}\" = \"cublas\" ]; then         SKIP_GRPC_BACKEND=\"backend-assets/grpc/llama-cpp-avx backend-assets/grpc/llama-cpp-avx2\" make build;     else         make build;     fi" did not complete successfully: exit code: 2
------
 > [builder 6/7] RUN if [ "hipblas" = "cublas" ]; then         SKIP_GRPC_BACKEND="backend-assets/grpc/llama-cpp-avx backend-assets/grpc/llama-cpp-avx2" make build;     else         make build;     fi:
14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12f02
14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12efa
14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12ef2
14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12eea
14460.3 .plt: pc-relative relocation address for .got.plt is too big: 0x81f12ee2
```

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->