### PR TITLE
fix(ui): Refresh model list on deletion

### DIFF
--- a/core/http/endpoints/localai/gallery.go
+++ b/core/http/endpoints/localai/gallery.go
@@ -20,6 +20,7 @@ type ModelGalleryEndpointService struct {
 	backendGalleries []config.Gallery
 	modelPath        string
 	galleryApplier   *services.GalleryService
+	configLoader     *config.ModelConfigLoader
 }
 
 type GalleryModel struct {
@@ -27,12 +28,13 @@ type GalleryModel struct {
 	gallery.GalleryModel
 }
 
-func CreateModelGalleryEndpointService(galleries []config.Gallery, backendGalleries []config.Gallery, systemState *system.SystemState, galleryApplier *services.GalleryService) ModelGalleryEndpointService {
+func CreateModelGalleryEndpointService(galleries []config.Gallery, backendGalleries []config.Gallery, systemState *system.SystemState, galleryApplier *services.GalleryService, configLoader *config.ModelConfigLoader) ModelGalleryEndpointService {
 	return ModelGalleryEndpointService{
 		galleries:        galleries,
 		backendGalleries: backendGalleries,
 		modelPath:        systemState.Model.ModelsPath,
 		galleryApplier:   galleryApplier,
+		configLoader:     configLoader,
 	}
 }
 
@@ -102,6 +104,8 @@ func (mgs *ModelGalleryEndpointService) DeleteModelGalleryEndpoint() echo.Handle
 			Delete:             true,
 			GalleryElementName: modelName,
 		}
+
+		mgs.configLoader.RemoveModelConfig(modelName)
 
 		uuid, err := uuid.NewUUID()
 		if err != nil {

--- a/core/http/routes/localai.go
+++ b/core/http/routes/localai.go
@@ -40,7 +40,7 @@ func RegisterLocalAIRoutes(router *echo.Echo,
 
 		// Edit model page
 		router.GET("/models/edit/:name", localai.GetEditModelPage(cl, appConfig))
-		modelGalleryEndpointService := localai.CreateModelGalleryEndpointService(appConfig.Galleries, appConfig.BackendGalleries, appConfig.SystemState, galleryService)
+		modelGalleryEndpointService := localai.CreateModelGalleryEndpointService(appConfig.Galleries, appConfig.BackendGalleries, appConfig.SystemState, galleryService, cl)
 		router.POST("/models/apply", modelGalleryEndpointService.ApplyModelGalleryEndpoint())
 		router.POST("/models/delete/:name", modelGalleryEndpointService.DeleteModelGalleryEndpoint())
 


### PR DESCRIPTION
When deleting a model it was possible that it would still be visible in the system menu and model selector due to a race. Now we sync the data properly.
