### PR TITLE
fix(ui): not all models comes from gallery

### DIFF
--- a/core/http/views/chat.html
+++ b/core/http/views/chat.html
@@ -229,7 +229,9 @@ SOFTWARE.
             <i class="fa-solid fa-comments mr-2"></i>
             {{ if $model }}
             {{ $galleryConfig:= index $allGalleryConfigs $model}}
+            {{ if $galleryConfig }}
             {{ if $galleryConfig.Icon }}<img src="{{$galleryConfig.Icon}}" class="rounded-lg w-8 h-8 mr-2">{{end}}
+            {{ end }}
             {{ end }}
             <h1 class="text-lg font-semibold">
               Chat {{ if .Model }} with {{.Model}} {{ end }}
@@ -262,7 +264,9 @@ SOFTWARE.
                 </template>
                 <template x-if="message.role != 'user'">
                   <div class="flex items-center space-x-2">
+                    {{ if $galleryConfig }}
                     {{ if $galleryConfig.Icon }}<img src="{{$galleryConfig.Icon}}" class="rounded-lg mt-2 max-w-8 max-h-8">{{end}}
+                    {{ end }}
                     <div class="flex flex-col flex-1">
                       <span class="text-xs font-semibold text-gray-400">{{if .Model}}{{.Model}}{{else}}Assistant{{end}}</span>
                       <div class="flex-1 text-white flex items-center space-x-2">


### PR DESCRIPTION
**Description**

This pull request includes changes to the `core/http/views/chat.html` file to improve the handling of gallery configurations in the chat interface. The most important changes focus on adding conditional checks for the presence of gallery configurations before attempting to display gallery icons.

Improvements to gallery configuration handling:

* [`core/http/views/chat.html`](diffhunk://#diff-65bba31d9ea4fd7a1ce1bfb2ee069e72bb00ea15d66032ee3c319dddfa3cfb22R232-R235): Added a conditional check for the presence of `$galleryConfig` before attempting to display the gallery icon in the chat header.
* [`core/http/views/chat.html`](diffhunk://#diff-65bba31d9ea4fd7a1ce1bfb2ee069e72bb00ea15d66032ee3c319dddfa3cfb22R267-R269): Added a conditional check for the presence of `$galleryConfig` before attempting to display the gallery icon in chat messages.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->