### PR TITLE
fix: correctly propagate error during model load

### DIFF
--- a/pkg/model/initializers.go
+++ b/pkg/model/initializers.go
@@ -173,9 +173,8 @@ func (ml *ModelLoader) backendLoader(opts ...Option) (client grpc.Backend, err e
 
 	model, err := ml.LoadModel(o.modelID, o.model, ml.grpcModel(backend, o))
 	if err != nil {
-		err := ml.StopGRPC(only(o.modelID))
-		if err != nil {
-			log.Error().Err(err).Str("model", o.modelID).Msg("error stopping model")
+		if stopErr := ml.StopGRPC(only(o.modelID));stopErr != nil {
+			log.Error().Err(stopErr).Str("model", o.modelID).Msg("error stopping model")
 		}
 		log.Error().Str("modelID", o.modelID).Err(err).Msgf("Failed to load model %s with backend %s", o.modelID, o.backendString)
 		return nil, err


### PR DESCRIPTION
**Description**

This PR fixes a shadowing bug when loading model fails and we don't correctly propagate errors to the caller. This causes a nil pointer dereference long the line because if the error is nil it is implied that a client is returned in many other code pieces. 

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->