### PR TITLE
chore(model gallery): add qwen3-14b

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -76,6 +76,38 @@
     - filename: Qwen_Qwen3-32B-Q4_K_M.gguf
       sha256: e41ec56ddd376963a116da97506fadfccb50fb402bb6f3cb4be0bc179a582bd6
       uri: huggingface://bartowski/Qwen_Qwen3-32B-GGUF/Qwen_Qwen3-32B-Q4_K_M.gguf
+- !!merge <<: *qwen3
+  name: "qwen3-14b"
+  urls:
+    - https://huggingface.co/Qwen/Qwen3-14B
+    - https://huggingface.co/MaziyarPanahi/Qwen3-14B-GGUF
+  description: |
+      Qwen3 is the latest generation of large language models in Qwen series, offering a comprehensive suite of dense and mixture-of-experts (MoE) models. Built upon extensive training, Qwen3 delivers groundbreaking advancements in reasoning, instruction-following, agent capabilities, and multilingual support, with the following key features:
+
+          Uniquely support of seamless switching between thinking mode (for complex logical reasoning, math, and coding) and non-thinking mode (for efficient, general-purpose dialogue) within single model, ensuring optimal performance across various scenarios.
+          Significantly enhancement in its reasoning capabilities, surpassing previous QwQ (in thinking mode) and Qwen2.5 instruct models (in non-thinking mode) on mathematics, code generation, and commonsense logical reasoning.
+          Superior human preference alignment, excelling in creative writing, role-playing, multi-turn dialogues, and instruction following, to deliver a more natural, engaging, and immersive conversational experience.
+          Expertise in agent capabilities, enabling precise integration with external tools in both thinking and unthinking modes and achieving leading performance among open-source models in complex agent-based tasks.
+          Support of 100+ languages and dialects with strong capabilities for multilingual instruction following and translation.
+
+      Qwen3-14B has the following features:
+
+          Type: Causal Language Models
+          Training Stage: Pretraining & Post-training
+          Number of Parameters: 14.8B
+          Number of Paramaters (Non-Embedding): 13.2B
+          Number of Layers: 40
+          Number of Attention Heads (GQA): 40 for Q and 8 for KV
+          Context Length: 32,768 natively and 131,072 tokens with YaRN.
+
+      For more details, including benchmark evaluation, hardware requirements, and inference performance, please refer to our blog, GitHub, and Documentation.
+  overrides:
+    parameters:
+      model: Qwen3-14B.Q4_K_M.gguf
+  files:
+    - filename: Qwen3-14B.Q4_K_M.gguf
+      sha256: ee624d4be12433277bb9a340d3e5aabf5eb68fc788a7048ee99917edaa46494a
+      uri: huggingface://MaziyarPanahi/Qwen3-14B-GGUF/Qwen3-14B.Q4_K_M.gguf
 - &gemma3
   url: "github:mudler/LocalAI/gallery/gemma.yaml@master"
   name: "gemma-3-27b-it"


### PR DESCRIPTION
**Description**

This pull request adds a new entry for the Qwen3-14B model to the `gallery/index.yaml` file, providing detailed metadata and descriptions for the model.

### Additions to the model gallery:

* Added a new entry for the Qwen3-14B model, including its name, URLs, description, and key features such as reasoning capabilities, multilingual support, and agent capabilities. The description highlights its ability to switch between thinking and non-thinking modes, superior human preference alignment, and strong performance in multilingual tasks.
* Included specific technical details for Qwen3-14B, such as the number of parameters (14.8B total, 13.2B non-embedding), number of layers (40), attention heads, and context length (32,768 natively, extendable to 131,072 with YaRN).
* Added file metadata for Qwen3-14B, including the filename, SHA256 checksum, and URI for downloading the model from Hugging Face.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->