### PR TITLE
Tune the "dark gray" font color in the webui to make it more readable

### DIFF
--- a/core/http/static/general.css
+++ b/core/http/static/general.css
@@ -68,7 +68,7 @@ ul {
 
 li {
     font-size: 0.875rem; /* Small text size */
-    color: #4a5568; /* Dark gray text */
+    color: #aab2c7; /* Dark gray text */
    /*  background-color: #f7fafc; Very light gray background */
     border-radius: 0.375rem; /* Rounded corners */
     padding: 0.5rem; /* Padding inside each list item */


### PR DESCRIPTION
**Description**

This PR fixes the `li` font color used in Chat prompts. The previous text color was barely readable as it was too close to the background color.