### PR TITLE
fix: add nil checks before mergo.Merge to prevent panic in gallery model installation

### DIFF
--- a/core/gallery/models.go
+++ b/core/gallery/models.go
@@ -123,8 +123,10 @@ func InstallModelFromGallery(
 		config.Files = append(config.Files, model.AdditionalFiles...)
 
 		// TODO model.Overrides could be merged with user overrides (not defined yet)
-		if err := mergo.Merge(&model.Overrides, req.Overrides, mergo.WithOverride); err != nil {
-			return err
+		if req.Overrides != nil {
+			if err := mergo.Merge(&model.Overrides, req.Overrides, mergo.WithOverride); err != nil {
+				return err
+			}
 		}
 
 		installedModel, err := InstallModel(ctx, systemState, installName, &config, model.Overrides, downloadStatus, enforceScan)
@@ -245,8 +247,10 @@ func InstallModel(ctx context.Context, systemState *system.SystemState, nameOver
 
 		configMap["name"] = name
 
-		if err := mergo.Merge(&configMap, configOverrides, mergo.WithOverride); err != nil {
-			return nil, err
+		if configOverrides != nil {
+			if err := mergo.Merge(&configMap, configOverrides, mergo.WithOverride); err != nil {
+				return nil, err
+			}
 		}
 
 		// Write updated config file

--- a/core/gallery/models_test.go
+++ b/core/gallery/models_test.go
@@ -184,6 +184,26 @@ var _ = Describe("Model test", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("handles nil configOverrides without panic", func() {
+			tempdir, err := os.MkdirTemp("", "test")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tempdir)
+			c, err := ReadConfigFile[ModelConfig](filepath.Join(os.Getenv("FIXTURES"), "gallery_simple.yaml"))
+			Expect(err).ToNot(HaveOccurred())
+
+			systemState, err := system.GetSystemState(
+				system.WithModelPath(tempdir),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = InstallModel(context.TODO(), systemState, "test-model", c, nil, func(string, string, string, float64) {}, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, f := range []string{"cerebras", "cerebras-completion.tmpl", "cerebras-chat.tmpl", "test-model.yaml"} {
+				_, err = os.Stat(filepath.Join(tempdir, f))
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+
 		It("does not delete shared model files when one config is deleted", func() {
 			tempdir, err := os.MkdirTemp("", "test")
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Summary
This PR fixes #7420

The issue was caused by a panic in `mergo.deepMerge` when `nil` values were passed to `mergo.Merge` during gallery model installation, specifically when downloading the Qwen-Image-Edit model.

## Changes
- Added nil check for `req.Overrides` before merging in `InstallModelFromGallery` (core/gallery/models.go:126)
- Added nil check for `configOverrides` before merging in `InstallModel` (core/gallery/models.go:250)
- Added test case "handles nil configOverrides without panic" to verify the fix

## Testing
- All existing tests pass
- New test case specifically verifies that nil configOverrides are handled without panic

---
Generated with Claude Code