### PR TITLE
fix(llama-cpp): Set enable_thinking in the correct place

### DIFF
--- a/backend/cpp/llama-cpp/grpc-server.cpp
+++ b/backend/cpp/llama-cpp/grpc-server.cpp
@@ -1348,11 +1348,14 @@ public:
                     body_json["min_p"] = data["min_p"];
                 }
 
-                // Pass metadata fields to body_json
+                // Pass enable_thinking via chat_template_kwargs (where oaicompat_chat_params_parse reads it)
                 const auto& metadata = request->metadata();
                 auto et_it = metadata.find("enable_thinking");
                 if (et_it != metadata.end()) {
-                    body_json["enable_thinking"] = (et_it->second == "true");
+                    if (!body_json.contains("chat_template_kwargs")) {
+                        body_json["chat_template_kwargs"] = json::object();
+                    }
+                    body_json["chat_template_kwargs"]["enable_thinking"] = (et_it->second == "true");
                 }
 
                 // Debug: Print full body_json before template processing (includes messages, tools, tool_choice, etc.)
@@ -2071,11 +2074,14 @@ public:
                     body_json["min_p"] = data["min_p"];
                 }
 
-                // Pass metadata fields to body_json
+                // Pass enable_thinking via chat_template_kwargs (where oaicompat_chat_params_parse reads it)
                 const auto& predict_metadata = request->metadata();
                 auto predict_et_it = predict_metadata.find("enable_thinking");
                 if (predict_et_it != predict_metadata.end()) {
-                    body_json["enable_thinking"] = (predict_et_it->second == "true");
+                    if (!body_json.contains("chat_template_kwargs")) {
+                        body_json["chat_template_kwargs"] = json::object();
+                    }
+                    body_json["chat_template_kwargs"]["enable_thinking"] = (predict_et_it->second == "true");
                 }
 
                 // Debug: Print full body_json before template processing (includes messages, tools, tool_choice, etc.)


### PR DESCRIPTION
**Description**

Allows thinking to be properly disabled when using Jinja templates

**Notes for Reviewers**

We were setting enable_thinking in the wrong map. It should be part of chat_template_kwargs

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->
