### PR TITLE
chore(deps): bump grpcio to 1.68.1

### DIFF
--- a/backend/python/autogptq/requirements.txt
+++ b/backend/python/autogptq/requirements.txt
@@ -1,6 +1,6 @@
 accelerate
 auto-gptq==0.7.1
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi
 transformers

--- a/backend/python/bark/requirements.txt
+++ b/backend/python/bark/requirements.txt
@@ -1,4 +1,4 @@
 bark==0.1.5
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi

--- a/backend/python/common/template/requirements.txt
+++ b/backend/python/common/template/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 grpcio-tools

--- a/backend/python/coqui/requirements.txt
+++ b/backend/python/coqui/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi
 packaging==24.1

--- a/backend/python/diffusers/requirements.txt
+++ b/backend/python/diffusers/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
-grpcio==1.68.0
+grpcio==1.68.1
 pillow
 protobuf
 certifi

--- a/backend/python/exllama2/requirements.txt
+++ b/backend/python/exllama2/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi
 wheel

--- a/backend/python/mamba/requirements.txt
+++ b/backend/python/mamba/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi

--- a/backend/python/openvoice/requirements-intel.txt
+++ b/backend/python/openvoice/requirements-intel.txt
@@ -2,7 +2,7 @@
 intel-extension-for-pytorch
 torch
 optimum[openvino]
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 librosa==0.9.1
 faster-whisper==0.9.0

--- a/backend/python/openvoice/requirements.txt
+++ b/backend/python/openvoice/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 librosa
 faster-whisper

--- a/backend/python/parler-tts/requirements.txt
+++ b/backend/python/parler-tts/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.68.0
+grpcio==1.68.1
 certifi
 llvmlite==0.43.0

--- a/backend/python/rerankers/requirements.txt
+++ b/backend/python/rerankers/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi

--- a/backend/python/sentencetransformers/requirements.txt
+++ b/backend/python/sentencetransformers/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi
 datasets

--- a/backend/python/transformers-musicgen/requirements.txt
+++ b/backend/python/transformers-musicgen/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 scipy==1.14.0
 certifi

--- a/backend/python/transformers/requirements.txt
+++ b/backend/python/transformers/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi
 setuptools==69.5.1 # https://github.com/mudler/LocalAI/issues/2406

--- a/backend/python/vall-e-x/requirements.txt
+++ b/backend/python/vall-e-x/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi

--- a/backend/python/vllm/install.sh
+++ b/backend/python/vllm/install.sh
@@ -22,7 +22,7 @@ if [ "x${BUILD_TYPE}" == "x" ] && [ "x${FROM_SOURCE}" == "xtrue" ]; then
             git clone https://github.com/vllm-project/vllm
         fi
         pushd vllm
-            uv pip install wheel packaging ninja "setuptools>=49.4.0" numpy typing-extensions pillow setuptools-scm grpcio==1.68.0 protobuf bitsandbytes
+            uv pip install wheel packaging ninja "setuptools>=49.4.0" numpy typing-extensions pillow setuptools-scm grpcio==1.68.1 protobuf bitsandbytes
             uv pip install -v -r requirements-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu
             VLLM_TARGET_DEVICE=cpu python setup.py install
         popd

--- a/backend/python/vllm/requirements.txt
+++ b/backend/python/vllm/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.0
+grpcio==1.68.1
 protobuf
 certifi
 setuptools


### PR DESCRIPTION
**Description**

This pull request includes updates to the `grpcio` dependency across multiple requirement files in the project. The `grpcio` version has been updated from `1.68.0` to `1.68.1` to ensure consistency and compatibility across different modules.

Dependency updates:

* [`backend/python/autogptq/requirements.txt`](diffhunk://#diff-326f4c9109482e17ae05b0eb5b30adbaddfa067a59199b82fc18f954ef7e4b65L3-R3): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/bark/requirements.txt`](diffhunk://#diff-a298ae0bd8fb041e45e658764d74d3a0087220ea2d9aa3a66b719e735f5ace07L2-R2): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/common/template/requirements.txt`](diffhunk://#diff-588cd64d1a39b6bfccc024d5faf067ccd3e984f3f1214273ac0b10f8ceba67deL1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/coqui/requirements.txt`](diffhunk://#diff-09dc1b8d98614c14a8329de58e69c1ac668ab0c0aeac2515c53b0f92d5c88fe8L1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/diffusers/requirements.txt`](diffhunk://#diff-b2da6892846bfa0dd6a7b588642147a762f20652e4a474aeec1f6dea3882cbd3L2-R2): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/exllama2/requirements.txt`](diffhunk://#diff-bdd704092954d0590e56c828e7e0cbe58f5a4e7ec335826e74ff378893ae573bL1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/mamba/requirements.txt`](diffhunk://#diff-3d7359528564451be0922b36c35c292e5cd729d3edae7a5a61585bdd8e15aa04L1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/openvoice/requirements-intel.txt`](diffhunk://#diff-c315c918c70a942ec461bb4055ad33f1193ee220f48629373e9c9bba4be11e08L5-R5): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/openvoice/requirements.txt`](diffhunk://#diff-a2b594bdb2172f454fbf1e07b655c8760a905e19914f4c10fc466a5672e8ea56L1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/parler-tts/requirements.txt`](diffhunk://#diff-ae06924beba4e1bc588bf1cde4215983aa230d936619ba2fb88adf0410121a10L1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/rerankers/requirements.txt`](diffhunk://#diff-3d7359528564451be0922b36c35c292e5cd729d3edae7a5a61585bdd8e15aa04L1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/sentencetransformers/requirements.txt`](diffhunk://#diff-4cde35f958662ce72b387edc4454ebc46e227d73dbcb100a565b5da6b2bdd462L1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/transformers-musicgen/requirements.txt`](diffhunk://#diff-de52aa5a6c830fb95afe383c5d3e1669d57946254dc32d7f19a2aad5ba2d8dcfL1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/transformers/requirements.txt`](diffhunk://#diff-9be76e0bb2ab14323a3c9955685d4ee24823f9bb345a7638317531fd5e4e68beL1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/vall-e-x/requirements.txt`](diffhunk://#diff-3d7359528564451be0922b36c35c292e5cd729d3edae7a5a61585bdd8e15aa04L1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.
* [`backend/python/vllm/install.sh`](diffhunk://#diff-fd6b2de7b25bcb1051e21b81d6f0af715d2faf10af7053a41692e431243a471aL25-R25): Updated `grpcio` from `1.68.0` to `1.68.1` in the installation script.
* [`backend/python/vllm/requirements.txt`](diffhunk://#diff-154a58b9d45a6aa01a60496065dc2c893d7babb5966ed2b20a187cf43e1233caL1-R1): Updated `grpcio` from `1.68.0` to `1.68.1`.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->