### PR TITLE
[gallery] add JSON schema for gallery model specification

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,20 @@ LOCALAI_IMAGE_TAG=test LOCALAI_IMAGE=local-ai-aio make run-e2e-aio
 
 We are welcome the contribution of the documents, please open new PR or create a new issue. The documentation is available under `docs/` https://github.com/mudler/LocalAI/tree/master/docs
 
+### Gallery YAML Schema
+
+LocalAI provides a JSON Schema for gallery model YAML files at:
+
+`core/schema/gallery-model.schema.json`
+
+This schema mirrors the internal gallery model configuration and can be used by editors (such as VS Code) to enable autocomplete, validation, and inline documentation when creating or modifying gallery files.
+
+To use it with the YAML language server, add the following comment at the top of a gallery YAML file:
+
+```yaml
+# yaml-language-server: $schema=../core/schema/gallery-model.schema.json
+```
+
 ## Community and Communication
 
 - You can reach out via the Github issue tracker.

--- a/core/schema/gallery-model.schema.json
+++ b/core/schema/gallery-model.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/mudler/LocalAI/main/schemas/gallery.model.schema.json",
+  "title": "LocalAI Gallery Model Spec",
+  "description": "Schema for LocalAI gallery model YAML files",
+  "type": "object",
+
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Model name"
+    },
+    "description": {
+      "type": "string",
+      "description": "Human-readable description of the model"
+    },
+    "icon": {
+      "type": "string",
+      "description": "Optional icon reference or URL"
+    },
+    "license": {
+      "type": "string",
+      "description": "Model license identifier or text"
+    },
+    "urls": {
+      "type": "array",
+      "description": "URLs pointing to remote model configuration",
+      "items": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
+    "config_file": {
+      "type": "string",
+      "description": "Inline YAML configuration that will be written to the model config file"
+    },
+    "files": {
+      "type": "array",
+      "description": "Files to download and install for this model",
+      "items": {
+        "type": "object",
+        "required": ["filename", "uri"],
+        "properties": {
+          "filename": {
+            "type": "string"
+          },
+          "sha256": {
+            "type": "string",
+            "description": "Optional SHA256 checksum for file verification"
+          },
+          "uri": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "prompt_templates": {
+      "type": "array",
+      "description": "Prompt templates written as .tmpl files",
+      "items": {
+        "type": "object",
+        "required": ["name", "content"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+
+  "additionalProperties": false
+}


### PR DESCRIPTION
**Description**

This PR fixes #5699

It adds a JSON Schema for LocalAI gallery model YAML files. This mirrors the existing internal gallery model configuration.

**Notes for Reviewers**
- The schema mirrors the existing `ModelConfig` structure used internally.
- Intended to improve editor validation, autocomplete, and contributor onboarding.
- No runtime behavior or validation logic is changed.


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->