### PR TITLE
chore(vllm): do not install from source

### DIFF
--- a/backend/python/openvoice/test.py
+++ b/backend/python/openvoice/test.py
@@ -19,7 +19,7 @@ class TestBackendServicer(unittest.TestCase):
         This method sets up the gRPC service by starting the server
         """
         self.service = subprocess.Popen(["python3", "backend.py", "--addr", "localhost:50051"])
-        time.sleep(10)
+        time.sleep(30)
 
     def tearDown(self) -> None:
         """

--- a/backend/python/vllm/install.sh
+++ b/backend/python/vllm/install.sh
@@ -13,7 +13,9 @@ if [ "x${BUILD_PROFILE}" == "xintel" ]; then
     EXTRA_PIP_INSTALL_FLAGS+=" --upgrade --index-strategy=unsafe-first-match"
 fi
 
-if [ "x${BUILD_TYPE}" == "x" ]; then
+# We don't embed this into the images as it is a large dependency and not always needed.
+# Besides, the speed inference are not actually usable in the current state for production use-cases.
+if [ "x${BUILD_TYPE}" == "x" ] && [ "x${FROM_SOURCE}" == "xtrue" ]; then
         ensureVenv
         # https://docs.vllm.ai/en/v0.6.1/getting_started/cpu-installation.html
         if [ ! -d vllm ]; then


### PR DESCRIPTION
**Description**

This pull request includes changes to the setup and installation scripts of vLLM to skip building from source when using CPU. Besides, extends the openvoice test timeout to avoid test flakiness.

Changes to test setup:

* Increased the sleep time in the `setUp` method of `backend/python/openvoice/test.py` from 10 to 30 seconds to ensure the gRPC service is fully started before tests run. (`backend/python/openvoice/test.py`)

Changes to installation script:

* Commented out the block of code in `backend/python/vllm/install.sh` that installs VLLM via source with CPU support. This change makes the installation of this large dependency optional and notes that the current speed of inference is not usable for production use-cases. (`backend/python/vllm/install.sh`)

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->