### PR TITLE
chore(build): Rename sycl to intel

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -109,7 +109,7 @@ jobs:
             skip-drivers: 'false'
             makeflags: "--jobs=4 --output-sync=target"
             aio: "-aio-gpu-vulkan"
-          - build-type: 'sycl'
+          - build-type: 'intel'
             platforms: 'linux/amd64'
             tag-latest: 'auto'
             base-image: "quay.io/go-skynet/intel-oneapi-base:latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,10 +100,7 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
         ldconfig \
     ; fi
 
-RUN expr "${BUILD_TYPE}" : sycl && \
-      echo "intel" > /run/localai/capability || \
-      echo "Not Intel"
-
+RUN expr "${BUILD_TYPE}" = intel && echo "intel" > /run/localai/capability || echo "not intel"
 
 # Cuda
 ENV PATH=/usr/local/cuda/bin:${PATH}

--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,7 @@ docker-image-intel:
 		--build-arg IMAGE_TYPE=$(IMAGE_TYPE) \
 		--build-arg GO_TAGS="$(GO_TAGS)" \
 		--build-arg MAKEFLAGS="$(DOCKER_MAKEFLAGS)" \
-		--build-arg BUILD_TYPE=sycl -t $(DOCKER_IMAGE) .
+		--build-arg BUILD_TYPE=intel -t $(DOCKER_IMAGE) .
 
 ########################################################
 ## Backends


### PR DESCRIPTION
It seems like I got distracted and did not actually commit these changes to the last intel PR.

This changes the build type from sycl to intel for the core. The backends are unaffected.
