### PR TITLE
fix(backends gallery): meta packages do not have URIs

### DIFF
--- a/core/gallery/backend_types.go
+++ b/core/gallery/backend_types.go
@@ -30,7 +30,7 @@ func (m *GalleryBackend) SetGallery(gallery config.Gallery) {
 }
 
 func (m *GalleryBackend) IsMeta() bool {
-	return len(m.CapabilitiesMap) > 0
+	return len(m.CapabilitiesMap) > 0 && m.URI == ""
 }
 
 func (m *GalleryBackend) SetInstalled(installed bool) {


### PR DESCRIPTION
**Description**

This PR fixes a corner case when defining galleries with YAML anchors. Meta packages ideally should be first, and using these as anchors will result in all subsequent to be considered metas (even if having URIs).

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->