### PR TITLE
security: validate URLs to prevent SSRF in content fetching endpoints

### DIFF
--- a/core/http/endpoints/openai/image.go
+++ b/core/http/endpoints/openai/image.go
@@ -23,10 +23,15 @@ import (
 	"github.com/mudler/LocalAI/core/backend"
 
 	model "github.com/mudler/LocalAI/pkg/model"
+	"github.com/mudler/LocalAI/pkg/utils"
 	"github.com/mudler/xlog"
 )
 
 func downloadFile(url string) (string, error) {
+	if err := utils.ValidateExternalURL(url); err != nil {
+		return "", fmt.Errorf("URL validation failed: %w", err)
+	}
+
 	// Get the data
 	resp, err := http.Get(url)
 	if err != nil {

--- a/pkg/utils/base64.go
+++ b/pkg/utils/base64.go
@@ -21,6 +21,10 @@ var dataURIPattern = regexp.MustCompile(`^data:([^;]+);base64,`)
 // GetContentURIAsBase64 checks if the string is an URL, if it's an URL downloads the content in memory encodes it in base64 and returns the base64 string, otherwise returns the string by stripping base64 data headers
 func GetContentURIAsBase64(s string) (string, error) {
 	if strings.HasPrefix(s, "http") || strings.HasPrefix(s, "https") {
+		if err := ValidateExternalURL(s); err != nil {
+			return "", fmt.Errorf("URL validation failed: %w", err)
+		}
+
 		// download the image
 		resp, err := base64DownloadClient.Get(s)
 		if err != nil {

--- a/pkg/utils/urlfetch.go
+++ b/pkg/utils/urlfetch.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+)
+
+// ValidateExternalURL checks that the given URL does not point to a private,
+// loopback, link-local, or otherwise internal network address. This prevents
+// Server-Side Request Forgery (SSRF) attacks where a user-supplied URL could
+// be used to probe internal services or cloud metadata endpoints.
+func ValidateExternalURL(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %w", err)
+	}
+
+	scheme := strings.ToLower(parsed.Scheme)
+	if scheme != "http" && scheme != "https" {
+		return fmt.Errorf("unsupported URL scheme: %s", scheme)
+	}
+
+	hostname := parsed.Hostname()
+	if hostname == "" {
+		return fmt.Errorf("URL has no hostname")
+	}
+
+	// Block well-known internal hostnames
+	lower := strings.ToLower(hostname)
+	if lower == "localhost" || strings.HasSuffix(lower, ".local") {
+		return fmt.Errorf("requests to internal hosts are not allowed")
+	}
+
+	// Block cloud metadata service hostnames
+	if lower == "metadata.google.internal" || lower == "instance-data" {
+		return fmt.Errorf("requests to cloud metadata services are not allowed")
+	}
+
+	ips, err := net.LookupHost(hostname)
+	if err != nil {
+		return fmt.Errorf("failed to resolve hostname: %w", err)
+	}
+
+	for _, ipStr := range ips {
+		ip := net.ParseIP(ipStr)
+		if ip == nil {
+			return fmt.Errorf("unable to parse resolved IP: %s", ipStr)
+		}
+
+		if !isPublicIP(ip) {
+			return fmt.Errorf("requests to internal network addresses are not allowed")
+		}
+	}
+
+	return nil
+}
+
+func isPublicIP(ip net.IP) bool {
+	if ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsPrivate() ||
+		ip.IsUnspecified() {
+		return false
+	}
+
+	// Block IPv4-mapped IPv6 addresses that wrap private IPv4
+	if ip4 := ip.To4(); ip4 != nil {
+		return !ip4.IsLoopback() &&
+			!ip4.IsLinkLocalUnicast() &&
+			!ip4.IsPrivate() &&
+			!ip4.IsUnspecified()
+	}
+
+	return true
+}

--- a/pkg/utils/urlfetch_test.go
+++ b/pkg/utils/urlfetch_test.go
@@ -1,0 +1,99 @@
+package utils_test
+
+import (
+	. "github.com/mudler/LocalAI/pkg/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("utils/urlfetch tests", func() {
+	Context("ValidateExternalURL", func() {
+		It("allows valid external HTTPS URLs", func() {
+			err := ValidateExternalURL("https://example.com/image.png")
+			Expect(err).To(BeNil())
+		})
+
+		It("allows valid external HTTP URLs", func() {
+			err := ValidateExternalURL("http://example.com/image.png")
+			Expect(err).To(BeNil())
+		})
+
+		It("blocks localhost", func() {
+			err := ValidateExternalURL("http://localhost/secret")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+
+		It("blocks 127.0.0.1", func() {
+			err := ValidateExternalURL("http://127.0.0.1/secret")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+
+		It("blocks private 10.x.x.x range", func() {
+			err := ValidateExternalURL("http://10.0.0.1/secret")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+
+		It("blocks private 172.16.x.x range", func() {
+			err := ValidateExternalURL("http://172.16.0.1/secret")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+
+		It("blocks private 192.168.x.x range", func() {
+			err := ValidateExternalURL("http://192.168.1.1/secret")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+
+		It("blocks link-local 169.254.x.x (AWS metadata)", func() {
+			err := ValidateExternalURL("http://169.254.169.254/latest/meta-data/")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+
+		It("blocks unsupported schemes", func() {
+			err := ValidateExternalURL("ftp://example.com/file")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("unsupported URL scheme"))
+		})
+
+		It("blocks file:// scheme", func() {
+			err := ValidateExternalURL("file:///etc/passwd")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("unsupported URL scheme"))
+		})
+
+		It("blocks URLs with no hostname", func() {
+			err := ValidateExternalURL("http:///path")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("no hostname"))
+		})
+
+		It("blocks .local hostnames", func() {
+			err := ValidateExternalURL("http://myservice.local/api")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+
+		It("blocks metadata.google.internal", func() {
+			err := ValidateExternalURL("http://metadata.google.internal/computeMetadata/v1/")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("metadata"))
+		})
+
+		It("blocks 0.0.0.0", func() {
+			err := ValidateExternalURL("http://0.0.0.0/")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+
+		It("blocks IPv6 loopback ::1", func() {
+			err := ValidateExternalURL("http://[::1]/secret")
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("internal"))
+		})
+	})
+})


### PR DESCRIPTION
*Vulnerability identified and fix provided by [Kolega.dev](https://kolega.dev/)*

**Description**

This PR fixes a Server-Side Request Forgery (SSRF) vulnerability in multiple endpoints that accept user-provided URLs and fetch them without validation.

**Vulnerability Details**

**Location:** `pkg/utils/base64.go` (`GetContentURIAsBase64`), `core/http/endpoints/openai/image.go` (`downloadFile`), and callers in `core/http/middleware/request.go` (lines 331, 341, 356) and `core/http/endpoints/localai/detection.go` (line 34).

**Description:** The `GetContentURIAsBase64()` function and `downloadFile()` function fetch arbitrary user-supplied URLs without any validation. This allows attackers to probe internal networks, access cloud metadata services (e.g., `169.254.169.254` on AWS/GCP), and reach internal services via loopback or private IP ranges.

**Fix Applied:** Added a `ValidateExternalURL()` function in `pkg/utils/urlfetch.go` that performs DNS resolution on the target URL hostname and verifies all resolved IPs are public. It blocks:
- Private IP ranges (10.x, 172.16-31.x, 192.168.x)
- Loopback addresses (127.0.0.1, ::1)
- Link-local addresses (169.254.x.x — AWS/GCP metadata endpoint)
- Well-known internal hostnames (localhost, *.local, metadata.google.internal)
- Non-HTTP(S) schemes (file://, ftp://, etc.)

This validation is called at the entry point of both `GetContentURIAsBase64()` and `downloadFile()` before any HTTP request is made.

**Notes for Reviewers**

- The fix is minimal and focused — only URL validation is added, no other changes
- 15 new test cases cover all blocked address categories (private, loopback, link-local, metadata, scheme, IPv6)
- All existing tests continue to pass, including the external URL download test

**Tests/Linters Ran**

| Check | Result |
|-------|--------|
| `go vet ./pkg/utils/...` | Passed |
| `go build ./pkg/utils/...` | Passed |
| `gofmt -l` (all changed files) | Passed (no formatting issues) |
| `go test ./pkg/utils/... -v` | 19/19 specs passed (4 existing + 15 new) |

**Contribution Notes**

- Commit follows conventional commit format as specified in the PR template
- `golangci-lint` was not available in the build environment but `go vet` was run as a substitute
- DCO sign-off was not applied as it requires GPG key configuration; maintainers may request this be added

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.