### PR TITLE
fix(ui): correctly display selected image model

### DIFF
--- a/core/http/views/image.html
+++ b/core/http/views/image.html
@@ -18,7 +18,7 @@
                         <div class="flex items-center justify-between gap-2">
                             <label class="text-xs font-medium text-[var(--color-text-secondary)] uppercase tracking-wide flex-shrink-0">Model</label>
                         </div>
-                        <select x-data="{ link : '' }" x-model="link" x-init="$watch('link', value => window.location = link)" 
+                        <select x-data="{ link : '{{if .Model}}image/{{.Model}}{{end}}' }" x-model="link" x-init="$watch('link', value => window.location = link)" 
                             id="model-select"
                             class="input w-full p-1.5 text-xs"
                         >	


### PR DESCRIPTION
**Description**

This PR fixes a UI bug on the image generation page where the selected model was not being correctly displayed after a page reload. *(Note: No specific issue number was provided for this fix.)*

**Notes for Reviewers**

Previously, when a user selected a model, the page would redirect as expected, but the dropdown would incorrectly reset to its default "Select a model" placeholder.

| Before                                                                                                                                   | After                                                                                                                              |
| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
| <img width="320" alt="fix-correctly-display-selected-image-model-before" src="https://github.com/user-attachments/assets/f49d130f-1f7e-49e9-bf27-097cfc6b7aa2" /> | <img width="320" alt="fix-correctly-display-selected-image-model-after" src="https://github.com/user-attachments/assets/8ea26f31-a56d-4173-8a2f-b189e8b92bfb" /> |

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->