### PR TITLE
chore(model gallery): Update changed SHA256 checksums for Qwen 3.5 models (+replace unavailable 35B A3B quant.)

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -31,10 +31,10 @@
       - use_jinja:true
   files:
     - filename: llama-cpp/models/Qwen_Qwen3.5-0.8B-Q4_K_M.gguf
-      sha256: 7403b7bc6e6a47ab3fd95621de5e9ccd7c849abdcd880dcbe2cb37ce3a08b6a1
+      sha256: 9d8472987aed5b36a0d167543a695bcbf349939445ca5382a4245219829f4581
       uri: https://huggingface.co/bartowski/Qwen_Qwen3.5-0.8B-GGUF/resolve/main/Qwen_Qwen3.5-0.8B-Q4_K_M.gguf
     - filename: llama-cpp/mmproj/mmproj-Qwen_Qwen3.5-0.8B-f16.gguf
-      sha256: 805487880b1b1a1621aada1e86423c57086f8534d208eaa124a3929b758b4a8b
+      sha256: 1dc1351c82e41b48edb55fd6ddfa7ca60fb5a16b3d5abf3ce7054880dd022847
       uri: https://huggingface.co/bartowski/Qwen_Qwen3.5-0.8B-GGUF/resolve/main/mmproj-Qwen_Qwen3.5-0.8B-f16.gguf
 - name: "qwen_qwen3.5-2b"
   url: "github:mudler/LocalAI/gallery/virtual.yaml@master"
@@ -68,10 +68,10 @@
       - use_jinja:true
   files:
     - filename: llama-cpp/models/Qwen_Qwen3.5-2B-Q4_K_M.gguf
-      sha256: 1e277e5d06f17a145fc0d6b1c152a0bcc6323ac2f87f1bacdbb85c71c8660e24
+      sha256: 84aeb7fe40e7b833d71303d7f1b9f9c1991b931b5dbd214e0aa48d56a0af1f85
       uri: https://huggingface.co/bartowski/Qwen_Qwen3.5-2B-GGUF/resolve/main/Qwen_Qwen3.5-2B-Q4_K_M.gguf
     - filename: llama-cpp/mmproj/mmproj-Qwen_Qwen3.5-2B-f16.gguf
-      sha256: d08bfcf088bd2df868298508149cb7ed377470f957196396dd210413c140464c
+      sha256: 044a0ea136cca70711ae16e23b24d754b44eab6f2462d187aee4d7c7a9503d36
       uri: https://huggingface.co/bartowski/Qwen_Qwen3.5-2B-GGUF/resolve/main/mmproj-Qwen_Qwen3.5-2B-f16.gguf
 - name: "qwen_qwen3.5-4b"
   url: "github:mudler/LocalAI/gallery/virtual.yaml@master"
@@ -103,7 +103,7 @@
       - use_jinja:true
   files:
     - filename: llama-cpp/models/Qwen_Qwen3.5-4B-Q4_K_M.gguf
-      sha256: 2c08bf55fdde0b2e4bd52fa7dc6d49150e83eac997910cf014b7221c172a4b20
+      sha256: 68c9c6bfeecee13dd3b3c1de7f73b2d86e5feadc100f0f50e5e11fd2388ca66d
       uri: https://huggingface.co/bartowski/Qwen_Qwen3.5-4B-GGUF/resolve/main/Qwen_Qwen3.5-4B-Q4_K_M.gguf
     - filename: llama-cpp/mmproj/mmproj-Qwen_Qwen3.5-4B-f16.gguf
       sha256: 659b59dd44b73b1cd34af6cc424669484b06dc80f4340adf8ea84ad776eef813
@@ -253,22 +253,22 @@
       - use_jinja:true
   files:
     - filename: llama-cpp/models/Qwen3.5-397B-A17B-Q4_K_M-00001-of-00006.gguf
-      sha256: 1300b09fae0f87ee8dc10f2b17e0070eaf73a3561e8664a3fa307fcad50c55e3
+      sha256: 63c290c9be83e1b4dd41833d81bd933afd535d65657579b9f92f5c3f76e0218d
       uri: https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF/resolve/main/Q4_K_M/Qwen3.5-397B-A17B-Q4_K_M-00001-of-00006.gguf
     - filename: llama-cpp/models/Qwen3.5-397B-A17B-Q4_K_M-00002-of-00006.gguf
-      sha256: 2bc58495b9108480cd9f3ceea0c323ddcb9fceffe354e56b71d48ef01c35ef60
+      sha256: dc94995a3605f3130700e96df51ee56cf93bd9340fe891918403450556453ed7
       uri: https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF/resolve/main/Q4_K_M/Qwen3.5-397B-A17B-Q4_K_M-00002-of-00006.gguf
     - filename: llama-cpp/models/Qwen3.5-397B-A17B-Q4_K_M-00003-of-00006.gguf
-      sha256: 64954cb1376d1de1778ddad0c8231f4bbd15492627caf118a685ae475d3efa81
+      sha256: 2952dadb60137f413d5f70f6ca3c06007e24198e712c882a094432f58f76c230
       uri: https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF/resolve/main/Q4_K_M/Qwen3.5-397B-A17B-Q4_K_M-00003-of-00006.gguf
     - filename: llama-cpp/models/Qwen3.5-397B-A17B-Q4_K_M-00004-of-00006.gguf
