### PR TITLE
docs(gpu): add ROCm 7.x and RDNA 3.5 / Strix Halo (gfx1151) to GPU acceleration guide

### DIFF
--- a/docs/content/features/GPU-acceleration.md
+++ b/docs/content/features/GPU-acceleration.md
@@ -169,33 +169,46 @@ Due to the nature of ROCm it is best to run all implementations in containers as
 ### AMD Strix Halo / gfx1151 (RDNA 3.5)
 
 AMD Ryzen AI MAX+ (Strix Halo) APUs with an integrated Radeon 8060S (gfx1151 / RDNA 3.5) are
-supported with ROCm 7.11.0+. These systems (e.g. Geekom A9 Mega, ASUS ROG Flow Z13 2025)
-provide up to 96 GB of unified VRAM accessible by the GPU.
+supported with ROCm 7.11.0+. These systems provide up to 96 GB of unified VRAM accessible by the GPU.
 
-**Required kernel boot parameters** (add to `GRUB_CMDLINE_LINUX` and run `update-grub`):
+Tested on: Geekom A9 Mega (AMD Ryzen AI MAX+ 395, ROCm 7.11.0, Ubuntu 24.04, kernel 6.14).
+
+**Required kernel boot parameters** (add to `GRUB_CMDLINE_LINUX` in `/etc/default/grub`, then run `update-grub`):
 ```
 iommu=pt amdgpu.gttsize=126976 ttm.pages_limit=32505856
 ```
 
-**Required runtime environment variables** (set automatically in LocalAI containers):
-```bash
-HSA_OVERRIDE_GFX_VERSION=11.5.1
-ROCBLAS_USE_HIPBLASLT=1
-```
+**Required environment variables** for gfx1151 (set automatically in the ROCm 7.x image):
 
-**Running LocalAI on gfx1151:**
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `HSA_OVERRIDE_GFX_VERSION` | `11.5.1` | Tells the HSA runtime to use gfx1151 code objects |
+| `ROCBLAS_USE_HIPBLASLT` | `1` | Prefer hipBLASLt over rocBLAS for GEMM (required for gfx1151) |
+| `HSA_XNACK` | `1` | Enable XNACK (memory-fault retry) for APU unified memory |
+| `HSA_ENABLE_SDMA` | `0` | Disable SDMA engine — causes hangs on APU/iGPU configs |
+
+> **Warning:** Do **not** set `GGML_CUDA_ENABLE_UNIFIED_MEMORY`. The C-level check is
+> `getenv(...) != nullptr`, so even `=0` activates `hipMallocManaged` (allocates from
+> system RAM instead of the 96 GB VRAM pool).
+
+**Running LocalAI on gfx1151** (using the ROCm 7.x image, tag suffix `-gpu-hipblas-rocm7`):
 ```yaml
-    image: quay.io/go-skynet/local-ai:master-gpu-hipblas
+    image: quay.io/go-skynet/local-ai:master-gpu-hipblas-rocm7
     environment:
       - HSA_OVERRIDE_GFX_VERSION=11.5.1
       - ROCBLAS_USE_HIPBLASLT=1
-      - GPU_TARGETS=gfx1151
+      - HSA_XNACK=1
+      - HSA_ENABLE_SDMA=0
     devices:
       - /dev/dri
       - /dev/kfd
     group_add:
       - video
 ```
+
+> **Note:** When updating the image, always recreate the container (`docker compose up --force-recreate`)
+> rather than just restarting it. `docker compose restart` preserves the old container environment
+> and will not pick up updated env vars from the image.
 
 For llama.cpp models, enable flash attention (`--flash-attention`) and disable mmap (`--no-mmap`) for best performance on APU systems.
 

