### PR TITLE
chore(l4t/diffusers): bump nvidia l4t index for pytorch 2.9

### DIFF
--- a/backend/python/diffusers/requirements-l4t.txt
+++ b/backend/python/diffusers/requirements-l4t.txt
@@ -1,4 +1,4 @@
---extra-index-url https://pypi.jetson-ai-lab.io/jp6/cu126/
+--extra-index-url https://pypi.jetson-ai-lab.io/jp6/cu129/
 torch
 git+https://github.com/huggingface/diffusers
 transformers


### PR DESCRIPTION
**Description**

This PR is an attempt to see if we can use cu129 repos that have torch 2.9 to support new chipsets such as GB10.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->