### PR TITLE
fix(talk): Talk interface sends content-type headers to chatgpt

### DIFF
--- a/core/http/static/talk.js
+++ b/core/http/static/talk.js
@@ -115,6 +115,7 @@ async function sendTextToChatGPT(text) {
 
     const response = await fetch('v1/chat/completions', {
         method: 'POST',
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             model: getModel(),
             messages: conversationHistory


### PR DESCRIPTION
**Description**

This PR fixes failing LLM request in Talk Interface.

**Notes for Reviewers**

Since de81b42 the Content-Type header has not been sent for the text generation request in the Talk Interface.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->