--- a/docs/content/features/GPU-acceleration.md
+++ b/docs/content/features/GPU-acceleration.md
@@ -178,7 +178,7 @@ Tested on: Geekom A9 Mega (AMD Ryzen AI MAX+ 395, ROCm 7.11.0, Ubuntu 24.04, ker
 iommu=pt amdgpu.gttsize=126976 ttm.pages_limit=32505856
 ```
 
-**Required environment variables** for gfx1151 (set automatically in the ROCm 7.x image):
+**Required environment variables** for gfx1151 (set automatically in the ROCm/hipblas image):
 
 | Variable | Value | Purpose |
 |----------|-------|---------|
@@ -191,9 +191,9 @@ iommu=pt amdgpu.gttsize=126976 ttm.pages_limit=32505856
 > `getenv(...) != nullptr`, so even `=0` activates `hipMallocManaged` (allocates from
 > system RAM instead of the 96 GB VRAM pool).
 
-**Running LocalAI on gfx1151** (using the ROCm 7.x image, tag suffix `-gpu-hipblas-rocm7`):
+**Running LocalAI on gfx1151** (use the standard ROCm/hipblas image — there is only one ROCm image, and it ships with ROCm 7.x by default):
 ```yaml
-    image: quay.io/go-skynet/local-ai:master-gpu-hipblas-rocm7
+    image: quay.io/go-skynet/local-ai:master-gpu-hipblas
     environment:
       - HSA_OVERRIDE_GFX_VERSION=11.5.1
       - ROCBLAS_USE_HIPBLASLT=1

--- a/docs/content/features/GPU-acceleration.md
+++ b/docs/content/features/GPU-acceleration.md
@@ -166,12 +166,45 @@ Due to the nature of ROCm it is best to run all implementations in containers as
 - Make sure to do not use GPU assigned for compute for desktop rendering.
 - Ensure at least 100GB of free space on disk hosting container runtime and storing images prior to installation.
 
+### AMD Strix Halo / gfx1151 (RDNA 3.5)
+
+AMD Ryzen AI MAX+ (Strix Halo) APUs with an integrated Radeon 8060S (gfx1151 / RDNA 3.5) are
+supported with ROCm 7.11.0+. These systems (e.g. Geekom A9 Mega, ASUS ROG Flow Z13 2025)
+provide up to 96 GB of unified VRAM accessible by the GPU.
+
+**Required kernel boot parameters** (add to `GRUB_CMDLINE_LINUX` and run `update-grub`):
+```
+iommu=pt amdgpu.gttsize=126976 ttm.pages_limit=32505856
+```
+
+**Required runtime environment variables** (set automatically in LocalAI containers):
+```bash
+HSA_OVERRIDE_GFX_VERSION=11.5.1
+ROCBLAS_USE_HIPBLASLT=1
+```
+
+**Running LocalAI on gfx1151:**
+```yaml
+    image: quay.io/go-skynet/local-ai:master-gpu-hipblas
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=11.5.1
+      - ROCBLAS_USE_HIPBLASLT=1
+      - GPU_TARGETS=gfx1151
+    devices:
+      - /dev/dri
+      - /dev/kfd
+    group_add:
+      - video
+```
+
+For llama.cpp models, enable flash attention (`--flash-attention`) and disable mmap (`--no-mmap`) for best performance on APU systems.
+
 ### Limitations
 
 Ongoing verification testing of ROCm compatibility with integrated backends.
 Please note the following list of verified backends and devices.
 
-LocalAI hipblas images are built against the following targets: gfx908, gfx90a, gfx942, gfx950, gfx1030, gfx1100, gfx1101, gfx1102, gfx1200, gfx1201
+LocalAI hipblas images are built against the following targets: gfx908, gfx90a, gfx942, gfx950, gfx1030, gfx1100, gfx1101, gfx1102, gfx1151, gfx1200, gfx1201
 
 **Note:** Starting with ROCm 6.4, AMD removed rocBLAS kernel support for older architectures (gfx803, gfx900, gfx906). Since llama.cpp and other backends depend on rocBLAS for matrix operations, these GPUs (e.g. Radeon VII) are no longer supported in pre-built images.
 
@@ -181,14 +214,15 @@ If your device is not one of the above targets, you must specify the correspondi
 
 The devices in the following list have been tested with `hipblas` images.
 
-| Backend | Verified | Devices |
-| ---- | ---- | ---- |
-| llama.cpp | yes | MI100 (gfx908), MI210/250 (gfx90a) |
-| diffusers | yes | MI100 (gfx908), MI210/250 (gfx90a) |
-| whisper | no | none |
-| coqui | no | none |
-| transformers | no | none |
-| vllm | no | none |
+| Backend | Verified | Devices | ROCm Version |
+| ---- | ---- | ---- | ---- |
+| llama.cpp | yes | MI100 (gfx908), MI210/250 (gfx90a) | 7.x |
+| llama.cpp | yes | Radeon 8060S / gfx1151 (Strix Halo) | 7.11.0 |
+| diffusers | yes | MI100 (gfx908), MI210/250 (gfx90a) | 7.x |
+| whisper | no | none | - |
+| coqui | no | none | - |
+| transformers | no | none | - |
+| vllm | no | none | - |
 
 **You can help by expanding this list.**
 


### PR DESCRIPTION
## Summary

- Adds a dedicated **AMD RDNA 3.5 / Strix Halo (gfx1151)** section with kernel boot params, required env vars, and a Docker Compose example
- Updates ROCm requirements to mention ROCm 7.x alongside 6.x
- Adds Ubuntu 24.04 to the tested OS list
- Documents the `AMDGPU_TARGETS` default (11 rocWMMA-compatible architectures) and when to override it
- Adds ROCm version column and gfx1151 / Radeon 8060S entry to the verified devices table
- Fixes typo: "deditated" → "dedicated"

### Background

AMD Ryzen AI MAX+ (Strix Halo) APUs with an integrated Radeon 8060S (gfx1151 / RDNA 3.5) expose up to 96 GB of unified VRAM to the GPU, but require ROCm 7.x (not available in ROCm 6.x) and two runtime env vars to work correctly:

```bash
HSA_OVERRIDE_GFX_VERSION=11.5.1   # tells HSA runtime to use gfx1151 code objects
ROCBLAS_USE_HIPBLASLT=1            # prefer hipBLASLt over rocBLAS GEMM
```

The companion build PR (feat(rocm) #9230) explains the AMDGPU_TARGETS default in detail: the default covers the 11 GPU architectures supported by the rocWMMA library, which is required for `-DGGML_HIP_ROCWMMA_FATTN=ON` (~50% FlashAttention speedup). GPUs outside that list (gfx803, gfx900, gfx906, gfx1012, gfx1030–1032, gfx1103, gfx1152) can still use ROCm 7.x but require a custom build with the full arch list and without the rocWMMA optimisation.

## Test plan

- [ ] Docs render correctly in Hugo / the LocalAI docs site
- [ ] Docker Compose example is functional on a Strix Halo system with the build-support PR applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)