### PR TITLE
fix(conf): Don't overwrite env provided galleries with runtime conf

### DIFF
--- a/core/application/config_file_watcher.go
+++ b/core/application/config_file_watcher.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"time"
 
 	"dario.cat/mergo"
@@ -211,6 +212,8 @@ func readRuntimeSettingsJson(startupAppConfig config.ApplicationConfig) fileHand
 		envP2PToken := appConfig.P2PToken == startupAppConfig.P2PToken
 		envP2PNetworkID := appConfig.P2PNetworkID == startupAppConfig.P2PNetworkID
 		envFederated := appConfig.Federated == startupAppConfig.Federated
+		envGalleries := slices.Equal(appConfig.Galleries, startupAppConfig.Galleries)
+		envBackendGalleries := slices.Equal(appConfig.BackendGalleries, startupAppConfig.BackendGalleries)
 		envAutoloadGalleries := appConfig.AutoloadGalleries == startupAppConfig.AutoloadGalleries
 		envAutoloadBackendGalleries := appConfig.AutoloadBackendGalleries == startupAppConfig.AutoloadBackendGalleries
 		envAgentJobRetentionDays := appConfig.AgentJobRetentionDays == startupAppConfig.AgentJobRetentionDays
@@ -324,10 +327,10 @@ func readRuntimeSettingsJson(startupAppConfig config.ApplicationConfig) fileHand
 			if settings.Federated != nil && !envFederated {
 				appConfig.Federated = *settings.Federated
 			}
-			if settings.Galleries != nil {
+			if settings.Galleries != nil && !envGalleries {
 				appConfig.Galleries = *settings.Galleries
 			}
-			if settings.BackendGalleries != nil {
+			if settings.BackendGalleries != nil && !envBackendGalleries {
 				appConfig.BackendGalleries = *settings.BackendGalleries
 			}
 			if settings.AutoloadGalleries != nil && !envAutoloadGalleries {


### PR DESCRIPTION
**Description**

This makes the galleries setting like other config options where the env var take precedence.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->
