### PR TITLE
fix(api): use query param instead of body for GET /backend/monitor

### DIFF
--- a/core/http/endpoints/localai/backend_monitor.go
+++ b/core/http/endpoints/localai/backend_monitor.go
@@ -9,7 +9,7 @@ import (
 // BackendMonitorEndpoint returns the status of the specified backend
 // @Summary Backend monitor endpoint
 // @Tags monitoring
-// @Param request body schema.BackendMonitorRequest true "Backend statistics request"
+// @Param model query string true "Model name"
 // @Success 200 {object} proto.StatusResponse "Response"
 // @Router /backend/monitor [get]
 func BackendMonitorEndpoint(bm *monitoring.BackendMonitorService) echo.HandlerFunc {


### PR DESCRIPTION
## Problem

The `/backend/monitor` endpoint uses HTTP GET but its Swagger annotation declares a request body (`@Param request body schema.BackendMonitorRequest`). This violates REST conventions and breaks:
- OpenAPI code generators
- Swagger UI (confusing UX)
- Standard HTTP clients that strip body from GET requests

## Root Cause

The Swagger annotation in `backend_monitor.go` uses `@Param request body` for a GET endpoint. Per OpenAPI spec, GET requests should not have request bodies.

## Solution

Changed the Swagger annotation from body param to query param:
```go
// Before:
// @Param request body schema.BackendMonitorRequest true "Backend statistics request"

// After:
// @Param model query string true "Model name"
```

Echo's `c.Bind()` already handles query parameters for GET requests, so no code changes are needed — only the annotation fix.

## Testing

- The endpoint already works with query params via Echo's Bind() — this just fixes the documentation/codegen.

Fixes #9207