### PR TITLE
Fix tag filtering in model gallery to return exact tag matches only

### DIFF
--- a/core/gallery/gallery.go
+++ b/core/gallery/gallery.go
@@ -92,6 +92,22 @@ func (gm GalleryElements[T]) Search(term string) GalleryElements[T] {
 	return filteredModels
 }
 
+// FilterByTag filters gallery elements to only those that have the exact specified tag
+func (gm GalleryElements[T]) FilterByTag(tag string) GalleryElements[T] {
+	var filteredModels GalleryElements[T]
+	tag = strings.ToLower(tag)
+	for _, m := range gm {
+		for _, t := range m.GetTags() {
+			if strings.ToLower(t) == tag {
+				filteredModels = append(filteredModels, m)
+				break
+			}
+		}
+	}
+
+	return filteredModels
+}
+
 func (gm GalleryElements[T]) SortByName(sortOrder string) GalleryElements[T] {
 	sort.Slice(gm, func(i, j int) bool {
 		if sortOrder == "asc" {

--- a/core/http/routes/ui_api.go
+++ b/core/http/routes/ui_api.go
@@ -191,6 +191,7 @@ func RegisterUIAPIRoutes(app *echo.Echo, cl *config.ModelConfigLoader, ml *model
 	// Model Gallery APIs
 	app.GET("/api/models", func(c echo.Context) error {
 		term := c.QueryParam("term")
+		tag := c.QueryParam("tag")
 		page := c.QueryParam("page")
 		if page == "" {
 			page = "1"
@@ -221,6 +222,12 @@ func RegisterUIAPIRoutes(app *echo.Echo, cl *config.ModelConfigLoader, ml *model
 		}
 		sort.Strings(tags)
 
+		// Apply tag filtering first (exact match) if specified
+		if tag != "" {
+			models = gallery.GalleryElements[*gallery.GalleryModel](models).FilterByTag(tag)
+		}
+
+		// Apply search term filtering if specified
 		if term != "" {
 			models = gallery.GalleryElements[*gallery.GalleryModel](models).Search(term)
 		}
@@ -672,6 +679,7 @@ func RegisterUIAPIRoutes(app *echo.Echo, cl *config.ModelConfigLoader, ml *model
 	// Backend Gallery APIs
 	app.GET("/api/backends", func(c echo.Context) error {
 		term := c.QueryParam("term")
+		tag := c.QueryParam("tag")
 		page := c.QueryParam("page")
 		if page == "" {
 			page = "1"
@@ -702,6 +710,12 @@ func RegisterUIAPIRoutes(app *echo.Echo, cl *config.ModelConfigLoader, ml *model
 		}
 		sort.Strings(tags)
 
+		// Apply tag filtering first (exact match) if specified
+		if tag != "" {
+			backends = gallery.GalleryElements[*gallery.GalleryBackend](backends).FilterByTag(tag)
+		}
+
+		// Apply search term filtering if specified
 		if term != "" {
 			backends = gallery.GalleryElements[*gallery.GalleryBackend](backends).Search(term)
 		}

--- a/core/http/views/backends.html
+++ b/core/http/views/backends.html
@@ -590,6 +590,7 @@ function backendsGallery() {
         allTags: [],
         repositories: [],
         searchTerm: '',
+        searchTag: '',
         loading: false,
         currentPage: 1,
         totalPages: 1,
@@ -677,6 +678,9 @@ function backendsGallery() {
                     items: 21,
                     term: this.searchTerm
                 });
+                if (this.searchTag) {
+                    params.append('tag', this.searchTag);
+                }
                 if (this.sortBy) {
                     params.append('sort', this.sortBy);
                     params.append('order', this.sortOrder);
@@ -701,6 +705,14 @@ function backendsGallery() {
         
         filterByTerm(term) {
             this.searchTerm = term;
+            this.searchTag = '';
+            this.currentPage = 1;
+            this.fetchBackends();
+        },
+
+        filterByTag(tag) {
+            this.searchTag = tag;
+            this.searchTerm = '';
             this.currentPage = 1;
             this.fetchBackends();
         },

--- a/core/http/views/models.html
+++ b/core/http/views/models.html
@@ -164,7 +164,7 @@
                     <div class="max-h-32 overflow-y-auto pr-2">
                         <div class="flex flex-wrap gap-2">
                             <template x-for="tag in allTags" :key="tag">
-                                <button @click="filterByTerm(tag)"
+                                <button @click="filterByTag(tag)"
                                     class="inline-flex items-center text-xs px-3 py-2 rounded bg-[var(--color-bg-primary)] hover:bg-[var(--color-bg-primary)]/80 text-[var(--color-text-secondary)] hover:text-[var(--color-text-primary)] border border-[var(--color-bg-secondary)] transition-colors">
                                     <i class="fas fa-tag text-xs mr-2"></i>
                                     <span x-text="tag"></span>
@@ -472,7 +472,7 @@
                                     <p class="text-sm mb-3 font-semibold text-[var(--color-text-primary)]">Tags</p>
                                     <div class="flex flex-row flex-wrap content-center">
                                         <template x-for="tag in selectedModel.tags" :key="tag">
-                                            <a :href="'browse?term=' + tag"
+                                            <a href="#" @click.prevent="filterByTag(tag)"
                                                class="inline-flex items-center text-xs px-3 py-1 rounded-full bg-[var(--color-bg-primary)] text-[var(--color-text-secondary)] border border-[var(--color-border-subtle)] hover:bg-[var(--color-primary-light)] hover:text-[var(--color-text-primary)] transition duration-200 ease-in-out mr-2 mb-2">
                                                 <i class="fas fa-tag pr-2"></i>
                                                 <span x-text="tag"></span>
@@ -631,6 +631,7 @@ function modelsGallery() {
         allTags: [],
         repositories: [],
         searchTerm: '',
+        searchTag: '',
         loading: false,
         currentPage: 1,
         totalPages: 1,
@@ -682,6 +683,9 @@ function modelsGallery() {
                     items: 21,
                     term: this.searchTerm
                 });
+                if (this.searchTag) {
+                    params.append('tag', this.searchTag);
+                }
                 if (this.sortBy) {
                     params.append('sort', this.sortBy);
                     params.append('order', this.sortOrder);
@@ -708,6 +712,14 @@ function modelsGallery() {
 
         filterByTerm(term) {
             this.searchTerm = term;
+            this.searchTag = '';
+            this.currentPage = 1;
+            this.fetchModels();
+        },
+
+        filterByTag(tag) {
+            this.searchTag = tag;
+            this.searchTerm = '';
             this.currentPage = 1;
             this.fetchModels();
         },


### PR DESCRIPTION
Fixes #8775. When browsing models by tag, the search was matching across
name, description, gallery name, and tags using substring matching. This
caused models without the specified tag to appear in results if the tag
string appeared anywhere in their metadata.

Added FilterByTag method for exact tag matching and updated the API to
accept a 'tag' query parameter. The frontend now uses this parameter when
clicking on tags in the 'Browse by Tags' section.