### PR TITLE
fix(initializer): correctly reap dangling processes

### DIFF
--- a/pkg/model/initializers.go
+++ b/pkg/model/initializers.go
@@ -376,7 +376,9 @@ func (ml *ModelLoader) grpcModel(backend string, o *Options) func(string, string
 
 		if !ready {
 			log.Debug().Msgf("GRPC Service NOT ready")
-			ml.deleteProcess(o.model)
+			if process := client.Process(); process != nil {
+				process.Stop()
+			}
 			return nil, fmt.Errorf("grpc service not ready")
 		}
 
@@ -388,11 +390,15 @@ func (ml *ModelLoader) grpcModel(backend string, o *Options) func(string, string
 
 		res, err := client.GRPC(o.parallelRequests, ml.wd).LoadModel(o.context, &options)
 		if err != nil {
-			ml.deleteProcess(o.model)
+			if process := client.Process(); process != nil {
+				process.Stop()
+			}
 			return nil, fmt.Errorf("could not load model: %w", err)
 		}
 		if !res.Success {
-			ml.deleteProcess(o.model)
+			if process := client.Process(); process != nil {
+				process.Stop()
+			}
 			return nil, fmt.Errorf("could not load model (no success): %s", res.Message)
 		}
 

--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -128,7 +128,7 @@ func (ml *ModelLoader) LoadModel(modelID, modelName string, loader func(string, 
 	defer ml.mu.Unlock()
 	model, err := loader(modelID, modelName, modelFile)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load model with internal loader: %s", err)
 	}
 
 	if model == nil {

--- a/pkg/model/process.go
+++ b/pkg/model/process.go
@@ -18,14 +18,18 @@ import (
 func (ml *ModelLoader) deleteProcess(s string) error {
 	defer delete(ml.models, s)
 
+	log.Debug().Msgf("Deleting process %s", s)
+
 	m, exists := ml.models[s]
 	if !exists {
+		log.Error().Msgf("Model does not exist %s", s)
 		// Nothing to do
 		return nil
 	}
 
 	process := m.Process()
 	if process == nil {
+		log.Error().Msgf("No process for %s", s)
 		// Nothing to do as there is no process
 		return nil
 	}


### PR DESCRIPTION
**Description**

This PR fixes a current existing issue when starting new processes. If the backend fails, for instance by loading the model and the model was not explicitly configured with a `backend`, LocalAI would loop over the backends - however if it fails it won't reap the process, and calling `deleteProcess` is a no-op as the model isn't registered yet.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->