### PR TITLE
fix(auth): do not allow to register in invite mode

### DIFF
--- a/core/http/auth/oauth.go
+++ b/core/http/auth/oauth.go
@@ -213,6 +213,22 @@ func (m *OAuthManager) CallbackHandler(providerName string, db *gorm.DB, adminEm
 			})
 		}
 
+		// In invite mode, block new OAuth users who don't have a valid invite code
+		// to prevent phantom pending records from accumulating in the DB.
+		// The first user (no users in DB yet) is always allowed through.
+		if registrationMode == "invite" && inviteCode == "" {
+			var existing User
+			if err := db.Where("provider = ? AND subject = ?", providerName, userInfo.Subject).First(&existing).Error; err != nil {
+				// Check if this would be the first user (always allowed)
+				var userCount int64
+				db.Model(&User{}).Count(&userCount)
+				if userCount > 0 {
+					// New user without invite code — reject without creating a DB record
+					return c.Redirect(http.StatusTemporaryRedirect, "/login?error=invite_required")
+				}
+			}
+		}
+
 		// Upsert user (with invite code support)
 		user, err := upsertOAuthUser(db, providerName, userInfo, adminEmail, registrationMode)
 		if err != nil {

--- a/core/http/react-ui/src/pages/Login.jsx
+++ b/core/http/react-ui/src/pages/Login.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { useAuth } from '../context/AuthContext'
 import { apiUrl } from '../utils/basePath'
 import './auth.css'
@@ -7,6 +7,7 @@ import './auth.css'
 export default function Login() {
   const navigate = useNavigate()
   const { code: urlInviteCode } = useParams()
+  const [searchParams] = useSearchParams()
   const { authEnabled, user, loading: authLoading, refresh } = useAuth()
   const [providers, setProviders] = useState([])
   const [hasUsers, setHasUsers] = useState(true)
@@ -41,6 +42,14 @@ export default function Login() {
       setMode('register')
     }
   }, [urlInviteCode])
+
+  // Show error from OAuth redirect (e.g. invite_required)
+  useEffect(() => {
+    const errorParam = searchParams.get('error')
+    if (errorParam === 'invite_required') {
+      setError('A valid invite code is required to register')
+    }
+  }, [searchParams])
 
   useEffect(() => {
     fetch(apiUrl('/api/auth/status'))
@@ -252,12 +261,14 @@ export default function Login() {
             <button type="submit" className="btn btn-primary login-btn-full" disabled={submitting}>
               {submitting ? 'Signing in...' : 'Sign In'}
             </button>
-            <p className="login-footer">
-              Don't have an account?{' '}
-              <button type="button" className="login-link" onClick={() => { setMode('register'); setError(''); setMessage('') }}>
-                Register
-              </button>
-            </p>
+            {!(registrationMode === 'invite' && hasUsers && !urlInviteCode) && (
+              <p className="login-footer">
+                Don't have an account?{' '}
+                <button type="button" className="login-link" onClick={() => { setMode('register'); setError(''); setMessage('') }}>
+                  Register
+                </button>
+              </p>
+            )}
           </form>
         )}
 


### PR DESCRIPTION
**Description**

This PR fixes a small nuance where users could still register in oauth mode when invite is enabled, even if they required manual approval.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->