### PR TITLE
bug: add SHA256 verification for backend downloads

### DIFF
--- a/core/gallery/backend_types.go
+++ b/core/gallery/backend_types.go
@@ -26,6 +26,7 @@ type GalleryBackend struct {
 	Metadata        `json:",inline" yaml:",inline"`
 	Alias           string            `json:"alias,omitempty" yaml:"alias,omitempty"`
 	URI             string            `json:"uri,omitempty" yaml:"uri,omitempty"`
+	SHA256          string            `json:"sha256,omitempty" yaml:"sha256,omitempty"`
 	Mirrors         []string          `json:"mirrors,omitempty" yaml:"mirrors,omitempty"`
 	CapabilitiesMap map[string]string `json:"capabilities,omitempty" yaml:"capabilities,omitempty"`
 }

--- a/core/gallery/backends.go
+++ b/core/gallery/backends.go
@@ -165,7 +165,7 @@ func InstallBackend(ctx context.Context, systemState *system.SystemState, modelL
 		}
 	} else {
 		xlog.Debug("Downloading backend", "uri", config.URI, "backendPath", backendPath)
-		if err := uri.DownloadFileWithContext(ctx, backendPath, "", 1, 1, downloadStatus); err != nil {
+		if err := uri.DownloadFileWithContext(ctx, backendPath, config.SHA256, 1, 1, downloadStatus); err != nil {
 			success := false
 			// Try to download from mirrors
 			for _, mirror := range config.Mirrors {
@@ -175,7 +175,7 @@ func InstallBackend(ctx context.Context, systemState *system.SystemState, modelL
 					return ctx.Err()
 				default:
 				}
-				if err := downloader.URI(mirror).DownloadFileWithContext(ctx, backendPath, "", 1, 1, downloadStatus); err == nil {
+				if err := downloader.URI(mirror).DownloadFileWithContext(ctx, backendPath, config.SHA256, 1, 1, downloadStatus); err == nil {
 					success = true
 					xlog.Debug("Downloaded backend", "uri", config.URI, "backendPath", backendPath)
 					break


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

**Description**

This PR adds SHA256 integrity verification for backend binary downloads, closing a supply chain vulnerability where executable code was downloaded without cryptographic verification.

**Notes for Reviewers**

## Vulnerability: Unvalidated File Downloads from Untrusted Sources

### Location
`core/gallery/backends.go:168-178`

### Description
Backend files are downloaded from URLs without validating file content before execution. At line 168, backend binaries are downloaded using `uri.DownloadFileWithContext(ctx, backendPath, "", 1, 1, downloadStatus)` with an empty SHA256 parameter. The downloader (`uri.go` lines 479-488) explicitly skips SHA verification when sha is empty. Backends are executable code (`run.sh` scripts and associated binaries) that LocalAI executes, making this a supply chain vulnerability.

### Analysis Notes
An attacker who can perform MITM attacks on the gallery URL, compromise the gallery server, or serve malicious content could inject arbitrary code that would be executed by LocalAI. The `GalleryBackend` struct did not have a SHA256 field for integrity verification, unlike the `File` struct used for model downloads which already supported SHA256 verification.

### Fix Applied
Added a `SHA256` field to the `GalleryBackend` struct (following the existing pattern from the `File` struct) and passed `config.SHA256` to `DownloadFileWithContext` calls for both primary URI and mirror downloads. When gallery maintainers populate the SHA256 field, downloaded backends will be cryptographically verified. The fix is backward-compatible: existing gallery definitions without SHA256 values continue to work (the downloader logs a debug message and skips verification, matching current behavior).

### Tests/Linters Ran
- `go build ./core/gallery/...` — passed
- `go vet ./core/gallery/...` — passed
- `golangci-lint run ./core/gallery/...` — passed (no issues)
- `go test ./core/gallery/... -v -count=1` — 4 pre-existing test failures on master (pointer equality comparisons in meta backend tests, unrelated to this change), all other 75 tests passed. Verified by running same tests on master branch.

### Contribution Notes
- Follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) as specified in the PR template
- Commits are not DCO-signed as this is an external contribution without access to the signing key; maintainer may need to handle this

**Signed commits**
- [ ] Yes, I signed my commits.