### PR TITLE
Revert "chore(chatterbox): bump l4t index to support more recent pytorch"

### DIFF
--- a/backend/python/chatterbox/requirements-l4t.txt
+++ b/backend/python/chatterbox/requirements-l4t.txt
@@ -1,4 +1,4 @@
---extra-index-url https://pypi.jetson-ai-lab.io/jp6/cu129/
+--extra-index-url https://pypi.jetson-ai-lab.io/jp6/cu126/
 torch
 torchaudio
 transformers


### PR DESCRIPTION
Reverts mudler/LocalAI#7332

This didn't worked out as expected:

```
/backends/nvidia-l4t-arm64-chatterbox-development/venv/lib/python3.10/site-packages/torchaudio/lib/libtorchaudio.so: undefined symbol: _ZNK3c106SymInt6sym_neERKS0_
```

See https://forums.developer.nvidia.com/t/issue-with-torchaudio-undefined-symbol-znk5torch8autograd4node4nameev-when-using-gpu-enabled-pytorch-on-jetson-orin-nano-super-for-stt/323708/3