### PR TITLE
fix: Bug: listing models needs to filter out GGUF extension

### DIFF
--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -122,6 +122,7 @@ var knownModelsNameSuffixToSkip []string = []string{
 	".bin",
 	".partial",
 	".tar.gz",
+	".gguf",
 }
 
 const retryTimeout = time.Duration(2 * time.Minute)

--- a/pkg/model/loader_test.go
+++ b/pkg/model/loader_test.go
@@ -68,6 +68,18 @@ var _ = Describe("ModelLoader", func() {
 			Expect(files).To(ContainElement("test.model"))
 			Expect(files).ToNot(ContainElement("README.md"))
 		})
+
+		It("should filter out .gguf files from the model listing", func() {
+			os.Create(filepath.Join(modelPath, "valid-model"))
+			os.Create(filepath.Join(modelPath, "model.gguf"))
+			os.Create(filepath.Join(modelPath, "another-model.gguf"))
+
+			files, err := modelLoader.ListFilesInModelPath()
+			Expect(err).To(BeNil())
+			Expect(files).To(ContainElement("valid-model"))
+			Expect(files).ToNot(ContainElement("model.gguf"))
+			Expect(files).ToNot(ContainElement("another-model.gguf"))
+		})
 	})
 
 	Context("LoadModel", func() {


### PR DESCRIPTION
## Summary
This PR fixes #1077

## Changes
- Added `.gguf` to the `knownModelsNameSuffixToSkip` list in `pkg/model/loader.go` to filter out GGUF files from the model listing endpoint
- Added test case to verify `.gguf` files are properly filtered from the model listing

## Testing
- All existing tests pass (61 of 61 specs)
- New test specifically verifies that `.gguf` files are excluded from `ListFilesInModelPath()`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)