### PR TITLE
fix(flux): Set CFG=1 so that prompts are followed

### DIFF
--- a/gallery/flux-ggml.yaml
+++ b/gallery/flux-ggml.yaml
@@ -10,3 +10,5 @@ config_file: |
     - "t5xxl_path:t5xxl_fp16.safetensors"
     - "vae_path:ae.safetensors"
     - "sampler:euler"
+
+    cfg_scale: 1

--- a/gallery/flux.yaml
+++ b/gallery/flux.yaml
@@ -12,4 +12,4 @@ config_file: |
     enable_parameters: num_inference_steps
     pipeline_type: FluxPipeline
 
-  cfg_scale: 0
+  cfg_scale: 1


### PR DESCRIPTION
The recommendation with Flux is to set CFG to 1 as shown in the
stablediffusion-cpp README.

Fixes: #5366
