### PR TITLE
feat(llama.cpp/clip): inject gpu options if we detect GPUs

### DIFF
--- a/core/config/guesser.go
+++ b/core/config/guesser.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/mudler/LocalAI/pkg/xsysinfo"
 	"github.com/rs/zerolog/log"
 	gguf "github.com/thxcode/gguf-parser-go"
 )
@@ -34,5 +35,11 @@ func guessDefaultsFromFile(cfg *BackendConfig, modelPath string, defaultCtx int)
 			defaultCtx = defaultContextSize
 		}
 		cfg.ContextSize = &defaultCtx
+	}
+
+	if cfg.Options == nil {
+		if xsysinfo.HasGPU("nvidia") || xsysinfo.HasGPU("amd") {
+			cfg.Options = []string{"gpu"}
+		}
 	}
 }

--- a/pkg/xsysinfo/gpu.go
+++ b/pkg/xsysinfo/gpu.go
@@ -1,6 +1,8 @@
 package xsysinfo
 
 import (
+	"strings"
+
 	"github.com/jaypipes/ghw"
 	"github.com/jaypipes/ghw/pkg/gpu"
 )
@@ -12,4 +14,20 @@ func GPUs() ([]*gpu.GraphicsCard, error) {
 	}
 
 	return gpu.GraphicsCards, nil
+}
+
+func HasGPU(vendor string) bool {
+	gpus, err := GPUs()
+	if err != nil {
+		return false
+	}
+	if vendor == "" {
+		return len(gpus) > 0
+	}
+	for _, gpu := range gpus {
+		if strings.Contains(gpu.String(), vendor) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
**Description**

This PR fixes https://github.com/mudler/LocalAI/issues/4815

We try to guess if we have GPUs and we set `options` gpu if not already configured. guessing of defaults can be always disabled with `LOCALAI_DISABLE_GUESSING=true`

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->