### PR TITLE
feat(openai): support input_audio chat api field

### DIFF
--- a/core/http/middleware/request.go
+++ b/core/http/middleware/request.go
@@ -308,7 +308,7 @@ func mergeOpenAIRequestAndBackendConfig(config *config.BackendConfig, input *sch
 					input.Messages[i].StringVideos = append(input.Messages[i].StringVideos, base64) // TODO: make sure that we only return base64 stuff
 					vidIndex++
 					nrOfVideosInMessage++
-				case "audio_url", "audio", "input_audio":
+				case "audio_url", "audio":
 					// Decode content as base64 either if it's an URL or base64 text
 					base64, err := utils.GetContentURIAsBase64(pp.AudioURL.URL)
 					if err != nil {
@@ -316,6 +316,11 @@ func mergeOpenAIRequestAndBackendConfig(config *config.BackendConfig, input *sch
 						continue CONTENT
 					}
 					input.Messages[i].StringAudios = append(input.Messages[i].StringAudios, base64) // TODO: make sure that we only return base64 stuff
+					audioIndex++
+					nrOfAudiosInMessage++
+				case "input_audio":
+					// TODO: make sure that we only return base64 stuff
+					input.Messages[i].StringAudios = append(input.Messages[i].StringAudios, pp.InputAudio.Data)
 					audioIndex++
 					nrOfAudiosInMessage++
 				case "image_url", "image":

--- a/core/schema/openai.go
+++ b/core/schema/openai.go
@@ -58,15 +58,23 @@ type Choice struct {
 }
 
 type Content struct {
-	Type     string     `json:"type" yaml:"type"`
-	Text     string     `json:"text" yaml:"text"`
-	ImageURL ContentURL `json:"image_url" yaml:"image_url"`
-	AudioURL ContentURL `json:"audio_url" yaml:"audio_url"`
-	VideoURL ContentURL `json:"video_url" yaml:"video_url"`
+	Type       string     `json:"type" yaml:"type"`
+	Text       string     `json:"text" yaml:"text"`
+	ImageURL   ContentURL `json:"image_url" yaml:"image_url"`
+	AudioURL   ContentURL `json:"audio_url" yaml:"audio_url"`
+	VideoURL   ContentURL `json:"video_url" yaml:"video_url"`
+	InputAudio InputAudio `json:"input_audio" yaml:"input_audio"`
 }
 
 type ContentURL struct {
 	URL string `json:"url" yaml:"url"`
+}
+
+type InputAudio struct {
+	// Format identifies the audio format, e.g. 'wav'.
+	Format string `json:"format" yaml:"format"`
+	// Data holds the base64-encoded audio data.
+	Data string `json:"data" yaml:"data"`
 }
 
 type Message struct {


### PR DESCRIPTION
**Description**
Improving the chat completion endpoint OpenAI API compatibility by supporting messages of type `input_audio`, e.g.:
```
{
  ...
  "messages": [
    {
      "role": "user",
      "content": [{
        "type": "input_audio",
        "input_audio": {
          "data": "<base64-encoded audio data>",
          "format": "wav"
        }
      }]
    }
  ]
}
```
This PR fixes #5869
Relates to #5226

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->