### PR TITLE
feat(ROCm): Allow selecting ROCm version when building llama.cpp backend

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1193,7 +1193,7 @@ jobs:
             platforms: 'linux/amd64'
             skip-drivers: 'true'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-hipblas-exllama2'
+            tag-suffix: '-gpu-amd-rocm-6-exllama2'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             runs-on: 'ubuntu-latest'
             backend: "exllama2"
@@ -1219,7 +1219,7 @@ jobs:
           #   cuda-minor-version: ""
           #   platforms: 'linux/amd64'
           #   tag-latest: 'auto'
-          #   tag-suffix: '-gpu-hipblas-rfdetr'
+          #   tag-suffix: '-gpu-amd-rocm-6-rfdetr'
           #   base-image: "rocm/dev-ubuntu-24.04:6.4.4"
           #   runs-on: 'ubuntu-latest'
           #   skip-drivers: 'false'

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -21,6 +21,8 @@ jobs:
       build-type: ${{ matrix.build-type }}
       cuda-major-version: ${{ matrix.cuda-major-version }}
       cuda-minor-version: ${{ matrix.cuda-minor-version }}
+      rocm-major-version: ${{ matrix.rocm-major-version }}
+      rocm-minor-version: ${{ matrix.rocm-minor-version }}
       platforms: ${{ matrix.platforms }}
       runs-on: ${{ matrix.runs-on }}
       base-image: ${{ matrix.base-image }}

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -576,6 +576,19 @@ jobs:
             context: "./"
             ubuntu-version: '2404'
           - build-type: 'hipblas'
+            rocm-major-version: "7"
+            rocm-minor-version: "1.1"
+            platforms: 'linux/amd64'
+            tag-latest: 'auto'
+            tag-suffix: '-gpu-amd-rocm-7-llama-cpp'
+            runs-on: 'ubuntu-latest'
+            base-image: "ubuntu:22.04"
+            skip-drivers: 'false'
+            backend: "llama-cpp"
+            dockerfile: "./backend/Dockerfile.llama-cpp"
+            context: "./"
+            ubuntu-version: '2204'
+          - build-type: 'hipblas'
             cuda-major-version: ""
             cuda-minor-version: ""
             platforms: 'linux/amd64'

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -554,7 +554,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-rerankers'
+            tag-suffix: '-gpu-amd-rocm-6-rerankers'
             runs-on: 'ubuntu-latest'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -563,13 +563,13 @@ jobs:
             context: "./"
             ubuntu-version: '2404'
           - build-type: 'hipblas'
-            cuda-major-version: ""
-            cuda-minor-version: ""
+            rocm-major-version: "6"
+            rocm-minor-version: "4.3"
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-llama-cpp'
+            tag-suffix: '-gpu-amd-rocm-6-llama-cpp'
             runs-on: 'ubuntu-latest'
-            base-image: "rocm/dev-ubuntu-24.04:6.4.4"
+            base-image: "ubuntu:24.04"
             skip-drivers: 'false'
             backend: "llama-cpp"
             dockerfile: "./backend/Dockerfile.llama-cpp"
@@ -580,7 +580,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-vllm'
+            tag-suffix: '-gpu-amd-rocm-6-vllm'
             runs-on: 'arc-runner-set'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -593,7 +593,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-transformers'
+            tag-suffix: '-gpu-amd-rocm-6-transformers'
             runs-on: 'arc-runner-set'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -606,7 +606,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-diffusers'
+            tag-suffix: '-gpu-amd-rocm-6-diffusers'
             runs-on: 'arc-runner-set'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -620,7 +620,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-kokoro'
+            tag-suffix: '-gpu-amd-rocm-6-kokoro'
             runs-on: 'arc-runner-set'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -633,7 +633,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-vibevoice'
+            tag-suffix: '-gpu-amd-rocm-6-vibevoice'
             runs-on: 'arc-runner-set'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -646,7 +646,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-faster-whisper'
+            tag-suffix: '-gpu-amd-rocm-6-faster-whisper'
             runs-on: 'ubuntu-latest'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -659,7 +659,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-coqui'
+            tag-suffix: '-gpu-amd-rocm-6-coqui'
             runs-on: 'ubuntu-latest'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -672,7 +672,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-bark'
+            tag-suffix: '-gpu-amd-rocm-6-bark'
             runs-on: 'arc-runner-set'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'
@@ -1055,7 +1055,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-whisper'
+            tag-suffix: '-gpu-amd-rocm-6-whisper'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             runs-on: 'ubuntu-latest'
             skip-drivers: 'false'
@@ -1244,7 +1244,7 @@ jobs:
             cuda-minor-version: ""
             platforms: 'linux/amd64'
             tag-latest: 'auto'
-            tag-suffix: '-gpu-rocm-hipblas-neutts'
+            tag-suffix: '-gpu-amd-rocm-6-neutts'
             runs-on: 'arc-runner-set'
             base-image: "rocm/dev-ubuntu-24.04:6.4.4"
             skip-drivers: 'false'

--- a/.github/workflows/backend_build.yml
+++ b/.github/workflows/backend_build.yml
@@ -20,6 +20,14 @@ on:
         description: 'CUDA minor version'
         default: "1"
         type: string
+      rocm-major-version:
+        description: 'ROCm major version'
+        default: "6"
+        type: string
+      rocm-minor-version:
+        description: 'ROCm minor version'
+        default: "3.4"
+        type: string
       platforms:
         description: 'Platforms'
         default: ''

--- a/.github/workflows/backend_build.yml
+++ b/.github/workflows/backend_build.yml
@@ -26,7 +26,7 @@ on:
         type: string
       rocm-minor-version:
         description: 'ROCm minor version'
-        default: "3.4"
+        default: "4.3"
         type: string
       platforms:
         description: 'Platforms'

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -1,17 +1,17 @@
 ---
   name: 'build container images'
-  
+
   on:
     push:
       branches:
         - master
       tags:
         - '*'
-  
+
   concurrency:
     group: ci-${{ github.head_ref || github.ref }}-${{ github.repository }}
     cancel-in-progress: true
-  
+
   jobs:
     hipblas-jobs:
       uses: ./.github/workflows/image_build.yml
@@ -38,9 +38,11 @@
         matrix:
           include:
             - build-type: 'hipblas'
+              rocm-major-version: "6"
+              rocm-minor-version: "4.3"
               platforms: 'linux/amd64'
               tag-latest: 'auto'
-              tag-suffix: '-gpu-hipblas'
+              tag-suffix: '-gpu-amd-rocm-6'
               base-image: "rocm/dev-ubuntu-24.04:6.4.4"
               grpc-base-image: "ubuntu:24.04"
               runs-on: 'ubuntu-latest'
@@ -48,7 +50,7 @@
               aio: "-aio-gpu-hipblas"
               ubuntu-version: '2404'
               ubuntu-codename: 'noble'
-  
+
     core-image-build:
       uses: ./.github/workflows/image_build.yml
       with:
@@ -134,7 +136,7 @@
               aio: "-aio-gpu-intel"
               ubuntu-version: '2404'
               ubuntu-codename: 'noble'
-  
+
     gh-runner:
       uses: ./.github/workflows/image_build.yml
       with:
