### PR TITLE
fix(paths): remove trailing slash from requests

### DIFF
--- a/core/http/app.go
+++ b/core/http/app.go
@@ -90,6 +90,8 @@ func API(application *application.Application) (*echo.Echo, error) {
 	// Middleware - StripPathPrefix must be registered early as it uses Rewrite which runs before routing
 	e.Pre(httpMiddleware.StripPathPrefix())
 
+	e.Pre(middleware.RemoveTrailingSlash())
+
 	if application.ApplicationConfig().MachineTag != "" {
 		e.Use(func(next echo.HandlerFunc) echo.HandlerFunc {
 			return func(c echo.Context) error {

--- a/core/http/routes/ui.go
+++ b/core/http/routes/ui.go
@@ -89,7 +89,7 @@ func RegisterUIRoutes(app *echo.Echo,
 	})
 
 	// P2P
-	app.GET("/p2p/", func(c echo.Context) error {
+	app.GET("/p2p", func(c echo.Context) error {
 		summary := map[string]interface{}{
 			"Title":   "LocalAI - P2P dashboard",
 			"BaseURL": middleware.BaseURL(c),
@@ -115,7 +115,7 @@ func RegisterUIRoutes(app *echo.Echo,
 		registerBackendGalleryRoutes(app, appConfig, galleryService, processingOps)
 	}
 
-	app.GET("/talk/", func(c echo.Context) error {
+	app.GET("/talk", func(c echo.Context) error {
 		modelConfigs, _ := services.ListModels(cl, ml, config.NoFilterFn, services.SKIP_IF_CONFIGURED)
 
 		if len(modelConfigs) == 0 {
@@ -136,7 +136,7 @@ func RegisterUIRoutes(app *echo.Echo,
 		return c.Render(200, "views/talk", summary)
 	})
 
-	app.GET("/chat/", func(c echo.Context) error {
+	app.GET("/chat", func(c echo.Context) error {
 		modelConfigs := cl.GetAllModelsConfigs()
 		modelsWithoutConfig, _ := services.ListModels(cl, ml, config.NoFilterFn, services.LOOSE_ONLY)
 
@@ -236,7 +236,7 @@ func RegisterUIRoutes(app *echo.Echo,
 		return c.Render(200, "views/text2image", summary)
 	})
 
-	app.GET("/text2image/", func(c echo.Context) error {
+	app.GET("/text2image", func(c echo.Context) error {
 		modelConfigs := cl.GetAllModelsConfigs()
 		modelsWithoutConfig, _ := services.ListModels(cl, ml, config.NoFilterFn, services.LOOSE_ONLY)
 
@@ -286,7 +286,7 @@ func RegisterUIRoutes(app *echo.Echo,
 		return c.Render(200, "views/tts", summary)
 	})
 
-	app.GET("/tts/", func(c echo.Context) error {
+	app.GET("/tts", func(c echo.Context) error {
 		modelConfigs := cl.GetAllModelsConfigs()
 		modelsWithoutConfig, _ := services.ListModels(cl, ml, config.NoFilterFn, services.LOOSE_ONLY)
 

--- a/core/http/routes/ui_gallery.go
+++ b/core/http/routes/ui_gallery.go
@@ -9,8 +9,7 @@ import (
 )
 
 func registerGalleryRoutes(app *echo.Echo, cl *config.ModelConfigLoader, appConfig *config.ApplicationConfig, galleryService *services.GalleryService, opcache *services.OpCache) {
-
-	app.GET("/browse/", func(c echo.Context) error {
+	app.GET("/browse", func(c echo.Context) error {
 		summary := map[string]interface{}{
 			"Title":        "LocalAI - Models",
 			"BaseURL":      middleware.BaseURL(c),


### PR DESCRIPTION
This removes any ambiguity from how paths are handled, and at the same time it uniforms the ui paths with the other paths that don't have a trailing slash
