### PR TITLE
fix: reranking models limited to 512 tokens in llama.cpp backend

### DIFF
--- a/backend/cpp/llama-cpp/grpc-server.cpp
+++ b/backend/cpp/llama-cpp/grpc-server.cpp
@@ -231,6 +231,7 @@ static void params_parse(const backend::ModelOptions* request,
     params.cpuparams.n_threads = request->threads();
     params.n_gpu_layers = request->ngpulayers();
     params.n_batch = request->nbatch();
+    params.n_ubatch = request->nbatch(); // fixes issue with reranking models being limited to 512 tokens (the default n_ubatch size); allows for setting the maximum input amount of tokens thereby avoiding this error "input is too large to process. increase the physical batch size"
     // Set params.n_parallel by environment variable (LLAMA_PARALLEL), defaults to 1
     //params.n_parallel = 1;
     const char *env_parallel = std::getenv("LLAMACPP_PARALLEL");


### PR DESCRIPTION
**Description**

I discovered a bug with how llamacpp's grcp backend is implemented in LocalAI.  Basically the batch parameter is exposed in the LocalAI model yaml file but this only changes the n_batch parameter in llama.cpp.  When trying to run a reranking model in llama.cpp, it sometimes complains that the prompt input is larger than the maximum physical batch size.  The default is 512 tokens and set by n_ubatch, not by n_batch.  I fixed it by making the batch value from the model yaml file change both the n_batch and n_ubatch parameters in llamacpp.  

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.