### PR TITLE
feat: Add message reasoning_content option for including past reasoning

### DIFF
--- a/core/backend/llm.go
+++ b/core/backend/llm.go
@@ -79,7 +79,8 @@ func ModelInference(ctx context.Context, s string, messages schema.Messages, ima
 	// if we are using the tokenizer template, we need to convert the messages to proto messages
 	// unless the prompt has already been tokenized (non-chat endpoints + functions)
 	if c.TemplateConfig.UseTokenizerTemplate && len(messages) > 0 {
-		protoMessages = messages.ToProto()
+		mergeThinking := c.ReasoningConfig.MessagesFormat == "reasoning_content_field"
+		protoMessages = messages.ToProto(mergeThinking)
 	}
 
 	// in GRPC, the backend is supposed to answer to 1 single token if stream is not supported

--- a/docs/content/advanced/model-configuration.md
+++ b/docs/content/advanced/model-configuration.md
@@ -408,6 +408,7 @@ Configure how reasoning tags are extracted and processed from model output. Reas
 | `reasoning.strip_reasoning_only` | bool | `false` | When `true`, extracts and removes reasoning tags from content but discards the reasoning text. Useful when you want to clean reasoning tags from output without storing the reasoning content. |
 | `reasoning.thinking_start_tokens` | array | `[]` | List of custom thinking start tokens to detect in prompts. Custom tokens are checked before default tokens. |
 | `reasoning.tag_pairs` | array | `[]` | List of custom tag pairs for reasoning extraction. Each entry has `start` and `end` fields. Custom pairs are checked before default pairs. |
+| `reasoning.messages_format` | string | `""` | Controls how `role: "thinking"` messages are handled when using the tokenizer template. See [Messages Format](#messages-format) below. |
 
 ### Reasoning Tag Formats
 
@@ -473,6 +474,29 @@ reasoning:
 ```
 
 **Note:** Custom tokens and tag pairs are checked before the default ones, giving them priority. This allows you to override default behavior or add support for new reasoning tag formats.
+
+### Messages Format
+
+When `use_tokenizer_template` is enabled, messages are sent to the backend for Jinja template rendering. Some clients (e.g. Open WebUI) send previous reasoning/thinking content back as a separate message with `role: "thinking"`. If the model's chat template does not handle this role, it will produce an error such as `'Unexpected message role.'`.
+
+The `messages_format` option controls how these `role: "thinking"` messages are represented before being sent to the template:
+
+| Value | Behavior |
+|-------|----------|
+| `""` (empty, default) | Same as `thinking_role`. |
+| `thinking_role` | Pass `role: "thinking"` messages through as-is. Use this if the model's template handles the "thinking" role natively. |
+| `reasoning_content_field` | Merge `role: "thinking"` messages into the next assistant message's `reasoning_content` field, removing them from the message list. Use this if the model's template expects `reasoning_content` on assistant messages (e.g. Qwen3 templates). |
+
+**Example — merge thinking into reasoning_content:**
+```yaml
+name: qwen3-model
+backend: llama-cpp
+parameters:
+  model: qwen3.gguf
+
+reasoning:
+  messages_format: reasoning_content_field
+```
 
 ## Pipeline Configuration
 

--- a/pkg/reasoning/config.go
+++ b/pkg/reasoning/config.go
@@ -12,4 +12,5 @@ type Config struct {
 	StripReasoningOnly         *bool     `yaml:"strip_reasoning_only,omitempty" json:"strip_reasoning_only,omitempty"`
 	ThinkingStartTokens        []string  `yaml:"thinking_start_tokens,omitempty" json:"thinking_start_tokens,omitempty"`
 	TagPairs                   []TagPair `yaml:"tag_pairs,omitempty" json:"tag_pairs,omitempty"`
+	MessagesFormat             string    `yaml:"messages_format,omitempty" json:"messages_format,omitempty"`
 }


### PR DESCRIPTION
**Description**

The jinja template for Qwen3.5 doesn't support the thinking role for
messages and throws an error when it sees an unrecognized role.
This commit merges them into the last assistant message.

This PR fixes #

**Notes for Reviewers**

I haven't tested this yet.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->
