### PR TITLE
fix(qwen3): Be explicit with function calling format

### DIFF
--- a/gallery/qwen3.yaml
+++ b/gallery/qwen3.yaml
@@ -25,9 +25,9 @@ config_file: |
       <|im_start|>system
       You are a function calling AI model. You are provided with functions to execute. You may call one or more functions to assist with the user query. Don't make assumptions about what values to plug into functions. Here are the available tools:
       {{range .Functions}}
-      {'type': 'function', 'function': {'name': '{{.Name}}', 'description': '{{.Description}}', 'parameters': {{toJson .Parameters}} }}
+      {"type": "function", "function": {"name": "{{.Name}}", "description": "{{.Description}}", "parameters": {{toJson .Parameters}} }}
       {{end}}
-      For each function call return a json object with function name and arguments
+      For each function call return a json object with function name and arguments: {"name": <function-name>, "arguments": <json-arguments-object>}
       <|im_end|>
       {{.Input -}}
       <|im_start|>assistant


### PR DESCRIPTION
Qwen3 4b was using the wrong function format (i.e. using "function"
instead of "name") within the realtime API.

If we specify the function calling format explicitly then it stops it.

