### PR TITLE
fix: select portable environment if detected

### DIFF
--- a/backend/python/common/libbackend.sh
+++ b/backend/python/common/libbackend.sh
@@ -286,7 +286,8 @@ _makeVenvPortable() {
 function ensureVenv() {
     local interpreter=""
 
-    if [ "x${PORTABLE_PYTHON}" == "xtrue" ]; then
+    if [ "x${PORTABLE_PYTHON}" == "xtrue" ] || [ -e "$(_portable_python)" ]; then
+        echo "Using portable Python"
         ensurePortablePython
         interpreter="$(_portable_python)"
     else


### PR DESCRIPTION
**Description**

This PR starts the portable python environment if we find out that the binary in the backend exist

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->