@@ -184,4 +186,3 @@
               skip-drivers: 'false'
               ubuntu-version: '2404'
               ubuntu-codename: 'noble'
-  

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -50,6 +50,17 @@
               aio: "-aio-gpu-hipblas"
               ubuntu-version: '2404'
               ubuntu-codename: 'noble'
+            - build-type: 'hipblas'
+              rocm-major-version: "7"
+              rocm-minor-version: "1.1"
+              platforms: 'linux/amd64'
+              tag-latest: 'auto'
+              tag-suffix: '-gpu-amd-rocm-7'
+              base-image: "ubuntu:24.04"
+              runs-on: 'ubuntu-latest'
+              makeflags: "--jobs=3 --output-sync=target"
+              aio: "-aio-gpu-amd-rocm-7"
+              ubuntu-version: '2204'
 
     core-image-build:
       uses: ./.github/workflows/image_build.yml

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -43,7 +43,7 @@
               platforms: 'linux/amd64'
               tag-latest: 'auto'
               tag-suffix: '-gpu-amd-rocm-6'
-              base-image: "rocm/dev-ubuntu-24.04:6.4.4"
+              base-image: "ubuntu:24.04"
               grpc-base-image: "ubuntu:24.04"
               runs-on: 'ubuntu-latest'
               makeflags: "--jobs=3 --output-sync=target"

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ FROM requirements AS requirements-drivers
 ARG BUILD_TYPE
 ARG CUDA_MAJOR_VERSION=12
 ARG CUDA_MINOR_VERSION=0
-ARG ROCM_MAJOR_VERSION=6
-ARG ROCM_MINOR_VERSION=1 # ROCm version to append to the major version, in the format of their apt repo (https://repo.radeon.com/rocm/apt/). Like `0_alpha` or `3.4`.
+ARG ROCM_MAJOR_VERSION=5
+ARG ROCM_MINOR_VERSION=5.1 # ROCm version to append to the major version, in the format of their apt repo (https://repo.radeon.com/rocm/apt/). Like `0_alpha` or `3.4`.
 ARG SKIP_DRIVERS=false
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/Dockerfile
+++ b/Dockerfile
@@ -162,15 +162,11 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
         echo "Package: *" >> /etc/apt/preferences.d/rocm-pin-600 && \
         echo "Pin: release o=repo.radeon.com" >> /etc/apt/preferences.d/rocm-pin-600 && \
         echo "Pin-Priority: 600" >> /etc/apt/preferences.d/rocm-pin-600 && \
-        # End setup steps for specific ROCm version
+        # End setup steps for specific ROCm version - the packages below will be installed from the configured repositories
         apt-get update && \
         apt-get install -y --no-install-recommends \
-            # Build dependencies
-            rocm-developer-tools \
-            rocm-hip-runtime-dev \
-            rocm-hip-sdk \
-            # Metapackage for the ROCm runtime + client tools
-            rocm && \
+            rocblas-dev \
+            hipblas-dev && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* && \
         echo "amd" > /run/localai/capability && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -169,8 +169,6 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
             rocm-developer-tools \
             rocm-hip-runtime-dev \
             rocm-hip-sdk \
-            hipblas-dev \
-            rocblas-dev \
             # Metapackage for the ROCm runtime + client tools
             rocm && \
         apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,6 +165,9 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
         # End setup steps for specific ROCm version
         apt-get update && \
         apt-get install -y --no-install-recommends \
+            rocm-developer-tools \
+            rocm-hip-runtime-dev \
+            rocm-hip-sdk \
             hipblas-dev \
             rocblas-dev && \
         apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,7 +170,7 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
             hipblas-dev && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* && \
-        echo "amd" > /run/localai/capability && \
+        echo "amd-rocm-${ROCM_MAJOR_VERSION}" > /run/localai/capability && \
         # I have no idea why, but the ROCM lib packages don't trigger ldconfig after they install, which results in local-ai and others not being able
         # to locate the libraries. We run ldconfig ourselves to work around this packaging deficiency
         ldconfig \

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,8 +165,9 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
         # End setup steps for specific ROCm version - the packages below will be installed from the configured repositories
         apt-get update && \
         apt-get install -y --no-install-recommends \
-            rocblas-dev \
-            hipblas-dev && \
+            rocm-hip-runtime # Gives libomp.so\
+            rocblas-dev # Give librocblas.so \
+            hipblas-dev # Gives libhipblas.so && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* && \
         echo "amd" > /run/localai/capability && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,11 +165,14 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
         # End setup steps for specific ROCm version
         apt-get update && \
         apt-get install -y --no-install-recommends \
+            # Build dependencies
             rocm-developer-tools \
             rocm-hip-runtime-dev \
             rocm-hip-sdk \
             hipblas-dev \
-            rocblas-dev && \
+            rocblas-dev \
+            # Metapackage for the ROCm runtime + client tools
+            rocm && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* && \
         echo "amd" > /run/localai/capability && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -165,9 +165,9 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
         # End setup steps for specific ROCm version - the packages below will be installed from the configured repositories
         apt-get update && \
         apt-get install -y --no-install-recommends \
-            rocm-hip-runtime # Gives libomp.so\
-            rocblas-dev # Give librocblas.so \
-            hipblas-dev # Gives libhipblas.so && \
+            rocm-hip-runtime \
+            rocblas-dev \
+            hipblas-dev && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* && \
         echo "amd" > /run/localai/capability && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ FROM requirements AS requirements-drivers
 ARG BUILD_TYPE
 ARG CUDA_MAJOR_VERSION=12
 ARG CUDA_MINOR_VERSION=0
-ARG ROCM_MAJOR_VERSION=5
-ARG ROCM_MINOR_VERSION=5.1 # ROCm version to append to the major version, in the format of their apt repo (https://repo.radeon.com/rocm/apt/). Like `0_alpha` or `3.4`.
+ARG ROCM_MAJOR_VERSION=6
+ARG ROCM_MINOR_VERSION=4.3 # ROCm version to append to the major version, in the format of their apt repo (https://repo.radeon.com/rocm/apt/). Like `0_alpha` or `3.4`.
 ARG SKIP_DRIVERS=false
 ARG TARGETARCH
 ARG TARGETVARIANT

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ FROM requirements AS requirements-drivers
 ARG BUILD_TYPE
 ARG CUDA_MAJOR_VERSION=12
 ARG CUDA_MINOR_VERSION=0
