### PR TITLE
fix(p2p): parse maddr correctly

### DIFF
--- a/core/p2p/p2p.go
+++ b/core/p2p/p2p.go
@@ -386,8 +386,20 @@ func newNodeOpts(token string) ([]node.Option, error) {
 	// TODO: move this up, expose more config options when creating a node
 	noDHT := os.Getenv("LOCALAI_P2P_DISABLE_DHT") == "true"
 	noLimits := os.Getenv("LOCALAI_P2P_ENABLE_LIMITS") == "true"
-	listenMaddrs := strings.Split(os.Getenv("LOCALAI_P2P_LISTEN_MADDRS"), ",")
-	bootstrapPeers := strings.Split(os.Getenv("LOCALAI_P2P_BOOTSTRAP_PEERS_MADDRS"), ",")
+
+	var listenMaddrs []string
+	var bootstrapPeers []string
+
+	laddrs := os.Getenv("LOCALAI_P2P_LISTEN_MADDRS")
+	if laddrs != "" {
+		listenMaddrs = strings.Split(laddrs, ",")
+	}
+
+	bootmaddr := os.Getenv("LOCALAI_P2P_BOOTSTRAP_PEERS_MADDRS")
+	if bootmaddr != "" {
+		bootstrapPeers = strings.Split(bootmaddr, ",")
+	}
+
 	dhtAnnounceMaddrs := stringsToMultiAddr(strings.Split(os.Getenv("LOCALAI_P2P_DHT_ANNOUNCE_MADDRS"), ","))
 
 	libp2ploglevel := os.Getenv("LOCALAI_P2P_LIB_LOGLEVEL")


### PR DESCRIPTION
Previously in case of not specifying a value it would pass a slice of 1 empty element

**Description**

This pull request includes changes to improve the configuration handling in the `newNodeOpts` function within the `core/p2p/p2p.go` file. The most important change is the modification of how the environment variables for `LOCALAI_P2P_LISTEN_MADDRS` and `LOCALAI_P2P_BOOTSTRAP_PEERS_MADDRS` are processed.

Improvements to configuration handling:

* [`core/p2p/p2p.go`](diffhunk://#diff-ba0b4d3c3fac0a53f790ed836fcd161d545c15e486a8e8eb5c70c9bc6071f5b7L389-R402): Modified the `newNodeOpts` function to handle empty environment variable values more gracefully by checking if the environment variables are non-empty before splitting them into slices.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->