### PR TITLE
Revert "chore(deps): bump securego/gosec from 2.22.9 to 2.22.11"

### DIFF
--- a/.github/workflows/secscan.yaml
+++ b/.github/workflows/secscan.yaml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
       - name: Run Gosec Security Scanner
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: securego/gosec@v2.22.11
+        uses: securego/gosec@v2.22.9
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-no-fail -fmt sarif -out results.sarif ./...'


### PR DESCRIPTION
Reverts mudler/LocalAI#7588

This release breaks our pipelines: https://github.com/mudler/LocalAI/actions/runs/20261081633/job/58173094036