### PR TITLE
fix(diffusers): consider options only in form of key/value

### DIFF
--- a/backend/python/diffusers/backend.py
+++ b/backend/python/diffusers/backend.py
@@ -168,8 +168,12 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             # We are storing all the options in a dict so we can use it later when
             # generating the images
             for opt in options:
+                if ":" not in opt:
+                    continue
                 key, value = opt.split(":")
                 self.options[key] = value
+
+            print(f"Options: {self.options}", file=sys.stderr)
 
             local = False
             modelFile = request.Model


### PR DESCRIPTION
**Description**

this PR fixes a shortcoming with #5243 where we inject the gpu option by default if we detect gpus. Diffusers was taking for granted that options are of key/value, but that is not always the case.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->