### PR TITLE
feat(templates): use a single template for multimodals messages

### DIFF
--- a/core/config/backend_config.go
+++ b/core/config/backend_config.go
@@ -197,9 +197,7 @@ type TemplateConfig struct {
 	// It defaults to \n
 	JoinChatMessagesByCharacter *string `yaml:"join_chat_messages_by_character"`
 
-	Video string `yaml:"video"`
-	Image string `yaml:"image"`
-	Audio string `yaml:"audio"`
+	Multimodal string `yaml:"multimodal"`
 }
 
 func (c *BackendConfig) UnmarshalYAML(value *yaml.Node) error {

--- a/pkg/templates/multimodal.go
+++ b/pkg/templates/multimodal.go
@@ -7,20 +7,60 @@ import (
 	"github.com/Masterminds/sprig/v3"
 )
 
-func TemplateMultiModal(templateString string, templateID int, text string) (string, error) {
+type MultiModalOptions struct {
+	TotalImages int
+	TotalAudios int
+	TotalVideos int
+
+	ImagesInMessage int
+	AudiosInMessage int
+	VideosInMessage int
+}
+
+type MultimodalContent struct {
+	ID int
+}
+
+const DefaultMultiModalTemplate = "{{ range .Audio }}[audio-{{.ID}}]{{end}}{{ range .Images }}[img-{{.ID}}]{{end}}{{ range .Video }}[vid-{{.ID}}]{{end}}{{.Text}}"
+
+func TemplateMultiModal(templateString string, opts MultiModalOptions, text string) (string, error) {
+	if templateString == "" {
+		templateString = DefaultMultiModalTemplate
+	}
+
 	// compile the template
 	tmpl, err := template.New("template").Funcs(sprig.FuncMap()).Parse(templateString)
 	if err != nil {
 		return "", err
 	}
+
+	videos := []MultimodalContent{}
+	for i := 0; i < opts.VideosInMessage; i++ {
+		videos = append(videos, MultimodalContent{ID: i + (opts.TotalVideos - opts.VideosInMessage)})
+	}
+
+	audios := []MultimodalContent{}
+	for i := 0; i < opts.AudiosInMessage; i++ {
+		audios = append(audios, MultimodalContent{ID: i + (opts.TotalAudios - opts.AudiosInMessage)})
+	}
+
+	images := []MultimodalContent{}
+	for i := 0; i < opts.ImagesInMessage; i++ {
+		images = append(images, MultimodalContent{ID: i + (opts.TotalImages - opts.ImagesInMessage)})
+	}
+
 	result := bytes.NewBuffer(nil)
 	// execute the template
 	err = tmpl.Execute(result, struct {
-		ID   int
-		Text string
+		Audio  []MultimodalContent
+		Images []MultimodalContent
+		Video  []MultimodalContent
+		Text   string
 	}{
-		ID:   templateID,
-		Text: text,
+		Audio:  audios,
+		Images: images,
+		Video:  videos,
+		Text:   text,
 	})
 	return result.String(), err
 }

--- a/pkg/templates/multimodal_test.go
+++ b/pkg/templates/multimodal_test.go
@@ -11,7 +11,77 @@ import (
 var _ = Describe("EvaluateTemplate", func() {
 	Context("templating simple strings for multimodal chat", func() {
 		It("should template messages correctly", func() {
-			result, err := TemplateMultiModal("[img-{{.ID}}]{{.Text}}", 1, "bar")
+			result, err := TemplateMultiModal("", MultiModalOptions{
+				TotalImages:     1,
+				TotalAudios:     0,
+				TotalVideos:     0,
+				ImagesInMessage: 1,
+				AudiosInMessage: 0,
+				VideosInMessage: 0,
+			}, "bar")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("[img-0]bar"))
+		})
+
+		It("should handle messages with more images correctly", func() {
+			result, err := TemplateMultiModal("", MultiModalOptions{
+				TotalImages:     2,
+				TotalAudios:     0,
+				TotalVideos:     0,
+				ImagesInMessage: 2,
+				AudiosInMessage: 0,
+				VideosInMessage: 0,
+			}, "bar")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("[img-0][img-1]bar"))
+		})
+		It("should handle messages with more images correctly", func() {
+			result, err := TemplateMultiModal("", MultiModalOptions{
+				TotalImages:     4,
+				TotalAudios:     1,
+				TotalVideos:     0,
+				ImagesInMessage: 2,
+				AudiosInMessage: 1,
+				VideosInMessage: 0,
+			}, "bar")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("[audio-0][img-2][img-3]bar"))
+		})
+		It("should handle messages with more images correctly", func() {
+			result, err := TemplateMultiModal("", MultiModalOptions{
+				TotalImages:     3,
+				TotalAudios:     1,
+				TotalVideos:     0,
+				ImagesInMessage: 1,
+				AudiosInMessage: 1,
+				VideosInMessage: 0,
+			}, "bar")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("[audio-0][img-2]bar"))
+		})
+		It("should handle messages with more images correctly", func() {
+			result, err := TemplateMultiModal("", MultiModalOptions{
+				TotalImages:     0,
+				TotalAudios:     0,
+				TotalVideos:     0,
+				ImagesInMessage: 0,
+				AudiosInMessage: 0,
+				VideosInMessage: 0,
+			}, "bar")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("bar"))
+		})
+	})
+	Context("templating with custom defaults", func() {
+		It("should handle messages with more images correctly", func() {
+			result, err := TemplateMultiModal("{{ range .Audio }}[audio-{{ add1 .ID}}]{{end}}{{ range .Images }}[img-{{ add1 .ID}}]{{end}}{{ range .Video }}[vid-{{ add1 .ID}}]{{end}}{{.Text}}", MultiModalOptions{
+				TotalImages:     1,
+				TotalAudios:     0,
+				TotalVideos:     0,
+				ImagesInMessage: 1,
+				AudiosInMessage: 0,
+				VideosInMessage: 0,
+			}, "bar")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal("[img-1]bar"))
 		})


### PR DESCRIPTION
**Description**

This pull request includes significant changes to the way multimodal content (images, audio, and video) is handled and templated in the backend configuration and request processing. The most important changes include consolidating individual media fields into a single `Multimodal` field, updating the request configuration to handle multiple media types more efficiently, and enhancing the templating logic to support multimodal content.

As opposed to https://github.com/mudler/LocalAI/pull/3728 - this PR focuses on replacing the following YAML configuration:

```yaml

template:
  video: "<|video_{{.ID}}|> {{.Text}}"
  image: "<|image_{{.ID}}|> {{.Text}}"
  audio: "<|audio_{{.ID}}|> {{.Text}}"
```

With a simple:

```yaml
template:
  multimodal:  "{{ range .Audio }}[audio-{{.ID}}]{{end}}{{ range .Images }}[img-{{.ID}}]{{end}}{{ range .Video }}[vid-{{.ID}}]{{end}}{{.Text}}"
```

that gives more granular control for each placeholder
### Backend Configuration Updates:
* Consolidated `Video`, `Image`, and `Audio` fields into a single `Multimodal` field in the `TemplateConfig` struct in `core/config/backend_config.go`.

### Templating Logic Improvements:
* Introduced `MultiModalOptions` and `MultimodalContent` types, along with a default multimodal template in `pkg/templates/multimodal.go`. The `TemplateMultiModal` function now uses these types to generate content placeholders dynamically.

### Testing Enhancements:
* Added new test cases in `pkg/templates/multimodal_test.go` to ensure the `TemplateMultiModal` function correctly handles various scenarios, including messages with multiple types of media.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->