### PR TITLE
fix(amd-gpu): correctly show total and used vram

### DIFF
--- a/pkg/xsysinfo/gpu.go
+++ b/pkg/xsysinfo/gpu.go
@@ -354,8 +354,8 @@ func getAMDGPUMemory() []GPUMemoryInfo {
 		}
 
 		// Parse memory values (in bytes or MB depending on rocm-smi version)
-		usedBytes, _ := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 64)
-		totalBytes, _ := strconv.ParseUint(strings.TrimSpace(parts[2]), 10, 64)
+		usedBytes, _ := strconv.ParseUint(strings.TrimSpace(parts[2]), 10, 64)
+		totalBytes, _ := strconv.ParseUint(strings.TrimSpace(parts[1]), 10, 64)
 
 		// If values seem like MB, convert to bytes
 		if totalBytes < 1000000 {


### PR DESCRIPTION
An example output of `rocm-smi --showproductname --showmeminfo vram --showuniqueid --csv`:

```
device,Unique ID,VRAM Total Memory (B),VRAM Total Used Memory (B),Card Series,Card Model,Card Vendor,Card SKU,Subsystem ID,Device Rev,Node ID,GUID,GFX Version
card0,0x9246____________,17163091968,692142080,Navi 21 [Radeon RX 6800/6800 XT / 6900 XT],0x73bf,Advanced Micro Devices Inc. [AMD/ATI],001,0x2406,0xc1,1,45534,gfx1030
card1,N/A,67108864,26079232,Raphael,0x164e,Advanced Micro Devices Inc. [AMD/ATI],RAPHAEL,0x364e,0xc6,2,52156,gfx1036
```

Total memory is actually showed before the total used memory as can be seen as an example in https://github.com/LostRuins/koboldcpp/issues/1104#issuecomment-2321143507.

This PR fixes https://github.com/mudler/LocalAI/issues/7724


**Notes for Reviewers**

I don't have an AMD card yet (I should buy it, yeap, but I've just got new gear that I could use it for) to test it, but according to outputs this looks the correct fix. If someone with a real card can test it meanwhile, that'd be great!

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->