### PR TITLE
fix: bark-cpp: assign FLAG_TTS to bark-cpp backend

### DIFF
--- a/core/config/backend_config.go
+++ b/core/config/backend_config.go
@@ -555,7 +555,7 @@ func (c *BackendConfig) GuessUsecases(u BackendConfigUsecases) bool {
 		}
 	}
 	if (u & FLAG_TTS) == FLAG_TTS {
-		ttsBackends := []string{"piper", "transformers-musicgen", "parler-tts"}
+		ttsBackends := []string{"bark-cpp", "parler-tts", "piper", "transformers-musicgen"}
 		if !slices.Contains(ttsBackends, c.Backend) {
 			return false
 		}


### PR DESCRIPTION
**Description**

This PR fixes model chooser in TTS web page. Now is possible to select and successfully use bark-cpp-small

After the fix:
![image](https://github.com/user-attachments/assets/8ac43d8d-6300-430d-b2ea-1f25ca608775)


Before this fix bark-cpp-small is not listed in the dropdown menu and can't be used.

**Notes for Reviewers**
Tested on latest 2.28.0

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->