### PR TITLE
chore: dependabot ignore generated grpc go package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+    - dependency-name: "github.com/mudler/LocalAI/pkg/grpc/proto"
   - package-ecosystem: "github-actions"
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: "/"


### PR DESCRIPTION
dependabot is frequently / always stuck on `github.com/mudler/LocalAI/pkg/grpc/proto` lately.

Adding a configuration flag to ignore this package, as its generated on build anyway.