### PR TITLE
fix(docs): Use notice instead of alert

### DIFF
--- a/.agents/coding-style.md
+++ b/.agents/coding-style.md
@@ -49,3 +49,4 @@ The project documentation is located in `docs/content`. When adding new features
 - **Feature Documentation**: If you add a new feature (like a new backend or API endpoint), create a new markdown file in `docs/content/features/` explaining what it is, how to configure it, and how to use it.
 - **Configuration**: If you modify configuration options, update the relevant sections in `docs/content/`.
 - **Examples**: providing concrete examples (like YAML configuration blocks) is highly encouraged to help users get started quickly.
+- **Shortcodes**: Use `{{% notice note %}}`, `{{% notice tip %}}`, or `{{% notice warning %}}` for callout boxes. Do **not** use `{{% alert %}}` — that shortcode does not exist in this project's Hugo theme and will break the docs build.

--- a/docs/content/features/fine-tuning.md
+++ b/docs/content/features/fine-tuning.md
@@ -17,9 +17,9 @@ LocalAI supports fine-tuning LLMs directly through the API and Web UI. Fine-tuni
 
 Fine-tuning is always enabled. When authentication is enabled, fine-tuning is a per-user feature (default OFF). Admins can enable it for specific users via the user management API.
 
-{{% alert note %}}
+{{% notice note %}}
 This feature is **experimental** and may change in future releases.
-{{% /alert %}}
+{{% /notice %}}
 
 ## Quick Start
 

--- a/docs/content/features/quantization.md
+++ b/docs/content/features/quantization.md
@@ -7,9 +7,9 @@ url = '/features/quantization/'
 
 LocalAI supports model quantization directly through the API and Web UI. Quantization converts HuggingFace models to GGUF format and compresses them to smaller sizes for efficient inference with llama.cpp.
 
-{{% alert note %}}
+{{% notice note %}}
 This feature is **experimental** and may change in future releases.
-{{% /alert %}}
+{{% /notice %}}
 
 ## Supported Backends
 


### PR DESCRIPTION
**Description**

Fix places where alert was used instead of notice. Also update the agent instructions because they keep guessing the wrong code.

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->
