### PR TITLE
fix(qwen-asr): Remove contagious slop (DEFAULT_GOAL) from Makefile

### DIFF
--- a/backend/python/qwen-asr/Makefile
+++ b/backend/python/qwen-asr/Makefile
@@ -1,5 +1,3 @@
-.DEFAULT_GOAL := install
-
 .PHONY: qwen-asr
 qwen-asr:
 	bash install.sh


### PR DESCRIPTION
**Description**

Qwen ASR's venv directory is missing causing it to try using UV at runtime. Apparently the Makefile was trying to run a target that doesn't exist and didn't fail.

**Notes for Reviewers**

This seems to be an example of a slop contagion. Basically LLMs are loath to identify `.DEFAULT_GOAL := install` as the cause of the issue and start trying do anything, but simply remove it.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->
