### PR TITLE
fix: filter GGUF and GGML files from model list

### DIFF
--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -120,6 +120,8 @@ var knownModelsNameSuffixToSkip []string = []string{
 	".",
 	".safetensors",
 	".bin",
+	".gguf",
+	".ggml",
 	".partial",
 	".tar.gz",
 }

--- a/pkg/model/loader_test.go
+++ b/pkg/model/loader_test.go
@@ -61,11 +61,13 @@ var _ = Describe("ModelLoader", func() {
 	Context("ListFilesInModelPath", func() {
 		It("should list all valid model files in the model path", func() {
 			os.Create(filepath.Join(modelPath, "test.model"))
+			os.Create(filepath.Join(modelPath, "model.gguf"))
 			os.Create(filepath.Join(modelPath, "README.md"))
 
 			files, err := modelLoader.ListFilesInModelPath()
 			Expect(err).To(BeNil())
 			Expect(files).To(ContainElement("test.model"))
+			Expect(files).ToNot(ContainElement("model.gguf"))
 			Expect(files).ToNot(ContainElement("README.md"))
 		})
 	})


### PR DESCRIPTION
## Summary
- Skip .gguf and .ggml loose files when listing models
- Add test coverage for .gguf exclusion

## Related issue
- Closes #1077