### PR TITLE
Fix Typos in Documentation and Python Comments

### DIFF
--- a/backend/python/kokoro/istftnet.py
+++ b/backend/python/kokoro/istftnet.py
@@ -154,7 +154,7 @@ class SineGen(torch.nn.Module):
         """ f0_values: (batchsize, length, dim)
             where dim indicates fundamental tone and overtones
         """
-        # convert to F0 in rad. The interger part n can be ignored
+        # convert to F0 in rad. The integer part n can be ignored
         # because 2 * np.pi * n doesn't affect phase
         rad_values = (f0_values / self.sampling_rate) % 1
 

--- a/docs/content/docs/features/GPU-acceleration.md
+++ b/docs/content/docs/features/GPU-acceleration.md
@@ -243,12 +243,12 @@ spec:
               amd.com/gpu: '1'
 ```
 
-This configuration has been tested on a 'custom' cluster managed by SUSE Rancher that was deployed on top of Ubuntu 22.04.4, certification of other configuration is ongoing and compatability is not gauranteed.
+This configuration has been tested on a 'custom' cluster managed by SUSE Rancher that was deployed on top of Ubuntu 22.04.4, certification of other configuration is ongoing and compatability is not guaranteed.
 
 ### Notes
 
 - When installing the ROCM kernel driver on your system ensure that you are installing an equal or newer version that that which is currently implemented in LocalAI (6.0.0 at time of writing).
-- AMD documentation indicates that this will ensure functionality however your milage may vary depending on the GPU and distro you are using.
+- AMD documentation indicates that this will ensure functionality however your mileage may vary depending on the GPU and distro you are using.
 - If you encounter an `Error 413` on attempting to upload an audio file or image for whisper or llava/bakllava on a k8s deployment, note that the ingress for your deployment may require the annotation `nginx.ingress.kubernetes.io/proxy-body-size: "25m"` to allow larger uploads. This may be included in future versions of the helm chart.
 
 ## Intel acceleration (sycl)


### PR DESCRIPTION
**Description**

This pull request corrects several typographical errors in both the Python backend and documentation files. Specifically, it fixes the spelling of "integer" in a code comment within backend/python/kokoro/istftnet.py, and corrects "gauranteed" to "guaranteed" and "milage" to "mileage" in docs/content/docs/features/GPU-acceleration.md. These changes improve the clarity and professionalism of the codebase and documentation.