### PR TITLE
docs: Update Home Assistant integrations list

### DIFF
--- a/docs/content/integrations.md
+++ b/docs/content/integrations.md
@@ -72,9 +72,10 @@ Feel free to open up a Pull request (by clicking at the "Edit page" below) to ge
 
 ### Home Automation
 
-- [hass-openai-custom-conversation](https://github.com/drndos/hass-openai-custom-conversation) — Home Assistant integration
-- [ha-llmvision](https://github.com/valentinfrlch/ha-llmvision) — Home Assistant LLM Vision
-- [HA-LocalAI-Monitor](https://github.com/loryanstrant/HA-LocalAI-Monitor) — Home Assistant monitoring
+- [Extended OpenAI Conversation](https://github.com/jekalmin/extended_openai_conversation) — Conversation agent for Home Assistant that supports a custom OpenAI endpoint
+- [LLM Vision](https://github.com/valentinfrlch/ha-llmvision) — Image & video feed analysis for Home Assistant
+- [OpenAI TTS Speech Service](https://github.com/sfortis/openai_tts) - OpenAI TTS custom component for Home Assistant
+- [LocalAI Monitor](https://github.com/loryanstrant/HA-LocalAI-Monitor) — Monitor & control of LocalAI from Home Assistant
 - Nextcloud [integration plugin](https://apps.nextcloud.com/apps/integration_openai) and [AI assistant](https://apps.nextcloud.com/apps/assistant)
 
 ### Automation & DevOps


### PR DESCRIPTION
**Description**

This pull request updates the Home Automation integrations section in the documentation to provide clearer names and descriptions for several Home Assistant-related projects, and adds a new integration for OpenAI TTS. The changes improve clarity and make it easier for users to understand the purpose of each integration.

**Changes**

* Removed entry for "hass-openai-custom-conversation" as has not been updated for 2 years.
* Added a new entry for "OpenAI TTS Speech Service," a custom component for Home Assistant that provides OpenAI-based text-to-speech functionality.
* Added new entry for "Extended OpenAI Conversation", a custom component for Home Assistant that allows for custom OpenAI-based endpoints.
* Corrected the description for "LocalAI Monitor" as being a custom component for Home Assistant that monitors LocalAI instances.
* Updated the names and descriptions of existing Home Assistant integrations to be more descriptive and user-friendly, including renaming and clarifying the purpose of each project.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.