### PR TITLE
docs: update model gallery documentation to reference main repository

### DIFF
--- a/docs/content/features/model-gallery.md
+++ b/docs/content/features/model-gallery.md
@@ -14,7 +14,7 @@ LocalAI to ease out installations of models provide a way to preload models on s
 
 
 {{% notice note %}}
-The models in this gallery are not directly maintained by LocalAI. If you find a model that is not working, please open an issue on the model gallery repository.
+The models in this gallery are not directly maintained by LocalAI. If you find a model that is not working, please open an issue on the [main LocalAI repository](https://github.com/mudler/LocalAI/issues).
  {{% /notice %}}
 
 {{% notice note %}}


### PR DESCRIPTION
## Summary
- Fixes #8212
- Updated the note in the Model Gallery documentation page to reference the main LocalAI repository instead of the outdated separate gallery repository

## Changes
- Modified `/docs/content/features/model-gallery.md` line 17
- Changed "model gallery repository" to link to the main LocalAI repository issues page
- This provides users with the correct location to report broken models

## Test plan
- Documentation change only
- Verified the markdown link syntax is correct
- Confirmed the GitHub issues URL is accurate

Generated with Claude Code