### PR TITLE
chore: drop neutts for l4t

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1330,19 +1330,6 @@ jobs:
             dockerfile: "./backend/Dockerfile.python"
             context: "./"
             ubuntu-version: '2404'
-          - build-type: 'l4t'
-            cuda-major-version: "12"
-            cuda-minor-version: "0"
-            platforms: 'linux/arm64'
-            skip-drivers: 'true'
-            tag-latest: 'auto'
-            tag-suffix: '-nvidia-l4t-arm64-neutts'
-            base-image: "nvcr.io/nvidia/l4t-jetpack:r36.4.0"
-            runs-on: 'bigger-runner'
-            backend: "neutts"
-            dockerfile: "./backend/Dockerfile.python"
-            context: "./"
-            ubuntu-version: '2204'
           - build-type: ''
             cuda-major-version: ""
             cuda-minor-version: ""

--- a/backend/index.yaml
+++ b/backend/index.yaml
@@ -537,18 +537,14 @@
     default: "cpu-neutts"
     nvidia: "cuda12-neutts"
     amd: "rocm-neutts"
-    nvidia-l4t: "nvidia-l4t-neutts"
     nvidia-cuda-12: "cuda12-neutts"
-    nvidia-l4t-cuda-12: "nvidia-l4t-arm64-neutts"
 - !!merge <<: *neutts
   name: "neutts-development"
   capabilities:
     default: "cpu-neutts-development"
     nvidia: "cuda12-neutts-development"
     amd: "rocm-neutts-development"
-    nvidia-l4t: "nvidia-l4t-neutts-development"
     nvidia-cuda-12: "cuda12-neutts-development"
-    nvidia-l4t-cuda-12: "nvidia-l4t-arm64-neutts-development"
 - !!merge <<: *llamacpp
   name: "llama-cpp-development"
   capabilities:
@@ -579,11 +575,6 @@
   mirrors:
     - localai/localai-backends:latest-gpu-rocm-hipblas-neutts
 - !!merge <<: *neutts
-  name: "nvidia-l4t-arm64-neutts"
-  uri: "quay.io/go-skynet/local-ai-backends:latest-nvidia-l4t-arm64-neutts"
-  mirrors:
-    - localai/localai-backends:latest-nvidia-l4t-arm64-neutts
-- !!merge <<: *neutts
   name: "cpu-neutts-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-cpu-neutts"
   mirrors:
@@ -598,11 +589,6 @@
   uri: "quay.io/go-skynet/local-ai-backends:master-gpu-rocm-hipblas-neutts"
   mirrors:
     - localai/localai-backends:master-gpu-rocm-hipblas-neutts
-- !!merge <<: *neutts
-  name: "nvidia-l4t-arm64-neutts-development"
-  uri: "quay.io/go-skynet/local-ai-backends:master-nvidia-l4t-arm64-neutts"
-  mirrors:
-    - localai/localai-backends:master-nvidia-l4t-arm64-neutts
 - !!merge <<: *mlx
   name: "mlx-development"
   uri: "quay.io/go-skynet/local-ai-backends:master-metal-darwin-arm64-mlx"


### PR DESCRIPTION
Builds exhausts CI currently, and there are better backends at this point in time. We will probably deprecate it in the future.
