### PR TITLE
fix(uri): consider subfolders when expanding huggingface URLs

### DIFF
--- a/pkg/downloader/uri.go
+++ b/pkg/downloader/uri.go
@@ -225,7 +225,7 @@ func (s URI) ResolveURL() string {
 		repo := repoPieces[1]
 
 		branch := "main"
-		filepath := repoPieces[2]
+		filepath := strings.Join(repoPieces[2:], "/")
 
 		if len(repoID) > 1 {
 			if strings.Contains(repo, "@") {


### PR DESCRIPTION
**Description**

This PR possibly fixes an inability to download file in subfolder from huggingface
for example to download that model i was forced to use https:// prefix instead of huggingface://
`https://huggingface.co/huihui-ai/Huihui-gpt-oss-20b-BF16-abliterated-v2/blob/main/GGUF/Huihui-gpt-oss-20b-BF16-abliterated-v2-Q4_K_M.gguf` 

the `huggingface://huihui-ai/Huihui-gpt-oss-20b-BF16-abliterated-v2/GGUF/Huihui-gpt-oss-20b-BF16-abliterated-v2-Q4_K_M.gguf` is invalid, and localai tries to download file named `GGUF` and gets 404

is that done on purpose, or just overlooked?