### PR TITLE
feat(dowloader): resume partial downloads

### DIFF
--- a/pkg/downloader/uri.go
+++ b/pkg/downloader/uri.go
@@ -282,8 +282,12 @@ func (uri URI) DownloadFile(filePath, sha string, fileN, total int, downloadStat
 	if err != nil {
 		return fmt.Errorf("failed to create parent directory for file %q: %v", filePath, err)
 	}
-
+	/** Enabling partial downloads
+	 * - Do I remove the partial file
+	 * -
+	 */
 	// save partial download to dedicated file
+	fmt.Printf("DELETEING PARTIAL FILE")
 	tmpFilePath := filePath + ".partial"
 
 	// remove tmp file

--- a/pkg/downloader/uri.go
+++ b/pkg/downloader/uri.go
@@ -324,11 +324,6 @@ func (uri URI) DownloadFile(filePath, sha string, fileN, total int, downloadStat
 		return fmt.Errorf("failed to create / open file %q: %v", tmpFilePath, err)
 	}
 	defer outFile.Close()
-	outFileInfo, err := outFile.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to get file info: %v", err)
-	}
-	fileSize := outFileInfo.Size()
 	hash, err := calculateHashForPartialFile(outFile)
 	if err != nil {
 		return fmt.Errorf("failed to calculate hash for partial file")
@@ -339,7 +334,6 @@ func (uri URI) DownloadFile(filePath, sha string, fileN, total int, downloadStat
 		hash:           hash,
 		fileNo:         fileN,
 		totalFiles:     total,
-		written:        fileSize,
 		downloadStatus: downloadStatus,
 	}
 	_, err = io.Copy(io.MultiWriter(outFile, progress), resp.Body)

--- a/pkg/downloader/uri_test.go
+++ b/pkg/downloader/uri_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"regexp"
+	"strconv"
 
 	. "github.com/mudler/LocalAI/pkg/downloader"
 	. "github.com/onsi/ginkgo/v2"
@@ -47,31 +49,88 @@ var _ = Describe("Gallery API tests", func() {
 })
 
 var _ = Describe("Download Test", func() {
+	var mockData []byte
+	var mockDataSha string
+	var filePath string
+
+	var getMockServer = func() *httptest.Server {
+		mockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var respData []byte
+			rangeString := r.Header.Get("Range")
+			if rangeString != "" {
+				regex := regexp.MustCompile(`^bytes=(\d+)-(\d+|)$`)
+				matches := regex.FindStringSubmatch(rangeString)
+				if matches == nil {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				startPos := 0
+				endPos := len(mockData)
+				var err error
+				if matches[1] != "" {
+					startPos, err = strconv.Atoi(matches[1])
+					Expect(err).ToNot(HaveOccurred())
+				}
+				if matches[2] != "" {
+					endPos, err = strconv.Atoi(matches[2])
+					Expect(err).ToNot(HaveOccurred())
+					endPos += 1
+				}
+				if startPos < 0 || startPos >= len(mockData) || endPos < 0 || endPos > len(mockData) || startPos > endPos {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				respData = mockData[startPos:endPos]
+			} else {
+				respData = mockData
+			}
+			w.WriteHeader(http.StatusOK)
+			w.Write(respData)
+		}))
+		mockServer.EnableHTTP2 = true
+		mockServer.Start()
+		return mockServer
+	}
+
+	BeforeEach(func() {
+		mockData = make([]byte, 20000)
+		_, err := rand.Read(mockData)
+		Expect(err).ToNot(HaveOccurred())
+		_mockDataSha := sha256.New()
+		_, err = _mockDataSha.Write(mockData)
+		Expect(err).ToNot(HaveOccurred())
+		mockDataSha = fmt.Sprintf("%x", _mockDataSha.Sum(nil))
+		dir, err := os.Getwd()
+		filePath = dir + "/my_supercool_model"
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	Context("URI DownloadFile", func() {
 		It("fetches files from mock server", func() {
-			mockData := make([]byte, 20000)
-			_, err := rand.Read(mockData)
-			Expect(err).ToNot(HaveOccurred())
-
-			mockDataSha := sha256.New()
-			mockDataSha.Write(mockData)
-
-			mockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				w.Write(mockData)
-			}))
-			mockServer.EnableHTTP2 = true
-			mockServer.Start()
-			dir, err := os.Getwd()
-			filePath := dir + "/my_supercool_model"
-			Expect(err).NotTo(HaveOccurred())
+			mockServer := getMockServer()
+			defer mockServer.Close()
 			uri := URI(mockServer.URL)
-			err = uri.DownloadFile(filePath, fmt.Sprintf("%x", mockDataSha.Sum(nil)), 1, 1, func(s1, s2, s3 string, f float64) {})
+			err := uri.DownloadFile(filePath, mockDataSha, 1, 1, func(s1, s2, s3 string, f float64) {})
 			Expect(err).ToNot(HaveOccurred())
 			err = os.Remove(filePath) // cleanup, also checks existance of filePath`
 			Expect(err).ToNot(HaveOccurred())
 		})
-		// It("resumes partially downloaded files")
+
+		It("resumes partially downloaded files", func() {
+			mockServer := getMockServer()
+			defer mockServer.Close()
+			uri := URI(mockServer.URL)
+			// Create a partial file
+			tmpFilePath := filePath + ".partial"
+			file, err := os.OpenFile(tmpFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = file.Write(mockData[0:10000])
+			Expect(err).ToNot(HaveOccurred())
+			err = uri.DownloadFile(filePath, mockDataSha, 1, 1, func(s1, s2, s3 string, f float64) {})
+			Expect(err).ToNot(HaveOccurred())
+			err = os.Remove(filePath) // cleanup, also checks existance of filePath`
+			Expect(err).ToNot(HaveOccurred())
+		})
 		// It("it accurately updates progress")
 		// It("deletes partial file if after completion hash of downloaded file doesn't match hash of the file in the server")
 	})

--- a/pkg/downloader/uri_test.go
+++ b/pkg/downloader/uri_test.go
@@ -38,3 +38,10 @@ var _ = Describe("Gallery API tests", func() {
 		})
 	})
 })
