### PR TITLE
feat(multimodal): allow to template placeholders

### DIFF
--- a/core/config/backend_config.go
+++ b/core/config/backend_config.go
@@ -196,6 +196,10 @@ type TemplateConfig struct {
 	// JoinChatMessagesByCharacter is a string that will be used to join chat messages together.
 	// It defaults to \n
 	JoinChatMessagesByCharacter *string `yaml:"join_chat_messages_by_character"`
+
+	Video string `yaml:"video"`
+	Image string `yaml:"image"`
+	Audio string `yaml:"audio"`
 }
 
 func (c *BackendConfig) UnmarshalYAML(value *yaml.Node) error {

--- a/pkg/model/initializers.go
+++ b/pkg/model/initializers.go
@@ -314,7 +314,7 @@ func (ml *ModelLoader) grpcModel(backend string, o *Options) func(string, string
 
 				client = NewModel(modelID, serverAddress, process)
 			} else {
-				log.Debug().Msg("external backend is uri")
+				log.Debug().Msg("external backend is a uri")
 				// address
 				client = NewModel(modelID, uri, nil)
 			}

--- a/pkg/templates/multimodal.go
+++ b/pkg/templates/multimodal.go
@@ -1,0 +1,24 @@
+package templates
+
+import (
+	"bytes"
+	"text/template"
+)
+
+func TemplateMultiModal(templateString string, templateID int, text string) (string, error) {
+	// compile the template
+	tmpl, err := template.New("template").Parse(templateString)
+	if err != nil {
+		return "", err
+	}
+	result := bytes.NewBuffer(nil)
+	// execute the template
+	err = tmpl.Execute(result, struct {
+		ID   int
+		Text string
+	}{
+		ID:   templateID,
+		Text: text,
+	})
+	return result.String(), err
+}

--- a/pkg/templates/multimodal_test.go
+++ b/pkg/templates/multimodal_test.go
@@ -1,0 +1,19 @@
+package templates_test
+
+import (
+	. "github.com/mudler/LocalAI/pkg/templates" // Update with your module path
+
+	// Update with your module path
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("EvaluateTemplate", func() {
+	Context("templating simple strings for multimodal chat", func() {
+		It("should template messages correctly", func() {
+			result, err := TemplateMultiModal("[img-{{.ID}}]{{.Text}}", 1, "bar")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("[img-1]bar"))
+		})
+	})
+})


### PR DESCRIPTION
**Description**

This PR allows to customize the placeholders for the images that are sent back to the model. 

For context, some models/libraries have different way to express images, videos or audio placeholders. For example, llama.cpp backend expects images within an `[img-ID]` tag, but other backends/models (e.g. vLLM) use a different notation ( `<|image_|>`). This changeset allow to specify the notation in the template config section of the YAML file:

For example, to override defaults, now it is possible to set in the model configuration the following:

```yaml

template:
  video: "<|video_{{.ID}}|> {{.Text}}"
  image: "<|image_{{.ID}}|> {{.Text}}"
  audio: "<|audio_{{.ID}}|> {{.Text}}"
```

**Notes for Reviewers**

This PR is related to #3670 #3602 #2318 

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->