### PR TITLE
fix(config): make syncKnownUsecasesFromString idempotent

### DIFF
--- a/core/config/model_config_filter.go
+++ b/core/config/model_config_filter.go
@@ -22,7 +22,7 @@ func BuildNameFilterFn(filter string) (ModelConfigFilterFn, error) {
 	}, nil
 }
 
-func BuildUsecaseFilterFn(usecases ModelConfigUsecases) ModelConfigFilterFn {
+func BuildUsecaseFilterFn(usecases ModelConfigUsecase) ModelConfigFilterFn {
 	if usecases == FLAG_ANY {
 		return NoFilterFn
 	}


### PR DESCRIPTION
**Description**

This PR fixes a discrepancy arose when we re-load the config YAML. We convert use-cases to a common format, which is then not respected if we recall the function again.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->