### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/docs/content/features/agents.md
+++ b/docs/content/features/agents.md
@@ -206,6 +206,25 @@ All agent endpoints are grouped under `/api/agents/`:
 | `GET` | `/api/agents/skills/export/*` | Export a skill |
 | `POST` | `/api/agents/skills/import` | Import a skill |
 
+### Git Skill Repositories
+
+Skills can be sourced from external git repositories that follow the [SKILL.md](https://agentskills.io) standard. LocalAI clones and syncs the repository, making all included skills available to agents.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/agents/git-repos` | List configured git repos |
+| `POST` | `/api/agents/git-repos` | Add a git repo |
+| `PUT` | `/api/agents/git-repos/:id` | Update a git repo |
+| `DELETE` | `/api/agents/git-repos/:id` | Delete a git repo |
+| `POST` | `/api/agents/git-repos/:id/sync` | Sync a git repo |
+| `POST` | `/api/agents/git-repos/:id/toggle` | Toggle a git repo |
+
+**Community skill repositories:**
+
+| Skill | Description | Repository |
+|-------|-------------|------------|
+| mmx-cli | Generate text, images, video, speech, and music via MiniMax AI | [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli) |
+
 ### Collections (Knowledge Base)
 
 | Method | Path | Description |


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` to the community skill repositories table in `docs/content/features/agents.md` so the mmx-cli skill is discoverable out of the box
- Also documents the previously undocumented `/api/agents/git-repos` API endpoints (git skill repositories) in the same section
- Users can add the repo via `POST /api/agents/git-repos` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**19 lines changed, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- `POST /api/agents/git-repos` with `{"url": "https://github.com/MiniMax-AI/cli"}` → repo cloned and synced
- `GET /api/agents/skills` lists the mmx-cli skill after sync
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal