### PR TITLE
feat(templates): add sprig to multimodal templates

### DIFF
--- a/pkg/templates/multimodal.go
+++ b/pkg/templates/multimodal.go
@@ -3,11 +3,13 @@ package templates
 import (
 	"bytes"
 	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
 )
 
 func TemplateMultiModal(templateString string, templateID int, text string) (string, error) {
 	// compile the template
-	tmpl, err := template.New("template").Parse(templateString)
+	tmpl, err := template.New("template").Funcs(sprig.FuncMap()).Parse(templateString)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
**Description**

This PR adds sprig to the multimodal templates. This allows to use sprig functions when configuring the multimodal templates, which can be needed in case of backends that expects the ID of images to start with 1 instead of 0 (and we can customize that in the template by ++-ing the IDs with sprig functions, rather then hardcoding it).

**Notes for Reviewers**

Part of https://github.com/mudler/LocalAI/issues/3670

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->