### PR TITLE
feat: add WebUI API token authorization

### DIFF
--- a/core/http/app_test.go
+++ b/core/http/app_test.go
@@ -345,7 +345,7 @@ var _ = Describe("API test", func() {
 			It("Should fail if the api key is missing", func() {
 				err, sc := postInvalidRequest("http://127.0.0.1:9090/models/available")
 				Expect(err).ToNot(BeNil())
-				Expect(sc).To(Equal(403))
+				Expect(sc).To(Equal(401))
 			})
 		})
 

--- a/core/http/routes/ui.go
+++ b/core/http/routes/ui.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/mudler/LocalAI/core/config"
@@ -86,6 +87,18 @@ func RegisterUIRoutes(app *fiber.App,
 	}
 
 	app.Get("/", localai.WelcomeEndpoint(appConfig, cl, ml, modelStatus))
+	app.Get("/login", func(c *fiber.Ctx) error {
+		// Assuming middleware is parsed the token correctly
+		token := strings.Split(c.GetReqHeaders()["Authorization"][0], " ")[1]
+		cookie := new(fiber.Cookie)
+		cookie.Name = "token"
+		cookie.Value = token
+		cookie.Expires = time.Now().Add(24 * time.Hour)
+
+		c.Cookie(cookie)
+
+		return c.RedirectToRoute("/", nil)
+	})
 
 	if p2p.IsP2PEnabled() {
 		app.Get("/p2p", func(c *fiber.Ctx) error {

--- a/core/http/routes/ui.go
+++ b/core/http/routes/ui.go
@@ -5,7 +5,6 @@ import (
 	"html/template"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/mudler/LocalAI/core/config"
@@ -87,18 +86,6 @@ func RegisterUIRoutes(app *fiber.App,
 	}
 
 	app.Get("/", localai.WelcomeEndpoint(appConfig, cl, ml, modelStatus))
-	app.Get("/login", func(c *fiber.Ctx) error {
-		// Assuming middleware is parsed the token correctly
-		token := strings.Split(c.GetReqHeaders()["Authorization"][0], " ")[1]
-		cookie := new(fiber.Cookie)
-		cookie.Name = "token"
-		cookie.Value = token
-		cookie.Expires = time.Now().Add(24 * time.Hour)
-
-		c.Cookie(cookie)
-
-		return c.RedirectToRoute("/", nil)
-	})
 
 	if p2p.IsP2PEnabled() {
 		app.Get("/p2p", func(c *fiber.Ctx) error {

--- a/core/http/views/login.html
+++ b/core/http/views/login.html
@@ -12,12 +12,9 @@
     <script>
         function login() {
             const token = document.getElementById('token').value;
-
-            const url = new URL(window.location.href)
-            const xhr = new XMLHttpRequest();
-            xhr.open('GET', url.origin + '/login');
-            xhr.setRequestHeader('Authorization', `Bearer ${token}`);
-            xhr.send();
+            var date = new Date();
+            date.setTime(date.getTime() + (24*60*60*1000));
+            document.cookie = `token=${token}; expires=${date.toGMTString()}`;
 
             window.location.reload();
         }

--- a/core/http/views/login.html
+++ b/core/http/views/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Open Authenticated Website</title>
+</head>
+<body>
+    <h1>Authorization is required</h1>
+    <input type="text" id="token" placeholder="Token" />
+    <button onclick="login()">Login</button>
+    <script>
+        function login() {
+            const token = document.getElementById('token').value;
+
+            const url = new URL(window.location.href)
+            const xhr = new XMLHttpRequest();
+            xhr.open('GET', url.origin + '/login');
+            xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+            xhr.send();
+
+            window.location.reload();
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
**Description**

This PR fixes #2227 (tracked in #2156)
I've added a simple (we can't use fancy template resources without auth) html login page for token input, which pushes xhr request to the new /login handler, which is sets a 24hr valid cookie for a token.
The v2keyauth is now looking for token field in cookies too.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->