+
+var _ = Describe("Download Test", func() {
+	Context("URI", func() {
+		It("Resumes partially downloaded files")
+		It("It accurately updates progress")
+	})
+})

--- a/pkg/downloader/uri_test.go
+++ b/pkg/downloader/uri_test.go
@@ -1,6 +1,13 @@
 package downloader_test
 
 import (
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+
 	. "github.com/mudler/LocalAI/pkg/downloader"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -40,8 +47,32 @@ var _ = Describe("Gallery API tests", func() {
 })
 
 var _ = Describe("Download Test", func() {
-	Context("URI", func() {
-		It("Resumes partially downloaded files")
-		It("It accurately updates progress")
+	Context("URI DownloadFile", func() {
+		It("fetches files from mock server", func() {
+			mockData := make([]byte, 20000)
+			_, err := rand.Read(mockData)
+			Expect(err).ToNot(HaveOccurred())
+
+			mockDataSha := sha256.New()
+			mockDataSha.Write(mockData)
+
+			mockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.Write(mockData)
+			}))
+			mockServer.EnableHTTP2 = true
+			mockServer.Start()
+			dir, err := os.Getwd()
+			filePath := dir + "/my_supercool_model"
+			Expect(err).NotTo(HaveOccurred())
+			uri := URI(mockServer.URL)
+			err = uri.DownloadFile(filePath, fmt.Sprintf("%x", mockDataSha.Sum(nil)), 1, 1, func(s1, s2, s3 string, f float64) {})
+			Expect(err).ToNot(HaveOccurred())
+			err = os.Remove(filePath) // cleanup, also checks existance of filePath`
+			Expect(err).ToNot(HaveOccurred())
+		})
+		// It("resumes partially downloaded files")
+		// It("it accurately updates progress")
+		// It("deletes partial file if after completion hash of downloaded file doesn't match hash of the file in the server")
 	})
 })

--- a/pkg/downloader/uri_test.go
+++ b/pkg/downloader/uri_test.go
@@ -131,7 +131,6 @@ var _ = Describe("Download Test", func() {
 			err = os.Remove(filePath) // cleanup, also checks existance of filePath`
 			Expect(err).ToNot(HaveOccurred())
 		})
-		// It("it accurately updates progress")
 		// It("deletes partial file if after completion hash of downloaded file doesn't match hash of the file in the server")
 	})
 })

--- a/pkg/downloader/uri_test.go
+++ b/pkg/downloader/uri_test.go
@@ -48,42 +48,77 @@ var _ = Describe("Gallery API tests", func() {
 	})
 })
 
