### PR TITLE
fix(ram): do not read from cgroup

### DIFF
--- a/pkg/xsysinfo/memory.go
+++ b/pkg/xsysinfo/memory.go
@@ -1,0 +1,47 @@
+package xsysinfo
+
+import (
+	sigar "github.com/cloudfoundry/gosigar"
+	"github.com/rs/zerolog/log"
+)
+
+// SystemRAMInfo contains system RAM usage information
+type SystemRAMInfo struct {
+	Total        uint64  `json:"total"`
+	Used         uint64  `json:"used"`
+	Free         uint64  `json:"free"`
+	Available    uint64  `json:"available"`
+	UsagePercent float64 `json:"usage_percent"`
+}
+
+// GetSystemRAMInfo returns real-time system RAM usage
+func GetSystemRAMInfo() (*SystemRAMInfo, error) {
+	total, used, free, err := getSystemRAM()
+	if err != nil {
+		return nil, err
+	}
+
+	usagePercent := 0.0
+	if total > 0 {
+		usagePercent = float64(used) / float64(total) * 100
+	}
+	log.Debug().Uint64("total", total).Uint64("used", used).Uint64("free", free).Float64("usage_percent", usagePercent).Msg("System RAM Info")
+	return &SystemRAMInfo{
+		Total:        total,
+		Used:         used,
+		Free:         free,
+		Available:    total - used,
+		UsagePercent: usagePercent,
+	}, nil
+}
+
+// getSystemRAM returns system RAM information using ghw
+func getSystemRAM() (total, used, free uint64, err error) {
+	mem := sigar.Mem{}
+
+	if err := mem.GetIgnoringCGroups(); err != nil {
+		return 0, 0, 0, err
+	}
+
+	return mem.Total, mem.ActualUsed, mem.ActualFree, nil
+}


### PR DESCRIPTION
**Description**

This PR refactors slightly xsysinfo and defaults to not read by cgroup which in this case would be misleading. Since LocalAI manages the host basically, and we spawn other processes, reading by cgroup would just give us a small glimpse of the actual RAM usage.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->