### PR TITLE
fix(realtime): Add transcription session created event, match OpenAI behavior

### DIFF
--- a/core/http/endpoints/openai/realtime.go
+++ b/core/http/endpoints/openai/realtime.go
@@ -256,20 +256,12 @@ func registerRealtime(application *application.Application) func(c *websocket.Co
 		sessions[sessionID] = session
 		sessionLock.Unlock()
 
-		// Send session.created and conversation.created events to the client
-		sendEvent(c, types.SessionCreatedEvent{
+		sendEvent(c, types.TranscriptionSessionCreatedEvent{
 			ServerEventBase: types.ServerEventBase{
 				EventID: "event_TODO",
-				Type:    types.ServerEventTypeSessionCreated,
+				Type:    types.ServerEventTypeTranscriptionSessionCreated,
 			},
 			Session: session.ToServer(),
-		})
-		sendEvent(c, types.ConversationCreatedEvent{
-			ServerEventBase: types.ServerEventBase{
-				EventID: "event_TODO",
-				Type:    types.ServerEventTypeConversationCreated,
-			},
-			Conversation: conversation.ToServer(),
 		})
 
 		var (

--- a/core/http/endpoints/openai/types/realtime.go
+++ b/core/http/endpoints/openai/types/realtime.go
@@ -704,6 +704,7 @@ const (
 	ServerEventTypeError                                            ServerEventType = "error"
 	ServerEventTypeSessionCreated                                   ServerEventType = "session.created"
 	ServerEventTypeSessionUpdated                                   ServerEventType = "session.updated"
+	ServerEventTypeTranscriptionSessionCreated                      ServerEventType = "transcription_session.created"
 	ServerEventTypeTranscriptionSessionUpdated                      ServerEventType = "transcription_session.updated"
 	ServerEventTypeConversationCreated                              ServerEventType = "conversation.created"
 	ServerEventTypeInputAudioBufferCommitted                        ServerEventType = "input_audio_buffer.committed"
@@ -765,6 +766,15 @@ type SessionCreatedEvent struct {
 	ServerEventBase
 	// The session resource.
 	Session ServerSession `json:"session"`
+}
+
+// TranscriptionSessionCreatedEvent is the event for session created.
+// Returned when a transcription session is created.
+// See https://platform.openai.com/docs/api-reference/realtime-server-events/session/created
+type TranscriptionSessionCreatedEvent struct {
+  ServerEventBase
+  // The transcription session resource.
+  Session ServerSession `json:"session"`
 }
 
 // SessionUpdatedEvent is the event for session updated.


### PR DESCRIPTION
**Description**

As revealed here: https://github.com/richiejp/VoxInput/issues/22 we don't send the right session created event.

This PR matches the behaviour of the OpenAI API. As well as the adding the right session created event, this also no longer sends the conversation created event.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->
