### PR TITLE
fix: listmodelservice / welcome endpoint use LOOSE_ONLY

### DIFF
--- a/core/http/endpoints/localai/welcome.go
+++ b/core/http/endpoints/localai/welcome.go
@@ -13,15 +13,10 @@ import (
 func WelcomeEndpoint(appConfig *config.ApplicationConfig,
 	cl *config.BackendConfigLoader, ml *model.ModelLoader, modelStatus func() (map[string]string, map[string]string)) func(*fiber.Ctx) error {
 	return func(c *fiber.Ctx) error {
-		models, _ := services.ListModels(cl, ml, config.NoFilterFn, services.SKIP_IF_CONFIGURED)
 		backendConfigs := cl.GetAllBackendConfigs()
-
 		galleryConfigs := map[string]*gallery.Config{}
-		modelsWithBackendConfig := map[string]interface{}{}
 
 		for _, m := range backendConfigs {
-			modelsWithBackendConfig[m.Name] = nil
-
 			cfg, err := gallery.GetLocalModelConfiguration(ml.ModelPath, m.Name)
 			if err != nil {
 				continue
@@ -29,12 +24,7 @@ func WelcomeEndpoint(appConfig *config.ApplicationConfig,
 			galleryConfigs[m.Name] = cfg
 		}
 
-		modelsWithoutConfig := []string{}
-		for _, m := range models {
-			if _, ok := modelsWithBackendConfig[m]; !ok {
-				modelsWithoutConfig = append(modelsWithoutConfig, m)
-			}
-		}
+		modelsWithoutConfig, _ := services.ListModels(cl, ml, config.NoFilterFn, services.LOOSE_ONLY)
 
 		// Get model statuses to display in the UI the operation in progress
 		processingModels, taskTypes := modelStatus()

--- a/core/services/list_models.go
+++ b/core/services/list_models.go
@@ -21,11 +21,12 @@ func ListModels(bcl *config.BackendConfigLoader, ml *model.ModelLoader, filter c
 	dataModels := []string{}
 
 	// Start with known configurations
-	if looseFilePolicy != LOOSE_ONLY {
-		for _, c := range bcl.GetBackendConfigsByFilter(filter) {
-			if looseFilePolicy == SKIP_IF_CONFIGURED {
-				skipMap[c.Model] = nil
-			}
+
+	for _, c := range bcl.GetBackendConfigsByFilter(filter) {
+		if (looseFilePolicy == SKIP_IF_CONFIGURED) || (looseFilePolicy == LOOSE_ONLY) {
+			skipMap[c.Model] = nil
+		}
+		if looseFilePolicy != LOOSE_ONLY {
 			dataModels = append(dataModels, c.Name)
 		}
 	}

--- a/core/services/list_models.go
+++ b/core/services/list_models.go
@@ -8,10 +8,10 @@ import (
 type LooseFilePolicy int
 
 const (
-	SKIP_IF_CONFIGURED LooseFilePolicy = iota
+	LOOSE_ONLY LooseFilePolicy = iota
+	SKIP_IF_CONFIGURED
 	SKIP_ALWAYS
 	ALWAYS_INCLUDE
-	LOOSE_ONLY
 )
 
 func ListModels(bcl *config.BackendConfigLoader, ml *model.ModelLoader, filter config.BackendConfigFilterFn, looseFilePolicy LooseFilePolicy) ([]string, error) {
@@ -23,6 +23,7 @@ func ListModels(bcl *config.BackendConfigLoader, ml *model.ModelLoader, filter c
 	// Start with known configurations
 
 	for _, c := range bcl.GetBackendConfigsByFilter(filter) {
+		// Is this better than looseFilePolicy <= SKIP_IF_CONFIGURED ? less performant but more readable?
 		if (looseFilePolicy == SKIP_IF_CONFIGURED) || (looseFilePolicy == LOOSE_ONLY) {
 			skipMap[c.Model] = nil
 		}


### PR DESCRIPTION
**Description**

This PR fixes #3790 - simplifies welcome.go by using LOOSE_ONLY, repairs it in listmodelservice

**Notes for Reviewers**
quick PR, seems to work in my simple mac testing.

