### PR TITLE
fix: ensure git-lfs is present

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && \
         ca-certificates \
         curl libssl-dev \
         git \
+        git-lfs \
         unzip upx-ucl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
devcontainer clean builds had issue with git-lfs not being present within the image.
Since the package isn't that large (~11 megs) -- see: https://packages.ubuntu.com/search?keywords=git-lfs I think it makes the most sense to put it in every image - that way we don't need to hunt this issue down again in the future.


