### PR TITLE
chore(model gallery): Add entry for Mistral Small 3.1 with mmproj

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -11366,13 +11366,13 @@
     - multimodal
   overrides:
     parameters:
-      model: mistralai_Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf
-    mmproj: mmproj-mistralai_Mistral-Small-3.1-24B-Instruct-2503-f16.gguf
+      model: llama-cpp/models/mistralai_Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf
+    mmproj: llama-cpp/mmproj/mmproj-mistralai_Mistral-Small-3.1-24B-Instruct-2503-f16.gguf
   files:
-    - filename: mistralai_Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf
+    - filename: llama-cpp/models/mistralai_Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf
       sha256: c5743c1bf39db0ae8a5ade5df0374b8e9e492754a199cfdad7ef393c1590f7c0
       uri: huggingface://bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF/mistralai_Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf
-    - filename: mmproj-mistralai_Mistral-Small-3.1-24B-Instruct-2503-f16.gguf
+    - filename: llama-cpp/mmproj/mmproj-mistralai_Mistral-Small-3.1-24B-Instruct-2503-f16.gguf
       sha256: f5add93ad360ef6ccba571bba15e8b4bd4471f3577440a8b18785f8707d987ed
       uri: huggingface://bartowski/mistralai_Mistral-Small-3.1-24B-Instruct-2503-GGUF/mmproj-mistralai_Mistral-Small-3.1-24B-Instruct-2503-f16.gguf
 - !!merge <<: *mistral03


### PR DESCRIPTION
**Description**

This PR adds multimodal entry for Mistral Small 3.1 to the model gallery. The entry is copy of the current model entry, just with added mmproj, allowing users to pick if they install text only or full multimodal setup. The new entry is identifiable by suffix `-multimodal`, mention of mmproj inclusion at the end of description, and by modified tags to include `multimodal`.

Addition of this version of the entry satisies the second half of issue #3535.

This PR is one from a set of model additions I am working on currently, where I attempt to satisfy all not yet satisfied model requests I have found, which don't require any backend side changes (such as need for moderation endpoint for Qwen 3 Guard (requested on LocalAI Discord), or what would adding Mochi 1 (requested on LocalAI Discord) entail).

**Notes for Reviewers**
Tests done on the model before PR:
- pulling model from LocalAI's webUI
- describing an image


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.