### PR TITLE
chore(ci): strip 'core' in the image suffix, identify python-based images with 'extras'

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -45,27 +45,27 @@ jobs:
           - build-type: 'hipblas'
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-hipblas'
+            tag-suffix: '-hipblas-extras'
             ffmpeg: 'true'
             image-type: 'extras'
             aio: "-aio-gpu-hipblas"
             base-image: "rocm/dev-ubuntu-22.04:6.1"
             grpc-base-image: "ubuntu:22.04"
-            latest-image: 'latest-gpu-hipblas'
+            latest-image: 'latest-gpu-hipblas-extras'
             latest-image-aio: 'latest-aio-gpu-hipblas'
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
           - build-type: 'hipblas'
             platforms: 'linux/amd64'
             tag-latest: 'false'
-            tag-suffix: '-hipblas-core'
+            tag-suffix: '-hipblas'
             ffmpeg: 'true'
             image-type: 'core'
             base-image: "rocm/dev-ubuntu-22.04:6.1"
             grpc-base-image: "ubuntu:22.04"
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
-            latest-image: 'latest-gpu-hipblas-core'
+            latest-image: 'latest-gpu-hipblas'
   self-hosted-jobs:
     uses: ./.github/workflows/image_build.yml
     with:
@@ -95,27 +95,18 @@ jobs:
       max-parallel: ${{ github.event_name != 'pull_request' && 5 || 8 }}
       matrix:
         include:
-          - build-type: ''
-            platforms: 'linux/amd64'
-            tag-latest: 'auto'
-            tag-suffix: ''
-            ffmpeg: 'true'
-            image-type: 'extras'
-            runs-on: 'arc-runner-set'
-            base-image: "ubuntu:22.04"
-            makeflags: "--jobs=3 --output-sync=target"
           - build-type: 'cublas'
             cuda-major-version: "11"
             cuda-minor-version: "7"
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-cublas-cuda11'
+            tag-suffix: '-cublas-cuda11-extras'
             ffmpeg: 'true'
             image-type: 'extras'
             runs-on: 'arc-runner-set'
             base-image: "ubuntu:22.04"
             aio: "-aio-gpu-nvidia-cuda-11"
-            latest-image: 'latest-gpu-nvidia-cuda-11'
+            latest-image: 'latest-gpu-nvidia-cuda-11-extras'
             latest-image-aio: 'latest-aio-gpu-nvidia-cuda-11'
             makeflags: "--jobs=3 --output-sync=target"
           - build-type: 'cublas'
@@ -123,13 +114,13 @@ jobs:
             cuda-minor-version: "0"
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-cublas-cuda12'
+            tag-suffix: '-cublas-cuda12-extras'
             ffmpeg: 'true'
             image-type: 'extras'
             runs-on: 'arc-runner-set'
             base-image: "ubuntu:22.04"
             aio: "-aio-gpu-nvidia-cuda-12"
-            latest-image: 'latest-gpu-nvidia-cuda-12'
+            latest-image: 'latest-gpu-nvidia-cuda-12-extras'
             latest-image-aio: 'latest-aio-gpu-nvidia-cuda-12'
             makeflags: "--jobs=3 --output-sync=target"
           - build-type: 'sycl_f16'
@@ -137,12 +128,12 @@ jobs:
             tag-latest: 'auto'
             base-image: "quay.io/go-skynet/intel-oneapi-base:latest"
             grpc-base-image: "ubuntu:22.04"
-            tag-suffix: '-sycl-f16'
+            tag-suffix: '-sycl-f16-extras'
             ffmpeg: 'true'
             image-type: 'extras'
             runs-on: 'arc-runner-set'
             aio: "-aio-gpu-intel-f16"
-            latest-image: 'latest-gpu-intel-f16'
+            latest-image: 'latest-gpu-intel-f16-extras'
             latest-image-aio: 'latest-aio-gpu-intel-f16'
             makeflags: "--jobs=3 --output-sync=target"
           - build-type: 'sycl_f32'
@@ -150,12 +141,12 @@ jobs:
             tag-latest: 'auto'
             base-image: "quay.io/go-skynet/intel-oneapi-base:latest"
             grpc-base-image: "ubuntu:22.04"
-            tag-suffix: '-sycl-f32'
+            tag-suffix: '-sycl-f32-extras'
             ffmpeg: 'true'
             image-type: 'extras'
             runs-on: 'arc-runner-set'
             aio: "-aio-gpu-intel-f32"
