### PR TITLE
Fix Typos in Comments and Error Messages

### DIFF
--- a/pkg/grpc/base/base.go
+++ b/pkg/grpc/base/base.go
@@ -1,6 +1,6 @@
 package base
 
-// This is a wrapper to statisfy the GRPC service interface
+// This is a wrapper to satisfy the GRPC service interface
 // It is meant to be used by the main executable that is the server for the specific backend type (falcon, gpt3, etc)
 import (
 	"fmt"

--- a/pkg/model/initializers.go
+++ b/pkg/model/initializers.go
@@ -332,7 +332,7 @@ func (ml *ModelLoader) grpcModel(backend string, autodetect bool, o *Options) fu
 		} else {
 			grpcProcess := backendPath(o.assetDir, backend)
 			if err := utils.VerifyPath(grpcProcess, o.assetDir); err != nil {
-				return nil, fmt.Errorf("refering to a backend not in asset dir: %s", err.Error())
+				return nil, fmt.Errorf("referring to a backend not in asset dir: %s", err.Error())
 			}
 
 			if autodetect {


### PR DESCRIPTION


Description:  
This pull request corrects minor spelling mistakes in the codebase:
- Fixed the typo "statisfy" to "satisfy" in a comment within pkg/grpc/base/base.go.
- Corrected "refering" to "referring" in an error message in pkg/model/initializers.go.

These changes improve code readability and maintain professionalism in comments and error outputs. No functional code was altered.