### PR TITLE
chore(refactor): drop unnecessary code in loader

### DIFF
--- a/core/backend/embeddings.go
+++ b/core/backend/embeddings.go
@@ -11,17 +11,9 @@ import (
 
 func ModelEmbedding(s string, tokens []int, loader *model.ModelLoader, backendConfig config.BackendConfig, appConfig *config.ApplicationConfig) (func() ([]float32, error), error) {
 
-	var inferenceModel interface{}
-	var err error
-
 	opts := ModelOptions(backendConfig, appConfig)
 
-	if backendConfig.Backend == "" {
-		inferenceModel, err = loader.GreedyLoader(opts...)
-	} else {
-		opts = append(opts, model.WithBackendString(backendConfig.Backend))
-		inferenceModel, err = loader.BackendLoader(opts...)
-	}
+	inferenceModel, err := loader.Load(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/core/backend/embeddings.go
+++ b/core/backend/embeddings.go
@@ -14,7 +14,7 @@ func ModelEmbedding(s string, tokens []int, loader *model.ModelLoader, backendCo
 	var inferenceModel interface{}
 	var err error
 
-	opts := ModelOptions(backendConfig, appConfig, []model.Option{})
+	opts := ModelOptions(backendConfig, appConfig)
 
 	if backendConfig.Backend == "" {
 		inferenceModel, err = loader.GreedyLoader(opts...)

--- a/core/backend/image.go
+++ b/core/backend/image.go
@@ -9,7 +9,7 @@ import (
 
 func ImageGeneration(height, width, mode, step, seed int, positive_prompt, negative_prompt, src, dst string, loader *model.ModelLoader, backendConfig config.BackendConfig, appConfig *config.ApplicationConfig) (func() error, error) {
 
-	opts := ModelOptions(backendConfig, appConfig, []model.Option{})
+	opts := ModelOptions(backendConfig, appConfig)
 
 	inferenceModel, err := loader.BackendLoader(
 		opts...,

--- a/core/backend/image.go
+++ b/core/backend/image.go
@@ -10,8 +10,7 @@ import (
 func ImageGeneration(height, width, mode, step, seed int, positive_prompt, negative_prompt, src, dst string, loader *model.ModelLoader, backendConfig config.BackendConfig, appConfig *config.ApplicationConfig) (func() error, error) {
 
 	opts := ModelOptions(backendConfig, appConfig)
-
-	inferenceModel, err := loader.BackendLoader(
+	inferenceModel, err := loader.Load(
 		opts...,
 	)
 	if err != nil {

--- a/core/backend/llm.go
+++ b/core/backend/llm.go
@@ -16,7 +16,6 @@ import (
 	"github.com/mudler/LocalAI/core/schema"
 
 	"github.com/mudler/LocalAI/core/gallery"
-	"github.com/mudler/LocalAI/pkg/grpc"
 	"github.com/mudler/LocalAI/pkg/grpc/proto"
 	model "github.com/mudler/LocalAI/pkg/model"
 	"github.com/mudler/LocalAI/pkg/utils"
@@ -35,15 +34,6 @@ type TokenUsage struct {
 func ModelInference(ctx context.Context, s string, messages []schema.Message, images, videos, audios []string, loader *model.ModelLoader, c config.BackendConfig, o *config.ApplicationConfig, tokenCallback func(string, TokenUsage) bool) (func() (LLMResponse, error), error) {
 	modelFile := c.Model
 
-	var inferenceModel grpc.Backend
-	var err error
-
-	opts := ModelOptions(c, o)
-
-	if c.Backend != "" {
-		opts = append(opts, model.WithBackendString(c.Backend))
-	}
-
 	// Check if the modelFile exists, if it doesn't try to load it from the gallery
 	if o.AutoloadGalleries { // experimental
 		if _, err := os.Stat(modelFile); os.IsNotExist(err) {
@@ -56,12 +46,8 @@ func ModelInference(ctx context.Context, s string, messages []schema.Message, im
 		}
 	}
 
-	if c.Backend == "" {
-		inferenceModel, err = loader.GreedyLoader(opts...)
-	} else {
-		inferenceModel, err = loader.BackendLoader(opts...)
-	}
-
+	opts := ModelOptions(c, o)
+	inferenceModel, err := loader.Load(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/core/backend/llm.go
+++ b/core/backend/llm.go
@@ -38,7 +38,7 @@ func ModelInference(ctx context.Context, s string, messages []schema.Message, im
 	var inferenceModel grpc.Backend
 	var err error
 
-	opts := ModelOptions(c, o, []model.Option{})
+	opts := ModelOptions(c, o)
 
 	if c.Backend != "" {
 		opts = append(opts, model.WithBackendString(c.Backend))

--- a/core/backend/options.go
+++ b/core/backend/options.go
@@ -11,7 +11,7 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func ModelOptions(c config.BackendConfig, so *config.ApplicationConfig, opts []model.Option) []model.Option {
+func ModelOptions(c config.BackendConfig, so *config.ApplicationConfig, opts ...model.Option) []model.Option {
 	name := c.Name
 	if name == "" {
 		name = c.Model

--- a/core/backend/rerank.go
+++ b/core/backend/rerank.go
@@ -12,7 +12,7 @@ import (
 func Rerank(modelFile string, request *proto.RerankRequest, loader *model.ModelLoader, appConfig *config.ApplicationConfig, backendConfig config.BackendConfig) (*proto.RerankResult, error) {
 
 	opts := ModelOptions(backendConfig, appConfig, model.WithModel(modelFile))
-	rerankModel, err := loader.BackendLoader(opts...)
+	rerankModel, err := loader.Load(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/core/backend/rerank.go
+++ b/core/backend/rerank.go
@@ -11,7 +11,7 @@ import (
 
 func Rerank(modelFile string, request *proto.RerankRequest, loader *model.ModelLoader, appConfig *config.ApplicationConfig, backendConfig config.BackendConfig) (*proto.RerankResult, error) {
 
-	opts := ModelOptions(backendConfig, appConfig, []model.Option{model.WithModel(modelFile)})
+	opts := ModelOptions(backendConfig, appConfig, model.WithModel(modelFile))
 	rerankModel, err := loader.BackendLoader(opts...)
 	if err != nil {
 		return nil, err

--- a/core/backend/soundgeneration.go
+++ b/core/backend/soundgeneration.go
@@ -25,7 +25,7 @@ func SoundGeneration(
 	backendConfig config.BackendConfig,
 ) (string, *proto.Result, error) {
 
-	opts := ModelOptions(backendConfig, appConfig, []model.Option{model.WithModel(modelFile)})
+	opts := ModelOptions(backendConfig, appConfig, model.WithModel(modelFile))
 
 	soundGenModel, err := loader.BackendLoader(opts...)
 	if err != nil {

--- a/core/backend/soundgeneration.go
+++ b/core/backend/soundgeneration.go
@@ -26,8 +26,7 @@ func SoundGeneration(
 ) (string, *proto.Result, error) {
 
 	opts := ModelOptions(backendConfig, appConfig, model.WithModel(modelFile))
-
-	soundGenModel, err := loader.BackendLoader(opts...)
+	soundGenModel, err := loader.Load(opts...)
 	if err != nil {
 		return "", nil, err
 	}

--- a/core/backend/stores.go
+++ b/core/backend/stores.go
@@ -8,16 +8,15 @@ import (
 )
 
 func StoreBackend(sl *model.ModelLoader, appConfig *config.ApplicationConfig, storeName string) (grpc.Backend, error) {
-    if storeName == "" {
-      storeName = "default"
-    }
+	if storeName == "" {
+		storeName = "default"
+	}
 
-    sc := []model.Option{
-      model.WithBackendString(model.LocalStoreBackend),
-      model.WithAssetDir(appConfig.AssetsDestination),
-      model.WithModel(storeName),
-    }
+	sc := []model.Option{
+		model.WithBackendString(model.LocalStoreBackend),
+		model.WithAssetDir(appConfig.AssetsDestination),
+		model.WithModel(storeName),
+	}
 
-    return sl.BackendLoader(sc...)
+	return sl.Load(sc...)
 }
-

--- a/core/backend/token_metrics.go
+++ b/core/backend/token_metrics.go
@@ -16,7 +16,7 @@ func TokenMetrics(
 	backendConfig config.BackendConfig) (*proto.MetricsResponse, error) {
 
 	opts := ModelOptions(backendConfig, appConfig, model.WithModel(modelFile))
-	model, err := loader.BackendLoader(opts...)
+	model, err := loader.Load(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/core/backend/token_metrics.go
+++ b/core/backend/token_metrics.go
@@ -15,9 +15,7 @@ func TokenMetrics(
 	appConfig *config.ApplicationConfig,
 	backendConfig config.BackendConfig) (*proto.MetricsResponse, error) {
 
-	opts := ModelOptions(backendConfig, appConfig, []model.Option{
-		model.WithModel(modelFile),
-	})
+	opts := ModelOptions(backendConfig, appConfig, model.WithModel(modelFile))
 	model, err := loader.BackendLoader(opts...)
 	if err != nil {
 		return nil, err

--- a/core/backend/tokenize.go
+++ b/core/backend/tokenize.go
@@ -17,10 +17,10 @@ func ModelTokenize(s string, loader *model.ModelLoader, backendConfig config.Bac
 	opts := ModelOptions(backendConfig, appConfig, model.WithModel(modelFile))
 
 	if backendConfig.Backend == "" {
-		inferenceModel, err = loader.GreedyLoader(opts...)
+		inferenceModel, err = loader.Load(opts...)
 	} else {
 		opts = append(opts, model.WithBackendString(backendConfig.Backend))
-		inferenceModel, err = loader.BackendLoader(opts...)
+		inferenceModel, err = loader.Load(opts...)
 	}
 	if err != nil {
 		return schema.TokenizeResponse{}, err

--- a/core/backend/tokenize.go
+++ b/core/backend/tokenize.go
@@ -14,9 +14,7 @@ func ModelTokenize(s string, loader *model.ModelLoader, backendConfig config.Bac
 	var inferenceModel grpc.Backend
 	var err error
 
-	opts := ModelOptions(backendConfig, appConfig, []model.Option{
-		model.WithModel(modelFile),
-	})
+	opts := ModelOptions(backendConfig, appConfig, model.WithModel(modelFile))
 
 	if backendConfig.Backend == "" {
 		inferenceModel, err = loader.GreedyLoader(opts...)

--- a/core/backend/transcript.go
+++ b/core/backend/transcript.go
@@ -20,7 +20,7 @@ func ModelTranscription(audio, language string, translate bool, ml *model.ModelL
 
 	opts := ModelOptions(backendConfig, appConfig)
 
-	transcriptionModel, err := ml.BackendLoader(opts...)
+	transcriptionModel, err := ml.Load(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/core/backend/transcript.go
+++ b/core/backend/transcript.go
@@ -18,7 +18,7 @@ func ModelTranscription(audio, language string, translate bool, ml *model.ModelL
 		backendConfig.Backend = model.WhisperBackend
 	}
 
-	opts := ModelOptions(backendConfig, appConfig, []model.Option{})
+	opts := ModelOptions(backendConfig, appConfig)
 
 	transcriptionModel, err := ml.BackendLoader(opts...)
 	if err != nil {

--- a/core/backend/tts.go
+++ b/core/backend/tts.go
@@ -28,11 +28,7 @@ func ModelTTS(
 		bb = model.PiperBackend
 	}
 
-	opts := ModelOptions(backendConfig, appConfig, []model.Option{
-		model.WithBackendString(bb),
-		model.WithModel(modelFile),
-	})
-
+	opts := ModelOptions(backendConfig, appConfig, model.WithBackendString(bb), model.WithModel(modelFile))
 	ttsModel, err := loader.BackendLoader(opts...)
 	if err != nil {
 		return "", nil, err

--- a/core/backend/tts.go
+++ b/core/backend/tts.go
@@ -29,7 +29,7 @@ func ModelTTS(
 	}
 
 	opts := ModelOptions(backendConfig, appConfig, model.WithBackendString(bb), model.WithModel(modelFile))
-	ttsModel, err := loader.BackendLoader(opts...)
+	ttsModel, err := loader.Load(opts...)
 	if err != nil {
 		return "", nil, err
 	}

--- a/core/startup/startup.go
+++ b/core/startup/startup.go
@@ -160,7 +160,7 @@ func Startup(opts ...config.AppOption) (*config.BackendConfigLoader, *model.Mode
 
 			log.Debug().Msgf("Auto loading model %s into memory from file: %s", m, cfg.Model)
 
-			o := backend.ModelOptions(*cfg, options, []model.Option{})
+			o := backend.ModelOptions(*cfg, options)
 
 			var backendErr error
 			if cfg.Backend != "" {

--- a/core/startup/startup.go
+++ b/core/startup/startup.go
@@ -163,12 +163,7 @@ func Startup(opts ...config.AppOption) (*config.BackendConfigLoader, *model.Mode
 			o := backend.ModelOptions(*cfg, options)
 
 			var backendErr error
-			if cfg.Backend != "" {
-				o = append(o, model.WithBackendString(cfg.Backend))
-				_, backendErr = ml.BackendLoader(o...)
-			} else {
-				_, backendErr = ml.GreedyLoader(o...)
-			}
+			_, backendErr = ml.Load(o...)
 			if backendErr != nil {
 				return nil, nil, nil, err
 			}

--- a/pkg/model/initializers.go
+++ b/pkg/model/initializers.go
@@ -455,7 +455,7 @@ func (ml *ModelLoader) ListAvailableBackends(assetdir string) ([]string, error) 
 	return orderBackends(backends)
 }
 
-func (ml *ModelLoader) BackendLoader(opts ...Option) (client grpc.Backend, err error) {
+func (ml *ModelLoader) backendLoader(opts ...Option) (client grpc.Backend, err error) {
 	o := NewOptions(opts...)
 
 	log.Info().Msgf("Loading model '%s' with backend %s", o.modelID, o.backendString)
@@ -500,7 +500,7 @@ func (ml *ModelLoader) stopActiveBackends(modelID string, singleActiveBackend bo
 	}
 }
 
-func (ml *ModelLoader) GreedyLoader(opts ...Option) (grpc.Backend, error) {
+func (ml *ModelLoader) Load(opts ...Option) (grpc.Backend, error) {
 	o := NewOptions(opts...)
 
 	// Return earlier if we have a model already loaded
@@ -512,6 +512,10 @@ func (ml *ModelLoader) GreedyLoader(opts ...Option) (grpc.Backend, error) {
 	}
 
 	ml.stopActiveBackends(o.modelID, o.singleActiveBackend)
+
+	if o.backendString != "" {
+		return ml.backendLoader(opts...)
+	}
 
 	var err error
 
@@ -536,7 +540,7 @@ func (ml *ModelLoader) GreedyLoader(opts ...Option) (grpc.Backend, error) {
 			WithBackendString(key),
 		}...)
 
-		model, modelerr := ml.BackendLoader(options...)
+		model, modelerr := ml.backendLoader(options...)
 		if modelerr == nil && model != nil {
 			log.Info().Msgf("[%s] Loads OK", key)
 			return model, nil

--- a/tests/integration/stores_test.go
+++ b/tests/integration/stores_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Integration tests for the stores backend(s) and internal APIs"
 			}
 
 			sl = model.NewModelLoader("")
-			sc, err = sl.BackendLoader(storeOpts...)
+			sc, err = sl.Load(storeOpts...)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sc).ToNot(BeNil())
 		})


### PR DESCRIPTION
**Description**

This PR contains some refactors extracted from #3722 .

It simplifies loading as it now expose a single method to load a model.

`BackendLoader` is now moved to an internal function ( `backendLoader`), `GreedyLoader` is now just `Loader`, which will automatically go in greedy mode if no backend is explicitly set in the configuration.


**Notes for Reviewers**

This has the added benefit that now not only the code is more consistent, but every caller have the chance to hit back the cache if a model was already loaded.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->