### PR TITLE
fix(p2p): parse correctly ExtraLLamaCPPArgs

### DIFF
--- a/core/cli/worker/worker_p2p.go
+++ b/core/cli/worker/worker_p2p.go
@@ -76,8 +76,14 @@ func (r *P2P) Run(ctx *cliContext.Context) error {
 					"util",
 					"llama-cpp-rpc-server",
 				)
-				extraArgs := strings.Split(r.ExtraLLamaCPPArgs, " ")
+				var extraArgs []string
+
+				if r.ExtraLLamaCPPArgs != "" {
+					extraArgs = strings.Split(r.ExtraLLamaCPPArgs, " ")
+				}
 				args := append([]string{"--host", address, "--port", fmt.Sprint(port)}, extraArgs...)
+				log.Debug().Msgf("Starting llama-cpp-rpc-server on '%s:%d' with args: %+v (%d)", address, port, args, len(args))
+
 				args, grpcProcess = library.LoadLDSO(r.BackendAssetsPath, args, grpcProcess)
 
 				cmd := exec.Command(


### PR DESCRIPTION
Previously we were sensible when args aren't defined and we would clash parsing extra args.

**Description**

This PR fixes #4214

This pull request includes an important change to the `Run` function in the `worker_p2p.go` file. The change ensures that the `extraArgs` variable is properly initialized and adds a debug log statement to provide better visibility into the arguments being used when starting the `llama-cpp-rpc-server`.

Initialization and logging improvements:

* [`core/cli/worker/worker_p2p.go`](diffhunk://#diff-9cb2fc9984e91747a6e95a6a4d4ac04b42f2992fccb6a7038dcb87fce745a69dL79-R86): Modified the initialization of the `extraArgs` variable to avoid splitting an empty string and added a debug log statement to log the arguments and their count when starting the `llama-cpp-rpc-server`.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->