### PR TITLE
fix(go-grpc-server): always close resultChan

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -144,6 +144,8 @@ func (s *server) PredictStream(in *pb.PredictOptions, stream pb.Backend_PredictS
 	}()
 
 	err := s.llm.PredictStream(in, resultChan)
+	// close the channel, so if resultChan is not closed by the LLM (maybe because does not implement PredictStream), the client will not hang
+	close(resultChan)
 	<-done
 
 	return err


### PR DESCRIPTION
**Description**

By not closing the channel, if a server not implementing PredictStream receives a client call would hang indefinetly as would wait for resultChan to be consumed.

If the prediction stream returns we close the channel now and we wait for the goroutine to finish.

**Notes for Reviewers**

The issue can be reproduced easily: install a whisper model, and try to chat it via the WebUI. Any call to other backend is now locked as LocalAI tries to shutdown the whisper model and fail as it still hanging, waiting for the previous PredictStream request to complete.

Only golang-based models are affected (e.g. tts with rhaspy and whisper)

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->