### PR TITLE
fix: Usage for image generation is incorrect (and causes error in LiteLLM)

### DIFF
--- a/core/http/endpoints/openai/image.go
+++ b/core/http/endpoints/openai/image.go
@@ -228,9 +228,6 @@ func ImageEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, appConfi
 
 		id := uuid.New().String()
 		created := int(time.Now().Unix())
-		// Create usage object with required fields for image generation API
-		inputTokens := 0
-		outputTokens := 0
 		resp := &schema.OpenAIResponse{
 			ID:      id,
 			Created: created,
@@ -239,8 +236,8 @@ func ImageEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, appConfi
 				PromptTokens:     0,
 				CompletionTokens: 0,
 				TotalTokens:      0,
-				InputTokens:      &inputTokens,
-				OutputTokens:     &outputTokens,
+				InputTokens:      0,
+				OutputTokens:     0,
 				InputTokensDetails: &schema.InputTokensDetails{
 					TextTokens:  0,
 					ImageTokens: 0,

--- a/core/http/endpoints/openai/inpainting.go
+++ b/core/http/endpoints/openai/inpainting.go
@@ -252,9 +252,6 @@ func InpaintingEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, app
 		}
 
 		created := int(time.Now().Unix())
-		// Create usage object with required fields for image generation API
-		inputTokens := 0
-		outputTokens := 0
 		resp := &schema.OpenAIResponse{
 			ID:      id,
 			Created: created,
@@ -265,8 +262,8 @@ func InpaintingEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, app
 				PromptTokens:     0,
 				CompletionTokens: 0,
 				TotalTokens:      0,
-				InputTokens:      &inputTokens,
-				OutputTokens:     &outputTokens,
+				InputTokens:      0,
+				OutputTokens:     0,
 				InputTokensDetails: &schema.InputTokensDetails{
 					TextTokens:  0,
 					ImageTokens: 0,

--- a/core/schema/openai.go
+++ b/core/schema/openai.go
@@ -28,8 +28,8 @@ type OpenAIUsage struct {
 	CompletionTokens int `json:"completion_tokens"`
 	TotalTokens      int `json:"total_tokens"`
 	// Fields for image generation API compatibility
-	InputTokens        *int                `json:"input_tokens,omitempty"`
-	OutputTokens       *int                `json:"output_tokens,omitempty"`
+	InputTokens        int                 `json:"input_tokens,omitempty"`
+	OutputTokens       int                 `json:"output_tokens,omitempty"`
 	InputTokensDetails *InputTokensDetails `json:"input_tokens_details,omitempty"`
 	// Extra timing data, disabled by default as is't not a part of OpenAI specification
 	TimingPromptProcessing float64 `json:"timing_prompt_processing,omitempty"`


### PR DESCRIPTION
## Summary
This PR fixes #7354 by correcting the type definitions for usage fields in image generation API responses to match the OpenAI API specification.

## Changes
- **core/schema/openai.go**: Changed `InputTokens` and `OutputTokens` from pointer types (`*int`) to regular `int` types in the `OpenAIUsage` struct
- **core/http/endpoints/openai/image.go**: Removed unnecessary variable declarations and directly assign integer values to usage fields
- **core/http/endpoints/openai/inpainting.go**: Removed unnecessary variable declarations and directly assign integer values to usage fields

## Technical Details
The issue was that the fields were defined as nullable pointers (`*int`) when they should be non-nullable integers according to the OpenAI specification. This was causing validation errors in LiteLLM and incorrect parsing in the OpenAI SDK:

**Before:**
```go
InputTokens:  &inputTokens,  // pointer to int - causes "NoneType" error
OutputTokens: &outputTokens, // pointer to int - causes "NoneType" error
```

**After:**
```go
InputTokens:  0,  // regular int - matches OpenAI spec
OutputTokens: 0,  // regular int - matches OpenAI spec
```

## Testing
- All existing tests pass
- `go test ./core/http/endpoints/openai/...` ✅
- `go test ./core/schema/...` ✅

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)