### PR TITLE
fix(gallery): correctly show status for downloading OCI images

### DIFF
--- a/core/gallery/backends.go
+++ b/core/gallery/backends.go
@@ -162,7 +162,7 @@ func InstallBackend(basePath string, config *GalleryBackend, downloadStatus func
 		return fmt.Errorf("failed to create backend path %q: %v", backendPath, err)
 	}
 
-	if err := oci.ExtractOCIImage(img, backendPath, downloadStatus); err != nil {
+	if err := oci.ExtractOCIImage(img, config.URI, backendPath, downloadStatus); err != nil {
 		return fmt.Errorf("failed to extract image %q: %v", config.URI, err)
 	}
 
@@ -246,6 +246,13 @@ func ListSystemBackends(basePath string) (map[string]string, error) {
 	for _, backend := range backends {
 		if backend.IsDir() {
 			runFile := filepath.Join(basePath, backend.Name(), runFile)
+			// Skip if metadata file don't exist
+
+			metadataFilePath := filepath.Join(basePath, backend.Name(), metadataFile)
+			if _, err := os.Stat(metadataFilePath); os.IsNotExist(err) {
+				continue
+			}
+
 			backendsNames[backend.Name()] = runFile
 
 			// Check for alias in metadata

--- a/core/gallery/backends_test.go
+++ b/core/gallery/backends_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Gallery Backends", func() {
 			concreteBackendPath := filepath.Join(tempDir, "concrete-backend")
 			err = os.MkdirAll(concreteBackendPath, 0750)
 			Expect(err).NotTo(HaveOccurred())
-			err = os.WriteFile(filepath.Join(concreteBackendPath, "run.sh"), []byte("#!/bin/bash"), 0755)
+			err = os.WriteFile(filepath.Join(concreteBackendPath, "metadata.json"), []byte("{}"), 0755)
 			Expect(err).NotTo(HaveOccurred())
 
 			// List system backends
@@ -318,6 +318,8 @@ var _ = Describe("Gallery Backends", func() {
 			backendNames := []string{"backend1", "backend2", "backend3"}
 			for _, name := range backendNames {
 				err := os.MkdirAll(filepath.Join(tempDir, name), 0750)
+				Expect(err).NotTo(HaveOccurred())
+				err = os.WriteFile(filepath.Join(tempDir, name, "metadata.json"), []byte("{}"), 0755)
 				Expect(err).NotTo(HaveOccurred())
 			}
 

--- a/core/gallery/gallery.go
+++ b/core/gallery/gallery.go
@@ -121,7 +121,12 @@ func AvailableGalleryModels(galleries []config.Gallery, basePath string) (Galler
 
 	// Get models from galleries
 	for _, gallery := range galleries {
-		galleryModels, err := getGalleryElements[*GalleryModel](gallery, basePath)
+		galleryModels, err := getGalleryElements[*GalleryModel](gallery, basePath, func(model *GalleryModel) bool {
+			if _, err := os.Stat(filepath.Join(basePath, fmt.Sprintf("%s.yaml", model.GetName()))); err == nil {
+				return true
+			}
+			return false
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -137,7 +142,14 @@ func AvailableBackends(galleries []config.Gallery, basePath string) (GalleryElem
 
 	// Get models from galleries
 	for _, gallery := range galleries {
-		galleryModels, err := getGalleryElements[*GalleryBackend](gallery, basePath)
+		galleryModels, err := getGalleryElements[*GalleryBackend](gallery, basePath, func(backend *GalleryBackend) bool {
+			backends, err := ListSystemBackends(basePath)
+			if err != nil {
+				return false
+			}
+			_, exists := backends[backend.GetName()]
+			return exists
+		})
 		if err != nil {
 			return nil, err
 		}
@@ -162,7 +174,7 @@ func findGalleryURLFromReferenceURL(url string, basePath string) (string, error)
 	return refFile, err
 }
 
-func getGalleryElements[T GalleryElement](gallery config.Gallery, basePath string) ([]T, error) {
+func getGalleryElements[T GalleryElement](gallery config.Gallery, basePath string, isInstalledCallback func(T) bool) ([]T, error) {
 	var models []T = []T{}
 
 	if strings.HasSuffix(gallery.URL, ".ref") {
@@ -187,15 +199,7 @@ func getGalleryElements[T GalleryElement](gallery config.Gallery, basePath strin
 	// Add gallery to models
 	for _, model := range models {
 		model.SetGallery(gallery)
-		// we check if the model was already installed by checking if the config file exists
-		// TODO: (what to do if the model doesn't install a config file?)
-		// TODO: This is sub-optimal now that the gallery handles both backends and models - we need to abstract this away
-		if _, err := os.Stat(filepath.Join(basePath, fmt.Sprintf("%s.yaml", model.GetName()))); err == nil {
-			model.SetInstalled(true)
-		}
-		if _, err := os.Stat(filepath.Join(basePath, model.GetName())); err == nil {
-			model.SetInstalled(true)
-		}
+		model.SetInstalled(isInstalledCallback(model))
 	}
 	return models, nil
 }

--- a/core/http/routes/ui_backend_gallery.go
+++ b/core/http/routes/ui_backend_gallery.go
@@ -223,7 +223,7 @@ func registerBackendGalleryRoutes(app *fiber.App, appConfig *config.ApplicationC
 			return c.SendString(elements.ProgressBar("0"))
 		}
 
-		if status.Progress == 100 {
+		if status.Progress == 100 && status.Processed && status.Message == "completed" {
 			c.Set("HX-Trigger", "done") // this triggers /browse/backend/job/:uid
 			return c.SendString(elements.ProgressBar("100"))
 		}

--- a/core/http/routes/ui_gallery.go
+++ b/core/http/routes/ui_gallery.go
@@ -243,7 +243,7 @@ func registerGalleryRoutes(app *fiber.App, cl *config.BackendConfigLoader, appCo
 			return c.SendString(elements.ProgressBar("0"))
 		}
 
-		if status.Progress == 100 {
+		if status.Progress == 100 && status.Processed && status.Message == "completed" {
 			c.Set("HX-Trigger", "done") // this triggers /browse/job/:uid (which is when the job is done)
 			return c.SendString(elements.ProgressBar("100"))
 		}

--- a/pkg/downloader/uri.go
+++ b/pkg/downloader/uri.go
@@ -256,7 +256,7 @@ func (uri URI) DownloadFile(filePath, sha string, fileN, total int, downloadStat
 			return fmt.Errorf("failed to get image %q: %v", url, err)
 		}
 
-		return oci.ExtractOCIImage(img, filepath.Dir(filePath), downloadStatus)
+		return oci.ExtractOCIImage(img, url, filepath.Dir(filePath), downloadStatus)
 	}
 
 	// Check if the file already exists

--- a/pkg/oci/image_test.go
+++ b/pkg/oci/image_test.go
@@ -30,7 +30,7 @@ var _ = Describe("OCI", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer os.RemoveAll(dir)
 
-			err = ExtractOCIImage(img, dir, nil)
+			err = ExtractOCIImage(img, imageName, dir, nil)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
We can't use the mutate.Extract written bytes as current status as that will be bigger than the compressed image size. Image manifest don't have any guarantee of the type of artifact (can be compressed or not) when showing the layer size.

Split the extraction process in two parts: Downloading and extracting as a flattened system, in this way we can display the status of downloading and extracting accordingly.

This change also fixes a small nuance in detecting installed backends, now it's more consistent and looks if a metadata.json and/or a path with a `run.sh` file is present.

**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->