### PR TITLE
fix(docs): Promote DEBUG=false in production docker compose

### DIFF
--- a/docs/content/installation/docker.md
+++ b/docs/content/installation/docker.md
@@ -150,7 +150,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      - DEBUG=true
+      - DEBUG=false
     volumes:
       - ./models:/models:cached
     # For NVIDIA GPUs, uncomment:


### PR DESCRIPTION
**Description**

We should promote DEBUG=false and not DEBUG=true in the docker compose provided in the documentation.
The Docker Compose code is presented for production use; thus, the proposed change.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 