### PR TITLE
fix(api): Add missing field in initial OpenAI streaming response

### DIFF
--- a/core/http/endpoints/openai/chat.go
+++ b/core/http/endpoints/openai/chat.go
@@ -36,6 +36,7 @@ func ChatEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, evaluator
 			Created: created,
 			Model:   req.Model, // we have to return what the user sent here, due to OpenAI spec.
 			Choices: []schema.Choice{{Delta: &schema.Message{Role: "assistant"}, Index: 0, FinishReason: nil}},
+			Object:  "chat.completion.chunk",
 		}
 		responses <- initialMessage
 


### PR DESCRIPTION
**Description**
Adds a missing field to the JSON response in the OpenAI streaming responses for the /v1/chat/completions endpoint.

**Notes for Reviewers**
N/A

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.