-ARG ROCM_VERSION=6.1.0 # ROCm version, in the format of their apt repo (https://repo.radeon.com/rocm/apt/). Like `latest` or `7.0_alpha` or `6.3.4`.
+ARG ROCM_MAJOR_VERSION=6
+ARG ROCM_MINOR_VERSION=1 # ROCm version to append to the major version, in the format of their apt repo (https://repo.radeon.com/rocm/apt/). Like `0_alpha` or `3.4`.
 ARG SKIP_DRIVERS=false
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -148,13 +149,16 @@ RUN if [ "${BUILD_TYPE}" = "clblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then \
 
 RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then \
         # Setup for specific ROCm version as described here: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/install-methods/package-manager/package-manager-ubuntu.html
+        ROCM_VERSION="${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}" && \
         apt-get update && \
         apt-get install -y --no-install-recommends \
             gpg wget && \
         mkdir --parents --mode=0755 /etc/apt/keyrings && \
         wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key | gpg --yes --dearmor --output /etc/apt/keyrings/rocm.gpg && \
         echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} jammy main" >> /etc/apt/sources.list.d/rocm.list && \
-        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/${ROCM_VERSION}/ubuntu jammy main" >> /etc/apt/sources.list.d/rocm.list && \
+        if [ "${ROCM_MAJOR_VERSION}" -ge 7 ]; then \
+            echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/${ROCM_VERSION}/ubuntu jammy main" >> /etc/apt/sources.list.d/rocm.list \
+        ; fi && \
         echo "Package: *" >> /etc/apt/preferences.d/rocm-pin-600 && \
         echo "Pin: release o=repo.radeon.com" >> /etc/apt/preferences.d/rocm-pin-600 && \
         echo "Pin-Priority: 600" >> /etc/apt/preferences.d/rocm-pin-600 && \

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 > :bulb: Get help - [❓FAQ](https://localai.io/faq/) [💭Discussions](https://github.com/go-skynet/LocalAI/discussions) [:speech_balloon: Discord](https://discord.gg/uJAeKSAGDy) [:book: Documentation website](https://localai.io/)
 >
-> [💻 Quickstart](https://localai.io/basics/getting_started/) [🖼️ Models](https://models.localai.io/) [🚀 Roadmap](https://github.com/mudler/LocalAI/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap) [🛫 Examples](https://github.com/mudler/LocalAI-examples) Try on 
+> [💻 Quickstart](https://localai.io/basics/getting_started/) [🖼️ Models](https://models.localai.io/) [🚀 Roadmap](https://github.com/mudler/LocalAI/issues?q=is%3Aissue+is%3Aopen+label%3Aroadmap) [🛫 Examples](https://github.com/mudler/LocalAI-examples) Try on
 [![Telegram](https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white)](https://t.me/localaiofficial_bot)
 
 [![tests](https://github.com/go-skynet/LocalAI/actions/workflows/test.yml/badge.svg)](https://github.com/go-skynet/LocalAI/actions/workflows/test.yml)[![Build and Release](https://github.com/go-skynet/LocalAI/actions/workflows/release.yaml/badge.svg)](https://github.com/go-skynet/LocalAI/actions/workflows/release.yaml)[![build container images](https://github.com/go-skynet/LocalAI/actions/workflows/image.yml/badge.svg)](https://github.com/go-skynet/LocalAI/actions/workflows/image.yml)[![Bump dependencies](https://github.com/go-skynet/LocalAI/actions/workflows/bump_deps.yaml/badge.svg)](https://github.com/go-skynet/LocalAI/actions/workflows/bump_deps.yaml)[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/localai)](https://artifacthub.io/packages/search?repo=localai)
@@ -131,10 +131,10 @@ For more installation options, see [Installer Options](https://localai.io/instal
 Or run with docker:
 
 > **💡 Docker Run vs Docker Start**
-> 
+>
 > - `docker run` creates and starts a new container. If a container with the same name already exists, this command will fail.
 > - `docker start` starts an existing container that was previously created with `docker run`.
-> 
+>
 > If you've already run LocalAI before and want to start it again, use: `docker start -i local-ai`
 
 ### CPU only image:
@@ -163,7 +163,7 @@ docker run -ti --name local-ai -p 8080:8080 --gpus all localai/localai:latest-nv
 ### AMD GPU Images (ROCm):
 
 ```bash
-docker run -ti --name local-ai -p 8080:8080 --device=/dev/kfd --device=/dev/dri --group-add=video localai/localai:latest-gpu-hipblas
+docker run -ti --name local-ai -p 8080:8080 --device=/dev/kfd --device=/dev/dri --group-add=video localai/localai:latest-gpu-amd-rocm-6
 ```
 
 ### Intel GPU Images (oneAPI):
@@ -194,7 +194,7 @@ docker run -ti --name local-ai -p 8080:8080 --gpus all localai/localai:latest-ai
 docker run -ti --name local-ai -p 8080:8080 localai/localai:latest-aio-gpu-intel
 
 # AMD GPU version
-docker run -ti --name local-ai -p 8080:8080 --device=/dev/kfd --device=/dev/dri --group-add=video localai/localai:latest-aio-gpu-hipblas
+docker run -ti --name local-ai -p 8080:8080 --device=/dev/kfd --device=/dev/dri --group-add=video localai/localai:latest-aio-gpu-amd-rocm-6
 ```
 
 For more information about the AIO images and pre-downloaded models, see [Container Documentation](https://localai.io/basics/container/).
@@ -254,7 +254,7 @@ Roadmap items: [List of issues](https://github.com/mudler/LocalAI/issues?q=is%3A
 - 🗣 [Text to Audio](https://localai.io/features/text-to-audio/)
 - 🔈 [Audio to Text](https://localai.io/features/audio-to-text/) (Audio transcription with `whisper.cpp`)
 - 🎨 [Image generation](https://localai.io/features/image-generation)
-- 🔥 [OpenAI-alike tools API](https://localai.io/features/openai-functions/) 
+- 🔥 [OpenAI-alike tools API](https://localai.io/features/openai-functions/)
 - 🧠 [Embeddings generation for vector databases](https://localai.io/features/embeddings/)
 - ✍️ [Constrained grammars](https://localai.io/features/constrained_grammars/)
 - 🖼️ [Download Models directly from Huggingface ](https://localai.io/models/)
@@ -362,7 +362,7 @@ Other:
 - Github bot which answer on issues, with code and documentation as context https://github.com/JackBekket/GitHelper
 - Github Actions: https://github.com/marketplace/actions/start-localai
 - Examples: https://github.com/mudler/LocalAI/tree/master/examples/
-  
+
 
 ### 🔗 Resources
 

--- a/backend/Dockerfile.llama-cpp
+++ b/backend/Dockerfile.llama-cpp
@@ -63,11 +63,13 @@ ARG BUILD_TYPE
 ENV BUILD_TYPE=${BUILD_TYPE}
 ARG CUDA_MAJOR_VERSION
 ARG CUDA_MINOR_VERSION
+ARG ROCM_MAJOR_VERSION
+ARG ROCM_MINOR_VERSION
 ARG SKIP_DRIVERS=false
 ENV CUDA_MAJOR_VERSION=${CUDA_MAJOR_VERSION}
 ENV CUDA_MINOR_VERSION=${CUDA_MINOR_VERSION}
-ARG ROCM_MAJOR_VERSION=7
-ARG ROCM_MINOR_VERSION=1.1 # ROCm version to append to the major version, in the format of their apt repo (https://repo.radeon.com/rocm/apt/). Like `0_alpha` or `3.4`.
+ENV ROCM_MAJOR_VERSION=${ROCM_MAJOR_VERSION}
+ENV ROCM_MINOR_VERSION=${ROCM_MINOR_VERSION}
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -223,9 +225,7 @@ RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then 
             # Build dependencies
             rocm-developer-tools \
             rocm-hip-runtime-dev \
-            rocm-hip-sdk \
-            # Metapackage for the ROCm runtime + client tools
-            rocm && \
+            rocm-hip-sdk && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* && \
         # I have no idea why, but the ROCM lib packages don't trigger ldconfig after they install, which results in local-ai and others not being able

--- a/backend/Dockerfile.llama-cpp
+++ b/backend/Dockerfile.llama-cpp
@@ -66,6 +66,8 @@ ARG CUDA_MINOR_VERSION
 ARG SKIP_DRIVERS=false
 ENV CUDA_MAJOR_VERSION=${CUDA_MAJOR_VERSION}
 ENV CUDA_MINOR_VERSION=${CUDA_MINOR_VERSION}
+ARG ROCM_MAJOR_VERSION=7
+ARG ROCM_MINOR_VERSION=1.1 # ROCm version to append to the major version, in the format of their apt repo (https://repo.radeon.com/rocm/apt/). Like `0_alpha` or `3.4`.
 ENV DEBIAN_FRONTEND=noninteractive
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -201,10 +203,29 @@ RUN if [ "${BUILD_TYPE}" = "clblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then \
     ; fi
 
 RUN if [ "${BUILD_TYPE}" = "hipblas" ] && [ "${SKIP_DRIVERS}" = "false" ]; then \
+        # Setup for specific ROCm version as described here: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/install-methods/package-manager/package-manager-ubuntu.html
+        ROCM_VERSION="${ROCM_MAJOR_VERSION}.${ROCM_MINOR_VERSION}" && \
         apt-get update && \
         apt-get install -y --no-install-recommends \
-            hipblas-dev \
-            rocblas-dev && \
+            gpg wget && \
+        mkdir --parents --mode=0755 /etc/apt/keyrings && \
+        wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key | gpg --yes --dearmor --output /etc/apt/keyrings/rocm.gpg && \
+        echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} jammy main" >> /etc/apt/sources.list.d/rocm.list && \
+        if [ "${ROCM_MAJOR_VERSION}" -ge 7 ]; then \
+            echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/graphics/${ROCM_VERSION}/ubuntu jammy main" >> /etc/apt/sources.list.d/rocm.list \
+        ; fi && \
+        echo "Package: *" >> /etc/apt/preferences.d/rocm-pin-600 && \
+        echo "Pin: release o=repo.radeon.com" >> /etc/apt/preferences.d/rocm-pin-600 && \
+        echo "Pin-Priority: 600" >> /etc/apt/preferences.d/rocm-pin-600 && \
+        # End setup steps for specific ROCm version
+        apt-get update && \
+        apt-get install -y --no-install-recommends \
+            # Build dependencies
+            rocm-developer-tools \
+            rocm-hip-runtime-dev \
+            rocm-hip-sdk \
+            # Metapackage for the ROCm runtime + client tools
+            rocm && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/* && \
         # I have no idea why, but the ROCM lib packages don't trigger ldconfig after they install, which results in local-ai and others not being able

--- a/backend/index.yaml
+++ b/backend/index.yaml
@@ -993,9 +993,9 @@
     - localai/localai-backends:latest-gpu-intel-rfdetr
 # - !!merge <<: *rfdetr
 #   name: "rocm6-rfdetr"
-#   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-hipblas-rfdetr"
+#   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-rfdetr"
 #   mirrors:
-#     - localai/localai-backends:latest-gpu-hipblas-rfdetr
+#     - localai/localai-backends:latest-gpu-amd-rocm-6-rfdetr
 - !!merge <<: *rfdetr
   name: "nvidia-l4t-arm64-rfdetr"
   uri: "quay.io/go-skynet/local-ai-backends:latest-nvidia-l4t-arm64-rfdetr"
@@ -1023,9 +1023,9 @@
     - localai/localai-backends:master-gpu-intel-rfdetr
 # - !!merge <<: *rfdetr
 #   name: "rocm6-rfdetr-development"
-#   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-hipblas-rfdetr"
+#   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-rfdetr"
 #   mirrors:
-#     - localai/localai-backends:master-gpu-hipblas-rfdetr
+#     - localai/localai-backends:master-gpu-amd-rocm-6-rfdetr
 - !!merge <<: *rfdetr
   name: "cpu-rfdetr-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-cpu-rfdetr"

--- a/backend/index.yaml
+++ b/backend/index.yaml
@@ -21,7 +21,7 @@
     default: "cpu-llama-cpp"
     nvidia: "cuda12-llama-cpp"
     intel: "intel-sycl-f16-llama-cpp"
-    amd: "rocm-llama-cpp"
+    amd-rocm-6: "rocm6-llama-cpp"
     metal: "metal-llama-cpp"
     vulkan: "vulkan-llama-cpp"
     nvidia-l4t: "nvidia-l4t-arm64-llama-cpp"
@@ -49,7 +49,7 @@
     nvidia: "cuda12-whisper"
     intel: "intel-sycl-f16-whisper"
     metal: "metal-whisper"
-    amd: "rocm-whisper"
+    amd-rocm-6: "rocm6-whisper"
     vulkan: "vulkan-whisper"
     nvidia-l4t: "nvidia-l4t-arm64-whisper"
     nvidia-cuda-13: "cuda13-whisper"
@@ -76,7 +76,7 @@
     default: "cpu-stablediffusion-ggml"
     nvidia: "cuda12-stablediffusion-ggml"
     intel: "intel-sycl-f16-stablediffusion-ggml"
-    # amd: "rocm-stablediffusion-ggml"
+    # amd-rocm-6: "rocm6-stablediffusion-ggml"
     vulkan: "vulkan-stablediffusion-ggml"
     nvidia-l4t: "nvidia-l4t-arm64-stablediffusion-ggml"
     metal: "metal-stablediffusion-ggml"
@@ -103,7 +103,7 @@
   capabilities:
     nvidia: "cuda12-rfdetr"
     intel: "intel-rfdetr"
-    #amd: "rocm-rfdetr"
+    #amd-rocm-6: "rocm6-rfdetr"
     nvidia-l4t: "nvidia-l4t-arm64-rfdetr"
     default: "cpu-rfdetr"
     nvidia-cuda-13: "cuda13-rfdetr"
@@ -139,7 +139,7 @@
   alias: "vllm"
   capabilities:
     nvidia: "cuda12-vllm"
-    amd: "rocm-vllm"
+    amd-rocm-6: "rocm6-vllm"
     intel: "intel-vllm"
     nvidia-cuda-12: "cuda12-vllm"
 - &mlx
@@ -197,7 +197,7 @@
   capabilities:
     nvidia: "cuda12-rerankers"
     intel: "intel-rerankers"
-    amd: "rocm-rerankers"
+    amd-rocm-6: "rocm6-rerankers"
 - &transformers
   name: "transformers"
   icon: https://camo.githubusercontent.com/26569a27b8a30a488dd345024b71dbc05da7ff1b2ba97bb6080c9f1ee0f26cc7/68747470733a2f2f68756767696e67666163652e636f2f64617461736574732f68756767696e67666163652f646f63756d656e746174696f6e2d696d616765732f7265736f6c76652f6d61696e2f7472616e73666f726d6572732f7472616e73666f726d6572735f61735f615f6d6f64656c5f646566696e6974696f6e2e706e67
@@ -214,7 +214,7 @@
   capabilities:
     nvidia: "cuda12-transformers"
     intel: "intel-transformers"
-    amd: "rocm-transformers"
+    amd-rocm-6: "rocm6-transformers"
     nvidia-cuda-13: "cuda13-transformers"
     nvidia-cuda-12: "cuda12-transformers"
 - &diffusers
@@ -233,7 +233,7 @@
   capabilities:
     nvidia: "cuda12-diffusers"
     intel: "intel-diffusers"
-    amd: "rocm-diffusers"
+    amd-rocm-6: "rocm6-diffusers"
     nvidia-l4t: "nvidia-l4t-diffusers"
     metal: "metal-diffusers"
     default: "cpu-diffusers"
@@ -272,7 +272,7 @@
   capabilities:
     nvidia: "cuda12-faster-whisper"
     intel: "intel-faster-whisper"
-    amd: "rocm-faster-whisper"
+    amd-rocm-6: "rocm6-faster-whisper"
     nvidia-cuda-13: "cuda13-faster-whisper"
     nvidia-cuda-12: "cuda12-faster-whisper"
 - &moonshine
@@ -310,7 +310,7 @@
   capabilities:
     nvidia: "cuda12-kokoro"
     intel: "intel-kokoro"
-    amd: "rocm-kokoro"
+    amd-rocm-6: "rocm6-kokoro"
     nvidia-l4t: "nvidia-l4t-kokoro"
     nvidia-cuda-13: "cuda13-kokoro"
     nvidia-cuda-12: "cuda12-kokoro"
@@ -335,7 +335,7 @@
   capabilities:
     nvidia: "cuda12-coqui"
     intel: "intel-coqui"
-    amd: "rocm-coqui"
+    amd-rocm-6: "rocm6-coqui"
     nvidia-cuda-13: "cuda13-coqui"
     nvidia-cuda-12: "cuda12-coqui"
   icon: https://avatars.githubusercontent.com/u/1338804?s=200&v=4
@@ -420,7 +420,7 @@
   capabilities:
     nvidia: "cuda12-vibevoice"
     intel: "intel-vibevoice"
-    amd: "rocm-vibevoice"
+    amd-rocm-6: "rocm6-vibevoice"
     nvidia-l4t: "nvidia-l4t-vibevoice"
     default: "cpu-vibevoice"
     nvidia-cuda-13: "cuda13-vibevoice"
@@ -514,7 +514,7 @@
   capabilities:
     default: "cpu-neutts"
     nvidia: "cuda12-neutts"
-    amd: "rocm-neutts"
+    amd-rocm-6: "rocm6-neutts"
     nvidia-l4t: "nvidia-l4t-neutts"
     nvidia-cuda-12: "cuda12-neutts"
     nvidia-l4t-cuda-12: "nvidia-l4t-arm64-neutts"
@@ -523,7 +523,7 @@
   capabilities:
     default: "cpu-neutts-development"
     nvidia: "cuda12-neutts-development"
-    amd: "rocm-neutts-development"
+    amd-rocm-6: "rocm6-neutts-development"
     nvidia-l4t: "nvidia-l4t-neutts-development"
     nvidia-cuda-12: "cuda12-neutts-development"
     nvidia-l4t-cuda-12: "nvidia-l4t-arm64-neutts-development"
@@ -533,7 +533,7 @@
     default: "cpu-llama-cpp-development"
     nvidia: "cuda12-llama-cpp-development"
     intel: "intel-sycl-f16-llama-cpp-development"
-    amd: "rocm-llama-cpp-development"
+    amd-rocm-6: "rocm6-llama-cpp-development"
     metal: "metal-llama-cpp-development"
     vulkan: "vulkan-llama-cpp-development"
     nvidia-l4t: "nvidia-l4t-arm64-llama-cpp-development"
@@ -552,10 +552,10 @@
   mirrors:
     - localai/localai-backends:latest-gpu-nvidia-cuda-12-neutts
 - !!merge <<: *neutts
-  name: "rocm-neutts"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-neutts"
+  name: "rocm6-neutts"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-neutts"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-neutts
+    - localai/localai-backends:latest-gpu-amd-rocm-6-neutts
 - !!merge <<: *neutts
   name: "nvidia-l4t-arm64-neutts"
   uri: "quay.io/go-skynet/local-ai-backends:latest-nvidia-l4t-arm64-neutts"
@@ -572,10 +572,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-neutts
 - !!merge <<: *neutts
-  name: "rocm-neutts-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-neutts"
+  name: "rocm6-neutts-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-neutts"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-neutts
+    - localai/localai-backends:master-gpu-amd-rocm-6-neutts
 - !!merge <<: *neutts
   name: "nvidia-l4t-arm64-neutts-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-nvidia-l4t-arm64-neutts"
@@ -658,10 +658,10 @@
   mirrors:
     - localai/localai-backends:latest-gpu-nvidia-cuda-12-llama-cpp
 - !!merge <<: *llamacpp
-  name: "rocm-llama-cpp"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-llama-cpp"
+  name: "rocm6-llama-cpp"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-llama-cpp"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-llama-cpp
+    - localai/localai-backends:latest-gpu-amd-rocm-6-llama-cpp
 - !!merge <<: *llamacpp
   name: "intel-sycl-f32-llama-cpp"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-sycl-f32-llama-cpp"
@@ -698,10 +698,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-llama-cpp
 - !!merge <<: *llamacpp
-  name: "rocm-llama-cpp-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-llama-cpp"
+  name: "rocm6-llama-cpp-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-llama-cpp"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-llama-cpp
+    - localai/localai-backends:master-gpu-amd-rocm-6-llama-cpp
 - !!merge <<: *llamacpp
   name: "intel-sycl-f32-llama-cpp-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-intel-sycl-f32-llama-cpp"
@@ -769,10 +769,10 @@
   mirrors:
     - localai/localai-backends:latest-gpu-nvidia-cuda-12-whisper
 - !!merge <<: *whispercpp
-  name: "rocm-whisper"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-whisper"
+  name: "rocm6-whisper"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-whisper"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-whisper
+    - localai/localai-backends:latest-gpu-amd-rocm-6-whisper
 - !!merge <<: *whispercpp
   name: "intel-sycl-f32-whisper"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-sycl-f32-whisper"
@@ -809,10 +809,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-whisper
 - !!merge <<: *whispercpp
-  name: "rocm-whisper-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-whisper"
+  name: "rocm6-whisper-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-whisper"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-whisper
+    - localai/localai-backends:master-gpu-amd-rocm-6-whisper
 - !!merge <<: *whispercpp
   name: "intel-sycl-f32-whisper-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-intel-sycl-f32-whisper"
@@ -927,7 +927,7 @@
   name: "vllm-development"
   capabilities:
     nvidia: "cuda12-vllm-development"
-    amd: "rocm-vllm-development"
+    amd-rocm-6: "rocm6-vllm-development"
     intel: "intel-vllm-development"
 - !!merge <<: *vllm
   name: "cuda12-vllm"
@@ -935,10 +935,10 @@
   mirrors:
     - localai/localai-backends:latest-gpu-nvidia-cuda-12-vllm
 - !!merge <<: *vllm
-  name: "rocm-vllm"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-vllm"
+  name: "rocm6-vllm"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-vllm"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-vllm
+    - localai/localai-backends:latest-gpu-amd-rocm-6-vllm
 - !!merge <<: *vllm
   name: "intel-vllm"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-vllm"
@@ -950,10 +950,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-vllm
 - !!merge <<: *vllm
-  name: "rocm-vllm-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-vllm"
+  name: "rocm6-vllm-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-vllm"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-vllm
+    - localai/localai-backends:master-gpu-amd-rocm-6-vllm
 - !!merge <<: *vllm
   name: "intel-vllm-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-intel-vllm"
@@ -965,7 +965,7 @@
   capabilities:
     nvidia: "cuda12-rfdetr-development"
     intel: "intel-rfdetr-development"
-    #amd: "rocm-rfdetr-development"
+    #amd-rocm-6: "rocm6-rfdetr-development"
     nvidia-l4t: "nvidia-l4t-arm64-rfdetr-development"
     default: "cpu-rfdetr-development"
     nvidia-cuda-13: "cuda13-rfdetr-development"
@@ -980,7 +980,7 @@
   mirrors:
     - localai/localai-backends:latest-gpu-intel-rfdetr
 # - !!merge <<: *rfdetr
-#   name: "rocm-rfdetr"
+#   name: "rocm6-rfdetr"
 #   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-hipblas-rfdetr"
 #   mirrors:
 #     - localai/localai-backends:latest-gpu-hipblas-rfdetr
@@ -1010,7 +1010,7 @@
   mirrors:
     - localai/localai-backends:master-gpu-intel-rfdetr
 # - !!merge <<: *rfdetr
-#   name: "rocm-rfdetr-development"
+#   name: "rocm6-rfdetr-development"
 #   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-hipblas-rfdetr"
 #   mirrors:
 #     - localai/localai-backends:master-gpu-hipblas-rfdetr
@@ -1040,7 +1040,7 @@
   capabilities:
     nvidia: "cuda12-rerankers-development"
     intel: "intel-rerankers-development"
-    amd: "rocm-rerankers-development"
+    amd-rocm-6: "rocm6-rerankers-development"
     nvidia-cuda-13: "cuda13-rerankers-development"
 - !!merge <<: *rerankers
   name: "cuda12-rerankers"
@@ -1053,8 +1053,8 @@
   mirrors:
     - localai/localai-backends:latest-gpu-intel-rerankers
 - !!merge <<: *rerankers
-  name: "rocm-rerankers"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-rerankers"
+  name: "rocm6-rerankers"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-rerankers"
   mirrors:
     - localai/localai-backends:latest-gpu-rocm-hipblas-rerankers
 - !!merge <<: *rerankers
@@ -1063,10 +1063,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-rerankers
 - !!merge <<: *rerankers
-  name: "rocm-rerankers-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-rerankers"
+  name: "rocm6-rerankers-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-rerankers"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-rerankers
+    - localai/localai-backends:master-gpu-amd-rocm-6-rerankers
 - !!merge <<: *rerankers
   name: "intel-rerankers-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-intel-rerankers"
@@ -1088,7 +1088,7 @@
   capabilities:
     nvidia: "cuda12-transformers-development"
     intel: "intel-transformers-development"
-    amd: "rocm-transformers-development"
+    amd-rocm-6: "rocm6-transformers-development"
     nvidia-cuda-13: "cuda13-transformers-development"
 - !!merge <<: *transformers
   name: "cuda12-transformers"
@@ -1096,10 +1096,10 @@
   mirrors:
     - localai/localai-backends:latest-gpu-nvidia-cuda-12-transformers
 - !!merge <<: *transformers
-  name: "rocm-transformers"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-transformers"
+  name: "rocm6-transformers"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-transformers"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-transformers
+    - localai/localai-backends:latest-gpu-amd-rocm-6-transformers
 - !!merge <<: *transformers
   name: "intel-transformers"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-transformers"
@@ -1111,10 +1111,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-transformers
 - !!merge <<: *transformers
-  name: "rocm-transformers-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-transformers"
+  name: "rocm6-transformers-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-transformers"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-transformers
+    - localai/localai-backends:master-gpu-amd-rocm-6-transformers
 - !!merge <<: *transformers
   name: "intel-transformers-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-intel-transformers"
@@ -1136,7 +1136,7 @@
   capabilities:
     nvidia: "cuda12-diffusers-development"
     intel: "intel-diffusers-development"
-    amd: "rocm-diffusers-development"
+    amd-rocm-6: "rocm6-diffusers-development"
     nvidia-l4t: "nvidia-l4t-diffusers-development"
     metal: "metal-diffusers-development"
     default: "cpu-diffusers-development"
@@ -1177,8 +1177,8 @@
   mirrors:
     - localai/localai-backends:latest-gpu-nvidia-cuda-12-diffusers
 - !!merge <<: *diffusers
-  name: "rocm-diffusers"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-diffusers"
+  name: "rocm6-diffusers"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-diffusers"
   mirrors:
     - localai/localai-backends:latest-gpu-rocm-hipblas-diffusers
 - !!merge <<: *diffusers
@@ -1192,10 +1192,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-diffusers
 - !!merge <<: *diffusers
-  name: "rocm-diffusers-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-diffusers"
+  name: "rocm6-diffusers-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-diffusers"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-diffusers
+    - localai/localai-backends:master-gpu-amd-rocm-6-diffusers
 - !!merge <<: *diffusers
   name: "intel-diffusers-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-intel-diffusers"
@@ -1243,7 +1243,7 @@
   capabilities:
     nvidia: "cuda12-kokoro-development"
     intel: "intel-kokoro-development"
-    amd: "rocm-kokoro-development"
+    amd-rocm-6: "rocm6-kokoro-development"
     nvidia-l4t: "nvidia-l4t-kokoro-development"
 - !!merge <<: *kokoro
   name: "cuda12-kokoro-development"
@@ -1251,10 +1251,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-kokoro
 - !!merge <<: *kokoro
-  name: "rocm-kokoro-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-kokoro"
+  name: "rocm6-kokoro-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-kokoro"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-kokoro
+    - localai/localai-backends:master-gpu-amd-rocm-6-kokoro
 - !!merge <<: *kokoro
   name: "intel-kokoro"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-kokoro"
@@ -1281,10 +1281,10 @@
   mirrors:
     - localai/localai-backends:latest-gpu-nvidia-cuda-12-kokoro
 - !!merge <<: *kokoro
-  name: "rocm-kokoro"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-kokoro"
+  name: "rocm6-kokoro"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-kokoro"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-kokoro
+    - localai/localai-backends:latest-gpu-amd-rocm-6-kokoro
 - !!merge <<: *kokoro
   name: "cuda13-kokoro"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-nvidia-cuda-13-kokoro"
@@ -1301,7 +1301,7 @@
   capabilities:
     nvidia: "cuda12-faster-whisper-development"
     intel: "intel-faster-whisper-development"
-    amd: "rocm-faster-whisper-development"
+    amd-rocm-6: "rocm6-faster-whisper-development"
     nvidia-cuda-13: "cuda13-faster-whisper-development"
 - !!merge <<: *faster-whisper
   name: "cuda12-faster-whisper-development"
@@ -1309,10 +1309,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-faster-whisper
 - !!merge <<: *faster-whisper
-  name: "rocm-faster-whisper-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-faster-whisper"
+  name: "rocm6-faster-whisper-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-faster-whisper"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-faster-whisper
+    - localai/localai-backends:master-gpu-amd-rocm-6-faster-whisper
 - !!merge <<: *faster-whisper
   name: "intel-faster-whisper"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-faster-whisper"
@@ -1378,7 +1378,7 @@
   capabilities:
     nvidia: "cuda12-coqui-development"
     intel: "intel-coqui-development"
-    amd: "rocm-coqui-development"
+    amd-rocm-6: "rocm6-coqui-development"
 - !!merge <<: *coqui
   name: "cuda12-coqui"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-nvidia-cuda-12-coqui"
@@ -1390,10 +1390,10 @@
   mirrors:
     - localai/localai-backends:master-gpu-nvidia-cuda-12-coqui
 - !!merge <<: *coqui
-  name: "rocm-coqui-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-coqui"
+  name: "rocm6-coqui-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-coqui"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-coqui
+    - localai/localai-backends:master-gpu-amd-rocm-6-coqui
 - !!merge <<: *coqui
   name: "intel-coqui"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-coqui"
@@ -1405,22 +1405,22 @@
   mirrors:
     - localai/localai-backends:master-gpu-intel-coqui
 - !!merge <<: *coqui
-  name: "rocm-coqui"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-coqui"
+  name: "rocm6-coqui"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-coqui"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-coqui
+    - localai/localai-backends:latest-gpu-amd-rocm-6-coqui
 ## bark
 - !!merge <<: *bark
   name: "bark-development"
   capabilities:
     nvidia: "cuda12-bark-development"
     intel: "intel-bark-development"
-    amd: "rocm-bark-development"
+    amd-rocm-6: "rocm6-bark-development"
 - !!merge <<: *bark
-  name: "rocm-bark-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-bark"
+  name: "rocm6-bark-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-bark"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-bark
+    - localai/localai-backends:master-gpu-amd-rocm-6-bark
 - !!merge <<: *bark
   name: "intel-bark"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-bark"
@@ -1437,10 +1437,10 @@
   mirrors:
     - localai/localai-backends:latest-gpu-nvidia-cuda-12-bark
 - !!merge <<: *bark
-  name: "rocm-bark"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-bark"
+  name: "rocm6-bark"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-bark"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-bark
+    - localai/localai-backends:latest-gpu-amd-rocm-6-bark
 - !!merge <<: *bark
   name: "cuda12-bark-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-nvidia-cuda-12-bark"
@@ -1528,7 +1528,7 @@
   capabilities:
     nvidia: "cuda12-vibevoice-development"
     intel: "intel-vibevoice-development"
-    amd: "rocm-vibevoice-development"
+    amd-rocm-6: "rocm6-vibevoice-development"
     nvidia-l4t: "nvidia-l4t-vibevoice-development"
     default: "cpu-vibevoice-development"
     nvidia-cuda-13: "cuda13-vibevoice-development"
@@ -1576,15 +1576,15 @@
   mirrors:
     - localai/localai-backends:master-gpu-intel-vibevoice
 - !!merge <<: *vibevoice
-  name: "rocm-vibevoice"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-rocm-hipblas-vibevoice"
+  name: "rocm6-vibevoice"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-6-vibevoice"
   mirrors:
-    - localai/localai-backends:latest-gpu-rocm-hipblas-vibevoice
+    - localai/localai-backends:latest-gpu-amd-rocm-6-vibevoice
 - !!merge <<: *vibevoice
-  name: "rocm-vibevoice-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-vibevoice"
+  name: "rocm6-vibevoice-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-vibevoice"
   mirrors:
-    - localai/localai-backends:master-gpu-rocm-hipblas-vibevoice
+    - localai/localai-backends:master-gpu-amd-rocm-6-vibevoice
 - !!merge <<: *vibevoice
   name: "nvidia-l4t-vibevoice"
   uri: "quay.io/go-skynet/local-ai-backends:latest-nvidia-l4t-vibevoice"

--- a/backend/index.yaml
+++ b/backend/index.yaml
@@ -22,6 +22,7 @@
     nvidia: "cuda12-llama-cpp"
     intel: "intel-sycl-f16-llama-cpp"
     amd-rocm-6: "rocm6-llama-cpp"
+    amd-rocm-7: "rocm7-llama-cpp"
     metal: "metal-llama-cpp"
     vulkan: "vulkan-llama-cpp"
     nvidia-l4t: "nvidia-l4t-arm64-llama-cpp"
@@ -534,6 +535,7 @@
     nvidia: "cuda12-llama-cpp-development"
     intel: "intel-sycl-f16-llama-cpp-development"
     amd-rocm-6: "rocm6-llama-cpp-development"
+    amd-rocm-7: "rocm7-llama-cpp-development"
     metal: "metal-llama-cpp-development"
     vulkan: "vulkan-llama-cpp-development"
     nvidia-l4t: "nvidia-l4t-arm64-llama-cpp-development"
@@ -663,6 +665,11 @@
   mirrors:
     - localai/localai-backends:latest-gpu-amd-rocm-6-llama-cpp
 - !!merge <<: *llamacpp
+  name: "rocm7-llama-cpp"
+  uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-amd-rocm-7-llama-cpp"
+  mirrors:
+    - localai/localai-backends:latest-gpu-amd-rocm-7-llama-cpp
+- !!merge <<: *llamacpp
   name: "intel-sycl-f32-llama-cpp"
   uri: "quay.io/go-skynet/local-ai-backends:latest-gpu-intel-sycl-f32-llama-cpp"
   mirrors:
@@ -702,6 +709,11 @@
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-6-llama-cpp"
   mirrors:
     - localai/localai-backends:master-gpu-amd-rocm-6-llama-cpp
+- !!merge <<: *llamacpp
+  name: "rocm7-llama-cpp-development"
+  uri: "quay.io/go-skynet/local-ai-backends:master-gpu-amd-rocm-7-llama-cpp"
+  mirrors:
+    - localai/localai-backends:master-gpu-amd-rocm-7-llama-cpp
 - !!merge <<: *llamacpp
   name: "intel-sycl-f32-llama-cpp-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-intel-sycl-f32-llama-cpp"

--- a/docs/content/features/GPU-acceleration.md
+++ b/docs/content/features/GPU-acceleration.md
@@ -182,7 +182,7 @@ The following are examples of the ROCm specific configuration elements required.
 
 ```yaml
     # For full functionality select a non-'core' image, version locking the image is recommended for debug purposes.
-    image: quay.io/go-skynet/local-ai:master-aio-gpu-hipblas
+    image: quay.io/go-skynet/local-ai:master-aio-gpu-amd-rocm-6
     environment:
       - DEBUG=true
       # If your gpu is not already included in the current list of default targets the following build details are required.
@@ -205,7 +205,7 @@ docker run \
  -e GPU_TARGETS=gfx906 \
  --device /dev/dri \
  --device /dev/kfd \
- quay.io/go-skynet/local-ai:master-aio-gpu-hipblas
+ quay.io/go-skynet/local-ai:master-aio-gpu-amd-rocm-6
 ```
 
 Please ensure to add all other required environment variables, port forwardings, etc to your `compose` file or `run` command.

--- a/docs/content/getting-started/container-images.md
+++ b/docs/content/getting-started/container-images.md
@@ -84,9 +84,9 @@ Standard container images do not have pre-installed models. Use these if you wan
 
 | Description | Quay | Docker Hub                                                  |
 | --- | --- |-------------------------------------------------------------|
-| Latest images from the branch (development) | `quay.io/go-skynet/local-ai:master-gpu-hipblas` | `localai/localai:master-gpu-hipblas`                      |
-| Latest tag | `quay.io/go-skynet/local-ai:latest-gpu-hipblas` | `localai/localai:latest-gpu-hipblas`                      |
-| Versioned image | `quay.io/go-skynet/local-ai:{{< version >}}-gpu-hipblas` | `localai/localai:{{< version >}}-gpu-hipblas`             |
+| Latest images from the branch (development) | `quay.io/go-skynet/local-ai:master-gpu-amd-rocm-6` | `localai/localai:master-gpu-amd-rocm-6`                      |
+| Latest tag | `quay.io/go-skynet/local-ai:latest-gpu-amd-rocm-6` | `localai/localai:latest-gpu-amd-rocm-6`                      |
+| Versioned image | `quay.io/go-skynet/local-ai:{{< version >}}-gpu-amd-rocm-6` | `localai/localai:{{< version >}}-gpu-amd-rocm-6`             |
 
 {{% /tab %}}
 
@@ -190,7 +190,7 @@ services:
 
 **Models caching**: The **AIO** image will download the needed models on the first run if not already present and store those in `/models` inside the container. The AIO models will be automatically updated with new versions of AIO images.
 
-You can change the directory inside the container by specifying a `MODELS_PATH` environment variable (or `--models-path`). 
+You can change the directory inside the container by specifying a `MODELS_PATH` environment variable (or `--models-path`).
 
 If you want to use a named model or a local directory, you can mount it as a volume to `/models`:
 
@@ -215,7 +215,7 @@ docker run -p 8080:8080 --name local-ai -ti -v localai-models:/models localai/lo
 | Versioned image (e.g. for CPU) | `quay.io/go-skynet/local-ai:{{< version >}}-aio-cpu` | `localai/localai:{{< version >}}-aio-cpu`             |
 | Latest images for Nvidia GPU (CUDA12) | `quay.io/go-skynet/local-ai:latest-aio-gpu-nvidia-cuda-12` | `localai/localai:latest-aio-gpu-nvidia-cuda-12`                      |
 | Latest images for Nvidia GPU (CUDA13) | `quay.io/go-skynet/local-ai:latest-aio-gpu-nvidia-cuda-13` | `localai/localai:latest-aio-gpu-nvidia-cuda-13`                      |
-| Latest images for AMD GPU | `quay.io/go-skynet/local-ai:latest-aio-gpu-hipblas` | `localai/localai:latest-aio-gpu-hipblas`                      |
+| Latest images for AMD GPU | `quay.io/go-skynet/local-ai:latest-aio-gpu-amd-rocm-6` | `localai/localai:latest-aio-gpu-amd-rocm-6`                      |
 | Latest images for Intel GPU | `quay.io/go-skynet/local-ai:latest-aio-gpu-intel` | `localai/localai:latest-aio-gpu-intel`                      |
 
 ### Available environment variables

--- a/docs/content/installation/docker.md
+++ b/docs/content/installation/docker.md
@@ -70,7 +70,7 @@ docker run -ti --name local-ai -p 8080:8080 --gpus all localai/localai:latest-gp
 
 **AMD GPU (ROCm):**
 ```bash
-docker run -ti --name local-ai -p 8080:8080 --device=/dev/kfd --device=/dev/dri --group-add=video localai/localai:latest-gpu-hipblas
+docker run -ti --name local-ai -p 8080:8080 --device=/dev/kfd --device=/dev/dri --group-add=video localai/localai:latest-gpu-amd-rocm-6
 ```
 
 **Intel GPU:**
@@ -119,7 +119,7 @@ docker run -ti --name local-ai -p 8080:8080 --gpus all localai/localai:latest-ai
 
 **AMD GPU (ROCm):**
 ```bash
-docker run -ti --name local-ai -p 8080:8080 --device=/dev/kfd --device=/dev/dri --group-add=video localai/localai:latest-aio-gpu-hipblas
+docker run -ti --name local-ai -p 8080:8080 --device=/dev/kfd --device=/dev/dri --group-add=video localai/localai:latest-aio-gpu-amd-rocm-6
 ```
 
 **Intel GPU:**
@@ -140,7 +140,7 @@ services:
     # image: localai/localai:latest-aio-gpu-nvidia-cuda-13
     # image: localai/localai:latest-aio-gpu-nvidia-cuda-12
     # image: localai/localai:latest-aio-gpu-nvidia-cuda-11
-    # image: localai/localai:latest-aio-gpu-hipblas
+    # image: localai/localai:latest-aio-gpu-amd-rocm-6
     # image: localai/localai:latest-aio-gpu-intel
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/readyz"]

--- a/docs/static/install.sh
+++ b/docs/static/install.sh
@@ -702,10 +702,10 @@ install_docker() {
             $envs \
             -d -p $PORT:8080 --name local-ai localai/localai:$IMAGE_TAG $STARTCOMMAND
     elif [ "$HAS_AMD" ]; then
-        IMAGE_TAG=${LOCALAI_VERSION}-gpu-hipblas
+        IMAGE_TAG=${LOCALAI_VERSION}-gpu-amd-rocm-6
         # AIO
         if [ "$USE_AIO" = true ]; then
-            IMAGE_TAG=${LOCALAI_VERSION}-aio-gpu-hipblas
+            IMAGE_TAG=${LOCALAI_VERSION}-aio-gpu-amd-rocm-6
         fi
 
         info "Starting LocalAI Docker container..."


### PR DESCRIPTION
**Description**

This PR implements the ability to select which version of ROCm to use when building llama.cpp, in a similar fashion to how we are able to select which version of CUDA to use.

**Notes for Reviewers**

The motivation is that perfectly usable AMD cards are unsupported by newer ROCm versions. The Vulkan build works excellently on these cards but is not good for distributed inference as it cannot do parallel processing, resulting in sequential layer processing, according to [the docs](https://github.com/ggml-org/llama.cpp/wiki/Feature-matrix) and my testing. Some say it is also not as performant.

I have some questions about how to finish this PR and I have not yet been able to test the actual backeds in my setup, thus leaving this PR as draft for now.

I have built with both version 6.3.3 and 7.1.1 (latest). I will only be able to tests with 6.3.3 since I only have Vega 10 GPUs available.

Some questions for maintainers:
- Should I include these flags in the base-level Dockerfile? Since backends are now built/shipped separately, I assume the usage in the base-level Dockerfile are no longer necessary.
- Should I make similar changes to the other backend Dockerfiles? I likely will only be able to test llama-cpp.
- Would you accept changing the github pipelines to build a v6 and v7 version of ROCm, similar to how we have a v11 and v12 build for CUDA?
    - Assuming the answer to the above question is "yes", would it be OK to make a breaking change to the ROCm backend name/tag, to better match the CUDA build? So we'd have something like `*-gpu-amd-rocm-6-llama-cpp` and `*-gpu-amd-rocm-7-llama-cpp`.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.