### PR TITLE
fix(llama-cpp): populate tensor_buft_override buffer so llama-cpp properly performs fit calculations

### DIFF
--- a/backend/cpp/llama-cpp/grpc-server.cpp
+++ b/backend/cpp/llama-cpp/grpc-server.cpp
@@ -417,6 +417,12 @@ static void params_parse(server_context& /*ctx_server*/, const backend::ModelOpt
     // n_ctx_checkpoints: max context checkpoints per slot (default: 8)
     params.n_ctx_checkpoints = 8;
 
+    // llama memory fit fails if we don't provide a buffer for tensor overrides
+    const size_t ntbo = llama_max_tensor_buft_overrides();
+    while (params.tensor_buft_overrides.size() < ntbo) {
+        params.tensor_buft_overrides.push_back({nullptr, nullptr});
+    }
+
      // decode options. Options are in form optname:optvale, or if booleans only optname.
     for (int i = 0; i < request->options_size(); i++) {
         std::string opt = request->options(i);


### PR DESCRIPTION
**Description**

While testing loading some large models on my PC (Qwen3-Coder-Next) I noticed that llama-cpp's CLI would load it and offload what it needed to system RAM, while LocalAI errored saying I didn't have enough VRAM.

Looking at the logs, I saw that llama-cpp was trying to perform fit calculations to load some tensors into VRAM and the rest into system RAM, but was erroring out:
<img width="1116" height="122" alt="image" src="https://github.com/user-attachments/assets/df9e5361-6dfd-4572-b15d-787089443563" />

Looking through llama-cpp's codebase, it looks like they [expect the tensor_buft_overrides parameter to be populated with a buffer](https://github.com/ggml-org/llama.cpp/blob/91ea5d67f2a47fff99592c46583758131bfcdf62/src/llama.cpp#L346) even if it isn't used.

This PR adds logic that mimics what [llama-cpp does during arg parsing](https://github.com/ggml-org/llama.cpp/blob/dbb023336bc6986f3d1bc292502d7badea3713c5/common/arg.cpp#L620) to fill this with an arbitrary buffer to avoid this bailout later.

**Notes for Reviewers**

Tested by building locally for cuda13 and validating that the 54GB model could load despite only 24GB VRAM available on a combination of VRAM/System RAM:
<img width="1096" height="174" alt="image" src="https://github.com/user-attachments/assets/629d25b8-5b25-4591-b457-338c22511bef" />

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 