### PR TITLE
feat(backends): allow backends to not have a metadata file

### DIFF
--- a/core/gallery/backends.go
+++ b/core/gallery/backends.go
@@ -250,16 +250,22 @@ func ListSystemBackends(basePath string) (map[string]string, error) {
 	for _, backend := range backends {
 		if backend.IsDir() {
 			runFile := filepath.Join(basePath, backend.Name(), runFile)
-			// Skip if metadata file don't exist
+
+			var metadata *BackendMetadata
+
+			// If metadata file does not exist, we just use the directory name
+			// and we do not fill the other metadata (such as potential backend Aliases)
 			metadataFilePath := filepath.Join(basePath, backend.Name(), metadataFile)
 			if _, err := os.Stat(metadataFilePath); os.IsNotExist(err) {
-				continue
-			}
-
-			// Check for alias in metadata
-			metadata, err := readBackendMetadata(filepath.Join(basePath, backend.Name()))
-			if err != nil {
-				return nil, err
+				metadata = &BackendMetadata{
+					Name: backend.Name(),
+				}
+			} else {
+				// Check for alias in metadata
+				metadata, err = readBackendMetadata(filepath.Join(basePath, backend.Name()))
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			if metadata == nil {


### PR DESCRIPTION
In this case we generate one on the fly and we infer the metadata we can.

Obviously this have the side effect of not being able to register potential aliases.

This PR fixes https://github.com/mudler/LocalAI/issues/5917

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->