### PR TITLE
feat(embeddings): add OpenAI-compatible `dimensions` parameter for Matryoshka models

### DIFF
--- a/backend/backend.proto
+++ b/backend/backend.proto
@@ -180,6 +180,7 @@ message PredictOptions {
   int32 TopLogprobs = 51;  // Number of top logprobs to return per token (maps to OpenAI top_logprobs parameter)
   map<string, string> Metadata = 52;  // Generic per-request metadata (e.g., enable_thinking)
   float MinP = 53;  // Minimum probability sampling threshold (0.0 = disabled)
+  int32 Dimensions = 54;  // Truncate embedding vectors to this many dimensions (OpenAI-compatible `dimensions` parameter for Matryoshka models)
 }
 
 // ToolCallDelta represents an incremental tool call update from the C++ parser.

--- a/backend/cpp/llama-cpp/grpc-server.cpp
+++ b/backend/cpp/llama-cpp/grpc-server.cpp
@@ -2452,8 +2452,12 @@ public:
 
         std::cout << "[DEBUG] Responses size: " << responses.size() << std::endl;
 
-        // Process the responses and extract embeddings
+        // Process the responses and extract embeddings.
+        // When request->dimensions() > 0 truncate each vector to that many dimensions
+        // (implements the OpenAI-compatible `dimensions` parameter for Matryoshka models).
+        const int n_truncate = request->dimensions();
         for (const auto & response_elem : responses) {
+            int dims_added = 0;
             // Check if the response has an "embedding" field
             if (response_elem.contains("embedding")) {
                 json embedding_data = json_value(response_elem, "embedding", json::array());
@@ -2462,7 +2466,9 @@ public:
                     for (const auto & embedding_vector : embedding_data) {
                         if (embedding_vector.is_array()) {
                             for (const auto & embedding_value : embedding_vector) {
+                                if (n_truncate > 0 && dims_added >= n_truncate) break;
                                 embeddingResult->add_embeddings(embedding_value.get<float>());
+                                dims_added++;
                             }
                         }
                     }
@@ -2471,7 +2477,9 @@ public:
                 // Check if the response itself contains the embedding data directly
                 if (response_elem.is_array()) {
                     for (const auto & embedding_value : response_elem) {
+                        if (n_truncate > 0 && dims_added >= n_truncate) break;
                         embeddingResult->add_embeddings(embedding_value.get<float>());
+                        dims_added++;
                     }
                 }
             }

--- a/core/backend/options.go
+++ b/core/backend/options.go
@@ -284,6 +284,10 @@ func gRPCPredictOpts(c config.ModelConfig, modelPath string) *pb.PredictOptions 
 		TypicalP:            float32(*c.TypicalP),
 	}
 
+	if c.Dimensions != nil {
+		pbOpts.Dimensions = int32(*c.Dimensions)
+	}
+
 	metadata := map[string]string{}
 	if c.ReasoningConfig.DisableReasoning != nil {
 		if *c.ReasoningConfig.DisableReasoning {

--- a/core/schema/prediction.go
+++ b/core/schema/prediction.go
@@ -136,4 +136,7 @@ type PredictionOptions struct {
 
 	// Embedding encoding format: "float" (default) or "base64" (OpenAI Node.js SDK default)
 	EncodingFormat string `json:"encoding_format,omitempty" yaml:"encoding_format,omitempty"`
+
+	// Embedding dimensions: truncate vectors to this length (OpenAI-compatible `dimensions` parameter for Matryoshka models)
+	Dimensions *int `json:"dimensions,omitempty" yaml:"dimensions,omitempty"`
 }


### PR DESCRIPTION
## Summary

Wires the `dimensions` request field end-to-end so callers can request truncated embedding vectors — e.g. `dimensions: 256` on a 1024-dim model. This matches the [OpenAI embeddings API](https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-dimensions) and is useful for Matryoshka Representation Learning (MRL) models like **jina-embeddings-v3** where lower-dimensional projections are semantically valid.

### Changes

| File | Change |
|------|--------|
| `backend/backend.proto` | Add `int32 Dimensions = 54` to `PredictOptions` |
| `core/schema/prediction.go` | Expose `Dimensions *int` in the API schema (`json:"dimensions"`) |
| `core/backend/options.go` | Forward `Dimensions` into `gRPCPredictOpts` |
| `backend/cpp/llama-cpp/grpc-server.cpp` | Truncate embedding vectors to `n_truncate` dims in `Embedding()` when `dimensions > 0` |

### Behaviour

- When `dimensions` is omitted (or 0): no change, full-length vectors returned as before.
- When `dimensions = N`: each embedding vector is truncated to the first N components before returning.
- The truncation is a no-op for models that don't support MRL; it does not re-normalise the vector (same semantics as OpenAI).

### Example

```bash
curl http://localhost:8080/v1/embeddings \
  -H "Content-Type: application/json" \
  -d '{"model":"jina-embeddings-v3","input":"hello","dimensions":256}'
# Returns a 256-dim vector instead of the default 1024-dim
```

### Notes

- No `make protogen` output is included here to keep the diff reviewable; the generated `*.pb.go` / `*.pb.cc` files should be regenerated by the maintainer or CI after merge.
- Ref: #8809

## Test plan

- [ ] Send an embeddings request without `dimensions` → full-length vector returned
- [ ] Send an embeddings request with `dimensions: 256` against a 1024-dim model → 256-element array returned
- [ ] Send `dimensions: 0` → full-length vector (no truncation)
- [ ] Verify `make protogen` succeeds after the proto change

🤖 Generated with [Claude Code](https://claude.com/claude-code)