### PR TITLE
fix(docs): Improve Header Responsiveness - Hide "Star us on GitHub!" on Mobile

### DIFF
--- a/docs/layouts/partials/docs/top-header.html
+++ b/docs/layouts/partials/docs/top-header.html
@@ -44,7 +44,7 @@
                 {{ end }}
             {{ end -}}
         </div>
-        <div class="d-flex align-items-center m-1">
+        <div class="d-none d-md-flex d-flex align-items-center m-1">
             <h5>Star us on GitHub !&nbsp;</h5>
             <script async defer src="https://buttons.github.io/buttons.js"></script>
             <a class="github-button" href="https://github.com/mudler/LocalAI" data-color-scheme="no-preference: light; light: light; dark: dark;" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star mudler/LocalAI on GitHub">Star</a> 


### PR DESCRIPTION
**Description**

This PR fixes the header responsiveness issue reported in #5769.

Improves the documentation header's responsiveness by hiding the "Star us on GitHub!" widget on mobile viewports.

**Problem Solved**
On mobile, the widget overlaps or pushes essential elements like social media links and the dark/light mode toggle, degrading the user experience.

**Changes Made**
Applied Bootstrap's `d-none d-md-flex` classes to the widget element in `docs/layouts/partials/docs/top-header.html`. This hides it on `xs`/`sm` screens and displays it correctly as a flex item on `md` and larger screens.

**Screenshots**

**Before (Mobile View):**
<img width="120" alt="docs_overview_mobile_before" src="https://github.com/user-attachments/assets/caf3b2c8-f36f-4eb7-aa3c-3b2710e9b24c" />

**After (Mobile View):**
<img width="120" alt="docs_overview_mobile_after" src="https://github.com/user-attachments/assets/131b2e09-860b-4eff-99ac-8336beb241c9" />

**Desktop View (no regressions):**
<img width="320" alt="docs_overview_desktop" src="https://github.com/user-attachments/assets/caf0e3ad-c38f-4afe-a3a8-356a40223592" />


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 