-            latest-image: 'latest-gpu-intel-f32'
+            latest-image: 'latest-gpu-intel-f32-extras'
             latest-image-aio: 'latest-aio-gpu-intel-f32'
             makeflags: "--jobs=3 --output-sync=target"
           # Core images
@@ -164,23 +155,23 @@ jobs:
             tag-latest: 'false'
             base-image: "quay.io/go-skynet/intel-oneapi-base:latest"
             grpc-base-image: "ubuntu:22.04"
-            tag-suffix: '-sycl-f16-core'
+            tag-suffix: '-sycl-f16'
             ffmpeg: 'true'
             image-type: 'core'
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
-            latest-image: 'latest-gpu-intel-f16-core'
+            latest-image: 'latest-gpu-intel-f16'
           - build-type: 'sycl_f32'
             platforms: 'linux/amd64'
             tag-latest: 'false'
             base-image: "quay.io/go-skynet/intel-oneapi-base:latest"
             grpc-base-image: "ubuntu:22.04"
-            tag-suffix: '-sycl-f32-core'
+            tag-suffix: '-sycl-f32'
             ffmpeg: 'true'
             image-type: 'core'
             runs-on: 'arc-runner-set'
             makeflags: "--jobs=3 --output-sync=target"
-            latest-image: 'latest-gpu-intel-f32-core'
+            latest-image: 'latest-gpu-intel-f32'
 
   core-image-build:
     uses: ./.github/workflows/image_build.yml
@@ -213,7 +204,7 @@ jobs:
           - build-type: ''
             platforms: 'linux/amd64,linux/arm64'
             tag-latest: 'auto'
-            tag-suffix: '-core'
+            tag-suffix: ''
             ffmpeg: 'true'
             image-type: 'core'
             base-image: "ubuntu:22.04"
@@ -228,38 +219,38 @@ jobs:
             cuda-minor-version: "7"
             platforms: 'linux/amd64'
             tag-latest: 'false'
-            tag-suffix: '-cublas-cuda11-core'
+            tag-suffix: '-cublas-cuda11'
             ffmpeg: 'true'
             image-type: 'core'
             runs-on: 'arc-runner-set'
             base-image: "ubuntu:22.04"
             makeflags: "--jobs=4 --output-sync=target"
             skip-drivers: 'false'
-            latest-image: 'latest-gpu-nvidia-cuda-12-core'
+            latest-image: 'latest-gpu-nvidia-cuda-12'
           - build-type: 'cublas'
             cuda-major-version: "12"
             cuda-minor-version: "0"
             platforms: 'linux/amd64'
             tag-latest: 'false'
-            tag-suffix: '-cublas-cuda12-core'
+            tag-suffix: '-cublas-cuda12'
             ffmpeg: 'true'
             image-type: 'core'
             runs-on: 'arc-runner-set'
             base-image: "ubuntu:22.04"
             skip-drivers: 'false'
             makeflags: "--jobs=4 --output-sync=target"
-            latest-image: 'latest-gpu-nvidia-cuda-12-core'
+            latest-image: 'latest-gpu-nvidia-cuda-12'
           - build-type: 'vulkan'
             platforms: 'linux/amd64'
             tag-latest: 'false'
-            tag-suffix: '-vulkan-core'
+            tag-suffix: '-vulkan'
             ffmpeg: 'true'
             image-type: 'core'
             runs-on: 'arc-runner-set'
             base-image: "ubuntu:22.04"
             skip-drivers: 'false'
             makeflags: "--jobs=4 --output-sync=target"
-            latest-image: 'latest-gpu-vulkan-core'
+            latest-image: 'latest-gpu-vulkan'
   gh-runner:
     uses: ./.github/workflows/image_build.yml
     with:
@@ -292,8 +283,8 @@ jobs:
             cuda-minor-version: "0"
             platforms: 'linux/arm64'
             tag-latest: 'false'
-            tag-suffix: '-nvidia-l4t-arm64-core'
-            latest-image: 'latest-nvidia-l4t-arm64-core'
+            tag-suffix: '-nvidia-l4t-arm64'
+            latest-image: 'latest-nvidia-l4t-arm64'
             ffmpeg: 'true'
             image-type: 'core'
             base-image: "nvcr.io/nvidia/l4t-jetpack:r36.4.0"


### PR DESCRIPTION
**Description**

This PR changes the image building tags.

In order to ease out usage, default images now are only the images without any python deps. Users might be otherwise confused by the large images which are shipping python backends and dependencies. Will follow-up docs updates.

From this change:

- Images now don't have anymore `core` inside suffix.
- Images with Python dependencies have the `extras` suffix

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->