### PR TITLE
fix(collections): start agent pool after http server

### DIFF
--- a/core/application/application.go
+++ b/core/application/application.go
@@ -102,19 +102,24 @@ func (a *Application) start() error {
 
 	a.agentJobService = agentJobService
 
-	// Initialize agent pool service (LocalAGI integration)
-	if a.applicationConfig.AgentPool.Enabled {
-		aps, err := services.NewAgentPoolService(a.applicationConfig)
-		if err == nil {
-			if err := aps.Start(a.applicationConfig.Context); err != nil {
-				xlog.Error("Failed to start agent pool", "error", err)
-			} else {
-				a.agentPoolService = aps
-			}
-		} else {
-			xlog.Error("Failed to create agent pool service", "error", err)
-		}
-	}
-
 	return nil
+}
+
+// StartAgentPool initializes and starts the agent pool service (LocalAGI integration).
+// This must be called after the HTTP server is listening, because backends like
+// PostgreSQL need to call the embeddings API during collection initialization.
+func (a *Application) StartAgentPool() {
+	if !a.applicationConfig.AgentPool.Enabled {
+		return
+	}
+	aps, err := services.NewAgentPoolService(a.applicationConfig)
+	if err != nil {
+		xlog.Error("Failed to create agent pool service", "error", err)
+		return
+	}
+	if err := aps.Start(a.applicationConfig.Context); err != nil {
+		xlog.Error("Failed to start agent pool", "error", err)
+		return
+	}
+	a.agentPoolService = aps
 }

--- a/core/cli/run.go
+++ b/core/cli/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -425,5 +426,38 @@ func (r *RunCMD) Run(ctx *cliContext.Context) error {
 		}
 	})
 
+	// Start the agent pool after the HTTP server is listening, because
+	// backends like PostgreSQL need to call the embeddings API during
+	// collection initialization.
+	go func() {
+		waitForServerReady(r.Address, app.ApplicationConfig().Context)
+		app.StartAgentPool()
+	}()
+
 	return appHTTP.Start(r.Address)
+}
+
+// waitForServerReady polls the given address until the HTTP server is
+// accepting connections or the context is cancelled.
+func waitForServerReady(address string, ctx context.Context) {
+	// Ensure the address has a host component for dialing.
+	// Echo accepts ":8080" but net.Dial needs a resolvable host.
+	host, port, err := net.SplitHostPort(address)
+	if err == nil && host == "" {
+		address = "127.0.0.1:" + port
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		conn, err := net.DialTimeout("tcp", address, 500*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
 }


### PR DESCRIPTION
Otherwise if using collections with postgresql we create a deadlock, as we need embeddings to be up

**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->