+type RangeHeaderError struct {
+	msg string
+}
+
+func (e *RangeHeaderError) Error() string { return e.msg }
+
 var _ = Describe("Download Test", func() {
 	var mockData []byte
 	var mockDataSha string
 	var filePath string
 
-	var getMockServer = func() *httptest.Server {
+	extractRangeHeader := func(rangeString string) (int, int, error) {
+		regex := regexp.MustCompile(`^bytes=(\d+)-(\d+|)$`)
+		matches := regex.FindStringSubmatch(rangeString)
+		rangeErr := RangeHeaderError{msg: "invalid / ill-formatted range"}
+		if matches == nil {
+			return -1, -1, &rangeErr
+		}
+		startPos, err := strconv.Atoi(matches[1])
+		if err != nil {
+			return -1, -1, err
+		}
+
+		endPos := -1
+		if matches[2] != "" {
+			endPos, err = strconv.Atoi(matches[2])
+			if err != nil {
+				return -1, -1, err
+			}
+			endPos += 1 // because range is inclusive in rangeString
+		}
+		return startPos, endPos, nil
+	}
+
+	getMockServer := func(supportsRangeHeader bool) *httptest.Server {
 		mockServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != "HEAD" && r.Method != "GET" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if r.Method == "HEAD" {
+				if supportsRangeHeader {
+					w.Header().Add("Accept-Ranges", "bytes")
+				}
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			// GET method
+			startPos := 0
+			endPos := len(mockData)
+			var err error
 			var respData []byte
 			rangeString := r.Header.Get("Range")
 			if rangeString != "" {
-				regex := regexp.MustCompile(`^bytes=(\d+)-(\d+|)$`)
-				matches := regex.FindStringSubmatch(rangeString)
-				if matches == nil {
-					w.WriteHeader(http.StatusBadRequest)
-					return
-				}
-				startPos := 0
-				endPos := len(mockData)
-				var err error
-				if matches[1] != "" {
-					startPos, err = strconv.Atoi(matches[1])
+				startPos, endPos, err = extractRangeHeader(rangeString)
+				if err != nil {
+					if _, ok := err.(*RangeHeaderError); ok {
+						w.WriteHeader(http.StatusBadRequest)
+						return
+					}
 					Expect(err).ToNot(HaveOccurred())
 				}
-				if matches[2] != "" {
-					endPos, err = strconv.Atoi(matches[2])
-					Expect(err).ToNot(HaveOccurred())
-					endPos += 1
+				if endPos == -1 {
+					endPos = len(mockData)
 				}
 				if startPos < 0 || startPos >= len(mockData) || endPos < 0 || endPos > len(mockData) || startPos > endPos {
 					w.WriteHeader(http.StatusBadRequest)
 					return
 				}
-				respData = mockData[startPos:endPos]
-			} else {
-				respData = mockData
 			}
+			respData = mockData[startPos:endPos]
 			w.WriteHeader(http.StatusOK)
 			w.Write(respData)
 		}))
@@ -107,17 +142,15 @@ var _ = Describe("Download Test", func() {
 
 	Context("URI DownloadFile", func() {
 		It("fetches files from mock server", func() {
-			mockServer := getMockServer()
+			mockServer := getMockServer(true)
 			defer mockServer.Close()
 			uri := URI(mockServer.URL)
 			err := uri.DownloadFile(filePath, mockDataSha, 1, 1, func(s1, s2, s3 string, f float64) {})
 			Expect(err).ToNot(HaveOccurred())
-			err = os.Remove(filePath) // cleanup, also checks existance of filePath`
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("resumes partially downloaded files", func() {
-			mockServer := getMockServer()
+			mockServer := getMockServer(true)
 			defer mockServer.Close()
 			uri := URI(mockServer.URL)
 			// Create a partial file
@@ -128,9 +161,25 @@ var _ = Describe("Download Test", func() {
 			Expect(err).ToNot(HaveOccurred())
 			err = uri.DownloadFile(filePath, mockDataSha, 1, 1, func(s1, s2, s3 string, f float64) {})
 			Expect(err).ToNot(HaveOccurred())
-			err = os.Remove(filePath) // cleanup, also checks existance of filePath`
+		})
+
+		It("restarts download from 0 if server doesn't support Range header", func() {
+			mockServer := getMockServer(false)
+			defer mockServer.Close()
+			uri := URI(mockServer.URL)
+			// Create a partial file
+			tmpFilePath := filePath + ".partial"
+			file, err := os.OpenFile(tmpFilePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = file.Write(mockData[0:10000])
+			Expect(err).ToNot(HaveOccurred())
+			err = uri.DownloadFile(filePath, mockDataSha, 1, 1, func(s1, s2, s3 string, f float64) {})
 			Expect(err).ToNot(HaveOccurred())
 		})
-		// It("deletes partial file if after completion hash of downloaded file doesn't match hash of the file in the server")
+	})
+
+	AfterEach(func() {
+		os.Remove(filePath) // cleanup, also checks existance of filePath`
+		os.Remove(filePath + ".partial")
 	})
 })


### PR DESCRIPTION
**Description**

This PR adds support for resuming partial downloads.

- [x] Resuming partial downloads
- [x] Verifying checksum
- [x] Reflecting download percentage on front end after resuming download

**Notes for Reviewers** 
A few questions:  
1. Should we check if the server supports Range Header(used here for partial downloads), most modern web servers do.   
2. I wanted to have a discussion when a model in gallery has multiple files. 


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
4. Build and test your changes before submitting a PR (`make build`). 
5. Sign your commits
6. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
7. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->