### PR TITLE
chore(model gallery): add qwentile2.5-32b-instruct

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -2387,6 +2387,31 @@
     - filename: miscii-14b-1225.Q4_K_M.gguf
       sha256: f21fe73450be394055aeb87b7619e98a09e5c190b48f145bdebef4e12df871fe
       uri: huggingface://mradermacher/miscii-14b-1225-GGUF/miscii-14b-1225.Q4_K_M.gguf
+- !!merge <<: *qwen25
+  name: "qwentile2.5-32b-instruct"
+  icon: https://cdn-uploads.huggingface.co/production/uploads/65b19c1b098c85365af5a83e/sF7RDZA7lFYOmGy4bGy1s.png
+  urls:
+    - https://huggingface.co/maldv/Qwentile2.5-32B-Instruct
+    - https://huggingface.co/bartowski/Qwentile2.5-32B-Instruct-GGUF
+  description: |
+    Qwentile 2.5 32B Instruct is a normalized denoised fourier interpolation of the following models:
+    - { "model": "AiCloser/Qwen2.5-32B-AGI", "base": "Qwen/Qwen2.5-32B", "alpha": 0.3 }
+    - { "model": "EVA-UNIT-01/EVA-Qwen2.5-32B-v0.2", "base": "Qwen/Qwen2.5-32B", "alpha": 0.7 }
+    - { "model": "fblgit/TheBeagle-v2beta-32B-MGS", "base": "Qwen/Qwen2.5-32B", "alpha": 0.6 }
+    - { "model": "huihui-ai/Qwen2.5-32B-Instruct-abliterated", "base": "Qwen/Qwen2.5-32B-Instruct", "alpha": 1.0 }
+    - { "model": "huihui-ai/QwQ-32B-Preview-abliterated", "base": "Qwen/Qwen2.5-32B", "alpha": 1.0 }
+    - { "model": "Qwen/QwQ-32B-Preview", "base": "Qwen/Qwen2.5-32B", "alpha": 0.8, "is_input": true }
+    - { "model": "rombodawg/Rombos-LLM-V2.5-Qwen-32b", "base": "Qwen/Qwen2.5-32B", "alpha": 1.0, "is_output": true }
+    - { "model": "nbeerbower/Qwen2.5-Gutenberg-Doppel-32B", "base": "Qwen/Qwen2.5-32B-Instruct", "alpha": 0.4 }
+    I started my experiment because of QwQ is a really nifty model, but it was giving me problems with xml output - which is what I use for my thought tokens. So, I thought... lets just merge it in!
+    The first model worked pretty well, but I got a sense that the balances could be tweaked. Why not throw in some other models as well for fun and see if I can't run out of disk space in the process?
+  overrides:
+    parameters:
+      model: Qwentile2.5-32B-Instruct-Q4_K_M.gguf
+  files:
+    - filename: Qwentile2.5-32B-Instruct-Q4_K_M.gguf
+      sha256: e476d6e3c15c78fc3f986d7ae8fa35c16116843827f2e6243c05767cef2f3615
+      uri: huggingface://bartowski/Qwentile2.5-32B-Instruct-GGUF/Qwentile2.5-32B-Instruct-Q4_K_M.gguf
 - &archfunct
   license: apache-2.0
   tags:


### PR DESCRIPTION
**Description**

This pull request includes an update to the `gallery/index.yaml` file to add a new model entry. The most important change is the addition of the Qwentile 2.5 32B Instruct model with detailed information and references.

Model addition:

* [`gallery/index.yaml`](diffhunk://#diff-c501316194bb8468dd656c88d5dbd0c4111ab10ece9de96c53cfaad5e5f375edR2390-R2414): Added a new model entry for "qwentile2.5-32b-instruct" with its name, icon, URLs, description, overrides, and associated files.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->