### PR TITLE
fix(mcp): make responses compliant to OpenAI APIs

### DIFF
--- a/core/http/endpoints/openai/mcp.go
+++ b/core/http/endpoints/openai/mcp.go
@@ -122,7 +122,7 @@ func MCPCompletionEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, 
 			ID:      id,
 			Created: created,
 			Model:   input.Model, // we have to return what the user sent here, due to OpenAI spec.
-			Choices: []schema.Choice{{Text: f.LastMessage().Content}},
+			Choices: []schema.Choice{{Message: &schema.Message{Role: "assistant", Content: &f.LastMessage().Content}}},
 			Object:  "text_completion",
 		}
 


### PR DESCRIPTION
The result is enclosed in the Message field to be compliant with the OpenAI client.
