### PR TITLE
fix(ci): switch gallery-agent to sigs.k8s.io/yaml

### DIFF
--- a/.github/gallery-agent/gallery.go
+++ b/.github/gallery-agent/gallery.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	"github.com/mudler/LocalAI/core/gallery/importers"
+	"sigs.k8s.io/yaml"
 )
 
 func formatTextContent(text string) string {

--- a/.github/gallery-agent/helpers.go
+++ b/.github/gallery-agent/helpers.go
@@ -9,8 +9,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/ghodss/yaml"
 	hfapi "github.com/mudler/LocalAI/pkg/huggingface-api"
+	"sigs.k8s.io/yaml"
 )
 
 var galleryIndexPath = os.Getenv("GALLERY_INDEX_PATH")


### PR DESCRIPTION
The gallery-agent lives under .github/, which Go tooling treats as a hidden directory and excludes from './...' expansion. That means 'go mod tidy' (run on every dependabot dependency bump) repeatedly strips github.com/ghodss/yaml from go.mod/go.sum, breaking 'go run ./.github/gallery-agent' with a missing go.sum entry error.

Switch to sigs.k8s.io/yaml. API-compatible with ghodss/yaml and already pulled in as a transitive dependency via non-hidden packages, so tidy can no longer remove it.
