### PR TITLE
chore(deps): bump grpcio to 1.69.0

### DIFF
--- a/backend/python/autogptq/requirements.txt
+++ b/backend/python/autogptq/requirements.txt
@@ -1,6 +1,6 @@
 accelerate
 auto-gptq==0.7.1
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi
 transformers

--- a/backend/python/bark/requirements.txt
+++ b/backend/python/bark/requirements.txt
@@ -1,4 +1,4 @@
 bark==0.1.5
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi

--- a/backend/python/common/template/requirements.txt
+++ b/backend/python/common/template/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 grpcio-tools

--- a/backend/python/coqui/requirements.txt
+++ b/backend/python/coqui/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi
 packaging==24.1

--- a/backend/python/diffusers/requirements.txt
+++ b/backend/python/diffusers/requirements.txt
@@ -1,5 +1,5 @@
 setuptools
-grpcio==1.68.1
+grpcio==1.69.0
 pillow
 protobuf
 certifi

--- a/backend/python/exllama2/requirements.txt
+++ b/backend/python/exllama2/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi
 wheel

--- a/backend/python/mamba/requirements.txt
+++ b/backend/python/mamba/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi

--- a/backend/python/openvoice/requirements-intel.txt
+++ b/backend/python/openvoice/requirements-intel.txt
@@ -4,7 +4,7 @@ torch==2.3.1+cxx11.abi
 torchaudio==2.3.1+cxx11.abi
 oneccl_bind_pt==2.3.100+xpu
 optimum[openvino]
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 librosa==0.9.1
 faster-whisper==0.9.0

--- a/backend/python/openvoice/requirements.txt
+++ b/backend/python/openvoice/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 librosa
 faster-whisper

--- a/backend/python/parler-tts/requirements.txt
+++ b/backend/python/parler-tts/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 certifi
 llvmlite==0.43.0
 setuptools

--- a/backend/python/rerankers/requirements.txt
+++ b/backend/python/rerankers/requirements.txt
@@ -1,3 +1,3 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi

--- a/backend/python/sentencetransformers/requirements.txt
+++ b/backend/python/sentencetransformers/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi
 datasets

--- a/backend/python/transformers-musicgen/requirements.txt
+++ b/backend/python/transformers-musicgen/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 scipy==1.14.0
 certifi

--- a/backend/python/transformers/requirements.txt
+++ b/backend/python/transformers/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi
 setuptools

--- a/backend/python/vall-e-x/requirements.txt
+++ b/backend/python/vall-e-x/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi
 setuptools

--- a/backend/python/vllm/requirements.txt
+++ b/backend/python/vllm/requirements.txt
@@ -1,4 +1,4 @@
-grpcio==1.68.1
+grpcio==1.69.0
 protobuf
 certifi
 setuptools


### PR DESCRIPTION
**Description**

This pull request updates the `grpcio` dependency across multiple requirement files in the backend Python projects. The version of `grpcio` has been updated from 1.68.1 to 1.69.0 to ensure consistency and compatibility across different modules.

Dependency updates:

* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/autogptq/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/bark/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/common/template/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/coqui/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/diffusers/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/exllama2/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/mamba/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/openvoice/requirements-intel.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/openvoice/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/parler-tts/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/rerankers/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/sentencetransformers/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/transformers-musicgen/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/transformers/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/vall-e-x/requirements.txt`
* Updated `grpcio` from 1.68.1 to 1.69.0 in `backend/python/vllm/requirements.txt`

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->