### PR TITLE
fix(qwen3.5): add qwen3.5 preset and mimick llama.cpp's PEG

### DIFF
--- a/pkg/functions/parse_test.go
+++ b/pkg/functions/parse_test.go
@@ -779,6 +779,42 @@ value
 			Expect(results[0].Name).To(Equal("glob"))
 			Expect(results[0].Arguments).To(Equal(`{"pattern":"**/package.json"}`))
 		})
+		It("should parse tool calls when reasoning (<think>) precedes tool block (Qwen3.5-style)", func() {
+			input := `<think>
+I need to run a command.
+</think>
+<tool_call>
+<function=bash>
+<parameter=script>
+echo hello
+</parameter>
+</function>
+</tool_call>`
+			cfg := FunctionsConfig{}
+			results := ParseFunctionCall(input, cfg)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("bash"))
+			Expect(results[0].Arguments).To(ContainSubstring("echo hello"))
+		})
+
+		It("should parse tool calls when reasoning (<think>) precedes tool block (Qwen3.5-style)", func() {
+			input := `<think>
+I need to run a command.
+</think>
+<tool_call>
+<function=bash>
+<parameter=script>
+echo hello
+</parameter>
+</function>
+</tool_call>`
+			cfg := FunctionsConfig{}
+			cfg.XMLFormatPreset = "qwen3.5"
+			results := ParseFunctionCall(input, cfg)
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].Name).To(Equal("bash"))
+			Expect(results[0].Arguments).To(ContainSubstring("echo hello"))
+		})
 
 		It("should parse XML tool calls alongside JSON tool calls", func() {
 			input := `{"name": "add", "arguments": {"x": 5, "y": 3}}


### PR DESCRIPTION
**Description**

This PR fixes Qwen3.5 tools calls by adding qwen3.5 presets and mirroring llama.cpp's PEG logics when parsing tool calls.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->