### PR TITLE
fix(openresponses): do not omit required field ORItemParam.Arguments

### DIFF
--- a/core/schema/openresponses.go
+++ b/core/schema/openresponses.go
@@ -96,7 +96,7 @@ type ORItemParam struct {
 	// Function call fields
 	CallID    string `json:"call_id,omitempty"`
 	Name      string `json:"name,omitempty"`
-	Arguments string `json:"arguments,omitempty"`
+	Arguments string `json:"arguments"`
 
 	// Function call output fields
 	Output interface{} `json:"output,omitempty"` // string or []ORContentPart


### PR DESCRIPTION
See #9047

**Description**

Continuation of #9047. With this, whole-chain tool calling via Responses API works in both non-streaming and non-streaming mode with a client that enforces the OpenAPI schema.

(This does not mean *everything* complies with the schema, just the parts I exercised.)

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->