### PR TITLE
chore(ci): add latest images for core

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -75,6 +75,7 @@ jobs:
             grpc-base-image: "ubuntu:22.04"
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
+            latest-image: 'latest-gpu-hipblas-core'
           - build-type: 'hipblas'
             platforms: 'linux/amd64'
             tag-latest: 'false'
@@ -251,6 +252,7 @@ jobs:
             image-type: 'core'
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
+            latest-image: 'latest-gpu-intel-f16-core'
           - build-type: 'sycl_f32'
             platforms: 'linux/amd64'
             tag-latest: 'false'
@@ -261,6 +263,7 @@ jobs:
             image-type: 'core'
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
+            latest-image: 'latest-gpu-intel-f32-core'
 
   core-image-build:
     uses: ./.github/workflows/image_build.yml
@@ -339,6 +342,7 @@ jobs:
             base-image: "ubuntu:22.04"
             makeflags: "--jobs=4 --output-sync=target"
             skip-drivers: 'false'
+            latest-image: 'latest-gpu-nvidia-cuda-12-core'
           - build-type: 'cublas'
             cuda-major-version: "12"
             cuda-minor-version: "0"
@@ -351,6 +355,7 @@ jobs:
             base-image: "ubuntu:22.04"
             skip-drivers: 'false'
             makeflags: "--jobs=4 --output-sync=target"
+            latest-image: 'latest-gpu-nvidia-cuda-12-core'
           - build-type: 'vulkan'
             platforms: 'linux/amd64'
             tag-latest: 'false'
@@ -362,6 +367,7 @@ jobs:
             base-image: "ubuntu:22.04"
             skip-drivers: 'false'
             makeflags: "--jobs=4 --output-sync=target"
+            latest-image: 'latest-gpu-vulkan-core'
   gh-runner:
     uses: ./.github/workflows/image_build.yml
     with:


### PR DESCRIPTION
**Description**

This pull request updates the `.github/workflows/image.yml` file to include new `latest-image` tags for various GPU configurations. These changes ensure that the workflow explicitly specifies the appropriate latest image for each build type.

### Workflow updates for GPU configurations:

* Added `latest-image: 'latest-gpu-hipblas-core'` for the `hipblas` build type.
* Added `latest-image: 'latest-gpu-intel-f16-core'` for the `sycl_f32` build type.
* Added `latest-image: 'latest-gpu-intel-f32-core'` for an additional Intel GPU configuration.
* Added `latest-image: 'latest-gpu-nvidia-cuda-12-core'` for the `cublas` build type.
* Added `latest-image: 'latest-gpu-vulkan-core'` for the `vulkan` build type.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->