### PR TITLE
feat(vllm): Additional vLLM config options (Disable logging, dtype, and Per-Prompt media limits)

### DIFF
--- a/backend/backend.proto
+++ b/backend/backend.proto
@@ -165,7 +165,7 @@ message Reply {
 
 message GrammarTrigger {
   string word = 1;
-  bool at_start = 2; 
+  bool at_start = 2;
 }
 
 message ModelOptions {
@@ -229,6 +229,11 @@ message ModelOptions {
   int32  MaxModelLen = 54;
   int32  TensorParallelSize = 55;
   string LoadFormat = 58;
+  bool   DisableLogStatus = 66;
+  string DType = 67;
+  int32  LimitImagePerPrompt = 68;
+  int32  LimitVideoPerPrompt = 69;
+  int32  LimitAudioPerPrompt = 70;
 
   string MMProj = 41;
 

--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -109,6 +109,17 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             engine_args.swap_space = request.SwapSpace
         if request.MaxModelLen != 0:
             engine_args.max_model_len = request.MaxModelLen
+        if request.DisableLogStatus:
+            engine_args.disable_log_status = request.DisableLogStatus
+        if request.DType != "":
+            engine_args.dtype = request.DType
+        if request.LimitImagePerPrompt != 0 or request.LimitVideoPerPrompt != 0 or request.LimitAudioPerPrompt != 0:
+            # limit-mm-per-prompt defaults to 1 per modality, based on vLLM docs
+            engine_args.limit_mm_per_prompt = {
+                "image": max(request.LimitImagePerPrompt, 1),
+                "video": max(request.LimitVideoPerPrompt, 1),
+                "audio": max(request.LimitAudioPerPrompt, 1)
+            }
 
         try:
             self.llm = AsyncLLMEngine.from_engine_args(engine_args)
@@ -269,7 +280,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
     def load_image(self, image_path: str):
         """
         Load an image from the given file path or base64 encoded data.
-        
+
         Args:
             image_path (str): The path to the image file or base64 encoded data.
 
@@ -288,7 +299,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
     def load_video(self, video_path: str):
         """
         Load a video from the given file path.
-        
+
         Args:
             video_path (str): The path to the image file.
 

--- a/core/backend/options.go
+++ b/core/backend/options.go
@@ -159,6 +159,12 @@ func grpcModelOpts(c config.BackendConfig) *pb.ModelOptions {
 		SwapSpace:            int32(c.SwapSpace),
 		MaxModelLen:          int32(c.MaxModelLen),
 		TensorParallelSize:   int32(c.TensorParallelSize),
+		DisableLogStatus      c.DisableLogStatus,
+		DType:                c.DType,
+		// LimitMMPerPrompt vLLM
+		LimitImagePerPrompt:  int32(c.LimitMMPerPrompt.LimitImagePerPrompt),
+		LimitVideoPerPrompt:  int32(c.LimitMMPerPrompt.LimitVideoPerPrompt),
+		LimitAudioPerPrompt:  int32(c.LimitMMPerPrompt.LimitAudioPerPrompt),
 		MMProj:               c.MMProj,
 		FlashAttention:       c.FlashAttention,
 		CacheTypeKey:         c.CacheTypeK,

--- a/core/backend/options.go
+++ b/core/backend/options.go
@@ -159,7 +159,7 @@ func grpcModelOpts(c config.BackendConfig) *pb.ModelOptions {
 		SwapSpace:            int32(c.SwapSpace),
 		MaxModelLen:          int32(c.MaxModelLen),
 		TensorParallelSize:   int32(c.TensorParallelSize),
-		DisableLogStatus      c.DisableLogStatus,
+		DisableLogStatus:     c.DisableLogStatus,
 		DType:                c.DType,
 		// LimitMMPerPrompt vLLM
 		LimitImagePerPrompt:  int32(c.LimitMMPerPrompt.LimitImagePerPrompt),

--- a/core/config/backend_config.go
+++ b/core/config/backend_config.go
@@ -130,25 +130,28 @@ type LLMConfig struct {
 	TrimSpace       []string `yaml:"trimspace"`
 	TrimSuffix      []string `yaml:"trimsuffix"`
 
-	ContextSize          *int      `yaml:"context_size"`
-	NUMA                 bool      `yaml:"numa"`
-	LoraAdapter          string    `yaml:"lora_adapter"`
-	LoraBase             string    `yaml:"lora_base"`
-	LoraAdapters         []string  `yaml:"lora_adapters"`
-	LoraScales           []float32 `yaml:"lora_scales"`
-	LoraScale            float32   `yaml:"lora_scale"`
-	NoMulMatQ            bool      `yaml:"no_mulmatq"`
-	DraftModel           string    `yaml:"draft_model"`
-	NDraft               int32     `yaml:"n_draft"`
-	Quantization         string    `yaml:"quantization"`
-	LoadFormat           string    `yaml:"load_format"`
-	GPUMemoryUtilization float32   `yaml:"gpu_memory_utilization"` // vLLM
-	TrustRemoteCode      bool      `yaml:"trust_remote_code"`      // vLLM
-	EnforceEager         bool      `yaml:"enforce_eager"`          // vLLM
-	SwapSpace            int       `yaml:"swap_space"`             // vLLM
-	MaxModelLen          int       `yaml:"max_model_len"`          // vLLM
-	TensorParallelSize   int       `yaml:"tensor_parallel_size"`   // vLLM
-	MMProj               string    `yaml:"mmproj"`
+	ContextSize          *int               `yaml:"context_size"`
+	NUMA                 bool               `yaml:"numa"`
+	LoraAdapter          string             `yaml:"lora_adapter"`
+	LoraBase             string             `yaml:"lora_base"`
+	LoraAdapters         []string           `yaml:"lora_adapters"`
+	LoraScales           []float32          `yaml:"lora_scales"`
+	LoraScale            float32            `yaml:"lora_scale"`
+	NoMulMatQ            bool               `yaml:"no_mulmatq"`
+	DraftModel           string             `yaml:"draft_model"`
+	NDraft               int32              `yaml:"n_draft"`
+	Quantization         string             `yaml:"quantization"`
+	LoadFormat           string             `yaml:"load_format"`
+	GPUMemoryUtilization float32            `yaml:"gpu_memory_utilization"` // vLLM
+	TrustRemoteCode      bool               `yaml:"trust_remote_code"`      // vLLM
+	EnforceEager         bool               `yaml:"enforce_eager"`          // vLLM
+	SwapSpace            int                `yaml:"swap_space"`             // vLLM
+	MaxModelLen          int                `yaml:"max_model_len"`          // vLLM
+	TensorParallelSize   int                `yaml:"tensor_parallel_size"`   // vLLM
+	DisableLogStatus     bool               `yaml:"disable_log_stats"`      // vLLM
+	DType                string             `yaml:"dtype"`                  // vLLM
+	LimitMMPerPrompt     LimitMMPerPrompt   `yaml:"limit_mm_per_prompt"`    // vLLM
+	MMProj               string             `yaml:"mmproj"`
 
 	FlashAttention bool   `yaml:"flash_attention"`
 	NoKVOffloading bool   `yaml:"no_kv_offloading"`
@@ -164,6 +167,13 @@ type LLMConfig struct {
 	YarnBetaSlow   float32 `yaml:"yarn_beta_slow"`
 
 	CFGScale float32 `yaml:"cfg_scale"` // Classifier-Free Guidance Scale
+}
+
+// LimitMMPerPrompt is a struct that holds the configuration for the limit-mm-per-prompt config in vLLM
+type LimitMMPerPrompt struct {
+	LimitImagePerPrompt   int   `yaml:"image"`
+	LimitVideoPerPrompt   int   `yaml:"video"`
+	LimitAudioPerPrompt   int   `yaml:"audio"`
 }
 
 // AutoGPTQ is a struct that holds the configuration specific to the AutoGPTQ backend

--- a/gallery/vllm.yaml
+++ b/gallery/vllm.yaml
@@ -16,6 +16,8 @@ config_file: |
       use_tokenizer_template: true
     # Uncomment to specify a quantization method (optional)
     # quantization: "awq"
+    # Uncomment to set dtype, choices are: 'auto', 'half', 'float16', 'bfloat16', 'float', 'float32'. awq on vLLM does not support bfloat16
+    # dtype: 'float16'
     # Uncomment to limit the GPU memory utilization (vLLM default is 0.9 for 90%)
     # gpu_memory_utilization: 0.5
     # Uncomment to trust remote code from huggingface
@@ -30,3 +32,10 @@ config_file: |
     # Allows you to partition and run large models. Performance gains are limited.
     # https://github.com/vllm-project/vllm/issues/1435
     # tensor_parallel_size: 2
+    # Uncomment to disable log stats
+    # disable_log_stats: true
+    # Uncomment to specify Multi-Model limits per prompt, defaults to 1 per modality if not specified
+    # limit_mm_per_prompt:
+    #   image: 2
+    #   video: 2
+    #   audio: 2

--- a/gallery/vllm.yaml
+++ b/gallery/vllm.yaml
@@ -16,8 +16,8 @@ config_file: |
       use_tokenizer_template: true
     # Uncomment to specify a quantization method (optional)
     # quantization: "awq"
-    # Uncomment to set dtype, choices are: 'auto', 'half', 'float16', 'bfloat16', 'float', 'float32'. awq on vLLM does not support bfloat16
-    # dtype: 'float16'
+    # Uncomment to set dtype, choices are: "auto", "half", "float16", "bfloat16", "float", "float32". awq on vLLM does not support bfloat16
+    # dtype: "float16"
     # Uncomment to limit the GPU memory utilization (vLLM default is 0.9 for 90%)
     # gpu_memory_utilization: 0.5
     # Uncomment to trust remote code from huggingface


### PR DESCRIPTION
**Description**

This allows for additional configuration of the vLLM backend, specifically the following options
- --disable-log-requests
  - This allows disable request logging for your deployment 
- --dtype
  - This allows configuring the datatype that vLLM will use. When using awq, bfloat16 is not supported, this you need to adjust 
- --limit-mm-per-prompt
  - This allows you to up the limit on attached media per request per modality. The default is 1 image/video/audio entry per request, even though many models support more 

_see: https://docs.vllm.ai/en/latest/serving/engine_args.html_

`limit_mm_per_prompt` is a nested object with config for image, video, and audio modality types. See below (and in commit) for example on bumping the default limit (1)

The resulting vllm-based config file would look like (skipping existing config)
```yaml
---
backend: vllm
.....
quantization: "awq"
dtype: "float16" # new dtype config
...
disable_log_stats: true # new config to disable request logging 
limit_mm_per_prompt:  # allow for requests to have more than just 1 media object per modality (which is default)
  image: 2
  video: 2
  audio: 2
```

**Notes for Reviewers**
Currently, working on getting this set up locally to fully test out these changes. I followed the local dev setup notes, but ran out of disk space on my machine (so, will need to clean up some space...) . These changes were made locally on my docker setup (localai:v2.25.0-cublas-cuda12) to enable running InternVL 2.5 AWQ via vLLM, and required the config changes included.

I am glad to rename/re-format the config variables as needed. Just let me know