### PR TITLE
Revert "chore(deps): Bump intel-extension-for-pytorch from 2.3.110+xpu to 2.6.10+xpu in /backend/python/diffusers"

### DIFF
--- a/backend/python/diffusers/requirements-intel.txt
+++ b/backend/python/diffusers/requirements-intel.txt
@@ -1,5 +1,5 @@
 --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/xpu/us/
-intel-extension-for-pytorch==2.6.10+xpu
+intel-extension-for-pytorch==2.3.110+xpu
 torch==2.3.1+cxx11.abi
 torchvision==0.18.1+cxx11.abi
 oneccl_bind_pt==2.3.100+xpu


### PR DESCRIPTION
Reverts mudler/LocalAI#4973