### PR TITLE
chore: get model also from query

### DIFF
--- a/core/http/ctx/fiber.go
+++ b/core/http/ctx/fiber.go
@@ -19,7 +19,9 @@ func ModelFromContext(ctx *fiber.Ctx, cl *config.BackendConfigLoader, loader *mo
 	if ctx.Params("model") != "" {
 		modelInput = ctx.Params("model")
 	}
-
+	if ctx.Query("model") != "" {
+		modelInput = ctx.Query("model")
+	}
 	// Set model from bearer token, if available
 	bearer := strings.TrimLeft(ctx.Get("authorization"), "Bear ") // Reduced duplicate characters of Bearer
 	bearerExists := bearer != "" && loader.ExistsInModelPath(bearer)


### PR DESCRIPTION
**Description**

This PR changes model detection such as it is now considered also in the query (e.g. `?model=xx`) of the URL

Context: extracted from #3714 