### PR TITLE
feat(api): support both /v1 and not on openai routes

### DIFF
--- a/core/http/routes/openai.go
+++ b/core/http/routes/openai.go
@@ -76,25 +76,37 @@ func RegisterOpenAIRoutes(app *fiber.App,
 	app.Post("/embeddings", embeddingChain...)
 	app.Post("/v1/engines/:model/embeddings", embeddingChain...)
 
-	// audio
-	app.Post("/v1/audio/transcriptions",
+	audioChain := []fiber.Handler{
 		re.BuildFilteredFirstAvailableDefaultModel(config.BuildUsecaseFilterFn(config.FLAG_TRANSCRIPT)),
 		re.SetModelAndConfig(func() schema.LocalAIRequest { return new(schema.OpenAIRequest) }),
 		re.SetOpenAIRequest,
 		openai.TranscriptEndpoint(application.ModelConfigLoader(), application.ModelLoader(), application.ApplicationConfig()),
-	)
+	}
+	// audio
+	app.Post("/v1/audio/transcriptions", audioChain...)
+	app.Post("/audio/transcriptions", audioChain...)
 
-	app.Post("/v1/audio/speech",
+	audioSpeechChain := []fiber.Handler{
 		re.BuildFilteredFirstAvailableDefaultModel(config.BuildUsecaseFilterFn(config.FLAG_TTS)),
 		re.SetModelAndConfig(func() schema.LocalAIRequest { return new(schema.TTSRequest) }),
-		localai.TTSEndpoint(application.ModelConfigLoader(), application.ModelLoader(), application.ApplicationConfig()))
+		localai.TTSEndpoint(application.ModelConfigLoader(), application.ModelLoader(), application.ApplicationConfig()),
+	}
+
+	app.Post("/v1/audio/speech",
+		audioSpeechChain...)
+	app.Post("/audio/speech", audioSpeechChain...)
 
 	// images
-	app.Post("/v1/images/generations",
+	imageChain := []fiber.Handler{
 		re.BuildConstantDefaultModelNameMiddleware("stablediffusion"),
 		re.SetModelAndConfig(func() schema.LocalAIRequest { return new(schema.OpenAIRequest) }),
 		re.SetOpenAIRequest,
-		openai.ImageEndpoint(application.ModelConfigLoader(), application.ModelLoader(), application.ApplicationConfig()))
+		openai.ImageEndpoint(application.ModelConfigLoader(), application.ModelLoader(), application.ApplicationConfig()),
+	}
+
+	app.Post("/v1/images/generations",
+		imageChain...)
+	app.Post("/images/generations", imageChain...)
 
 	// List models
 	app.Get("/v1/models", openai.ListModelsEndpoint(application.ModelConfigLoader(), application.ModelLoader(), application.ApplicationConfig()))


### PR DESCRIPTION
**Description**

This PR makes sure we support routes with and without `/v1` prefix.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->