### PR TITLE
fix(gpu): do not assume gpu being returned has node and mem

### DIFF
--- a/core/config/gguf.go
+++ b/core/config/gguf.go
@@ -170,7 +170,7 @@ func guessGGUFFromFile(cfg *BackendConfig, f *gguf.GGUFFile, defaultCtx int) {
 	vram, err := xsysinfo.TotalAvailableVRAM()
 	if err != nil {
 		log.Error().Msgf("guessDefaultsFromFile(TotalAvailableVRAM): %s", err)
-	} else {
+	} else if vram > 0 {
 		estimate, err := xsysinfo.EstimateGGUFVRAMUsage(f, vram)
 		if err != nil {
 			log.Error().Msgf("guessDefaultsFromFile(EstimateGGUFVRAMUsage): %s", err)

--- a/pkg/xsysinfo/gpu.go
+++ b/pkg/xsysinfo/gpu.go
@@ -24,8 +24,10 @@ func TotalAvailableVRAM() (uint64, error) {
 
 	var totalVRAM uint64
 	for _, gpu := range gpus {
-		if gpu.Node.Memory.TotalUsableBytes > 0 {
-			totalVRAM += uint64(gpu.Node.Memory.TotalUsableBytes)
+		if gpu != nil && gpu.Node != nil && gpu.Node.Memory != nil {
+			if gpu.Node.Memory.TotalUsableBytes > 0 {
+				totalVRAM += uint64(gpu.Node.Memory.TotalUsableBytes)
+			}
 		}
 	}
 


### PR DESCRIPTION
**Description**

This pull request includes changes to improve error handling and ensure robustness in VRAM estimation logic. The updates focus on adding checks for nil values and refining conditions to handle edge cases.

### Improvements to error handling and robustness:

* [`core/config/gguf.go`](diffhunk://#diff-bdc83435b880ad06671e5db75945668b47a68de007cac1238fd69ec7ad26a5c3L173-R173): Updated the `guessGGUFFromFile` function to only estimate VRAM usage if the available VRAM is greater than zero, preventing unnecessary operations when VRAM is unavailable.

* [`pkg/xsysinfo/gpu.go`](diffhunk://#diff-38514486650e23ed983a536f6ec9220e87671665dc9061c762bcef65fc7b8defR27-R32): Enhanced the `TotalAvailableVRAM` function by adding checks to ensure that `gpu`, `gpu.Node`, and `gpu.Node.Memory` are not nil before accessing their properties, improving stability when processing GPU information.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->