-      sha256: 554485298f616b0ff59e1ec2982167d55bece87f682827c68a32acd0fd03425f
+      sha256: c7b99959e8fb78c8cfc9b71f3da07a2b4a6d39bf377dfa226f0a7b730c8cf3ba
       uri: https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF/resolve/main/Q4_K_M/Qwen3.5-397B-A17B-Q4_K_M-00004-of-00006.gguf
     - filename: llama-cpp/models/Qwen3.5-397B-A17B-Q4_K_M-00005-of-00006.gguf
-      sha256: 24d6f5668ea2c6eaddde5f08ea6325b495bc66be7217bb2de0a5c8b5eace1c51
+      sha256: eeea4540f7289ab3baad2b3f2b4b6798e70a1802b9b4b269799a1f04d75b0af0
       uri: https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF/resolve/main/Q4_K_M/Qwen3.5-397B-A17B-Q4_K_M-00005-of-00006.gguf
     - filename: llama-cpp/models/Qwen3.5-397B-A17B-Q4_K_M-00006-of-00006.gguf
-      sha256: e36715e951da55d9e48b40aab61ba7829a7bfad5c6a155eb79aa13fe8b39347f
+      sha256: d3bf93bb9fe007910ae9c0fd130d7776d7c6149635c9e7f158312308beb9b754
       uri: https://huggingface.co/unsloth/Qwen3.5-397B-A17B-GGUF/resolve/main/Q4_K_M/Qwen3.5-397B-A17B-Q4_K_M-00006-of-00006.gguf
     - filename: llama-cpp/mmproj/mmproj-F32.gguf
       sha256: e47df150363dd9d53b4ddf01e5477a6803f7fc2d2e0341064dcf39511ad5f110
@@ -322,13 +322,13 @@
       - use_jinja:true
   files:
     - filename: llama-cpp/models/Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf
-      sha256: 914ac4aea369a78a16db389cd11293bd7ed4d2fe7960cdc7bc5140b21e5d8074
+      sha256: 467c9bd92ea518539cf75bf5a5fbfbd35e9a0b40d766ccaa67bf120e12041df3
       uri: https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf
     - filename: llama-cpp/models/Qwen3.5-122B-A10B-Q4_K_M-00002-of-00003.gguf
-      sha256: 073b82aaccefa6b360d4220299e488dc8810ad76d286b282c44ec374534e41d4
+      sha256: 90db14846413aebdac365b57206441437cac5f7e5037d94b325f0167f902e6e7
       uri: https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00002-of-00003.gguf
     - filename: llama-cpp/models/Qwen3.5-122B-A10B-Q4_K_M-00003-of-00003.gguf
-      sha256: 0c9eed4a95f8fac03cb57e3fb63a49dcf400f958d86a387b98f0e9b4fbb54fd6
+      sha256: e3c24b8ebec070bb4f69ea0aca25a16531da7440cd515529953e046882901f97
       uri: https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00003-of-00003.gguf
     - filename: llama-cpp/mmproj/mmproj-F32.gguf
       sha256: ba889ce164a6cc7ffe34296851d0f2bbe139bd27deeb7fe3830d08bd776a28a6
@@ -339,7 +339,7 @@
     - https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF
   overrides:
     parameters:
-      model: llama-cpp/models/Qwen3.5-35B-A3B-UD-Q4_K_M.gguf
+      model: llama-cpp/models/Qwen3.5-35B-A3B-UD-Q4_K_L.gguf
     name: Qwen3.5-35B-A3B-GGUF
     backend: llama-cpp
     template:
@@ -354,9 +354,9 @@
     options:
       - use_jinja:true
   files:
-    - filename: llama-cpp/models/Qwen3.5-35B-A3B-UD-Q4_K_M.gguf
-      sha256: 223138866b87b12e68ffb43a1d45afb572921e9cd4c594e6a736df94c5130466
-      uri: https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF/resolve/main/Qwen3.5-35B-A3B-UD-Q4_K_M.gguf
+    - filename: llama-cpp/models/Qwen3.5-35B-A3B-UD-Q4_K_L.gguf
+      sha256: b65bba850b65e989ac8c37978970b2fe2ed3aa404fcb8408c9b3f2df13e6ab0b
+      uri: https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF/resolve/main/Qwen3.5-35B-A3B-UD-Q4_K_L.gguf
     - filename: llama-cpp/mmproj/mmproj-F32.gguf
       uri: https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF/resolve/main/mmproj-F32.gguf
       sha256: 5de13d9052180b24cceda247af3023e3a2cbe785612198efe05b81905e3a5dc7


### PR DESCRIPTION
**Description**

This PR fixes invalid SHA256 checksums for updated Qwen 3.5 models and derivatives, and replaces currently non-existing `Qwen3.5-35B-A3B-UD-Q4_K_M` quantization with `Qwen3.5-35B-A3B-UD-Q4_K_L` (as nearest replacement) for Qwen 3.5 35B A3B model. 

**Notes for Reviewers**

PR is being submitted as draft due to need of testing for updated models. Smaller models I can test by myself over time, but I am looking for help with big size ones, as I cannot run those on my hardware. Help with testing smaller models is welcome too, as I am busy currently, and won't be able to test all the smaller ones too quickly due to that.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.