### PR TITLE
fix(llama-cpp): rename linked target common -> llama-common

### DIFF
--- a/backend/cpp/llama-cpp/CMakeLists.txt
+++ b/backend/cpp/llama-cpp/CMakeLists.txt
@@ -62,7 +62,7 @@ add_executable(${TARGET} grpc-server.cpp json.hpp httplib.h)
 target_include_directories(${TARGET} PRIVATE ../llava)
 target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR})
 
-target_link_libraries(${TARGET} PRIVATE common llama mtmd ${CMAKE_THREAD_LIBS_INIT} absl::flags hw_grpc_proto
+target_link_libraries(${TARGET} PRIVATE llama-common llama mtmd ${CMAKE_THREAD_LIBS_INIT} absl::flags hw_grpc_proto
   absl::flags_parse
   gRPC::${_REFLECTION}
   gRPC::${_GRPC_GRPCPP}

--- a/backend/cpp/llama-cpp/Makefile
+++ b/backend/cpp/llama-cpp/Makefile
@@ -1,5 +1,5 @@
 
-LLAMA_VERSION?=4fbdabdc61c04d1262b581e1b8c0c3b119f688ff
+LLAMA_VERSION?=45cac7ca703fb9085eae62b9121fca01d20177f6
 LLAMA_REPO?=https://github.com/ggerganov/llama.cpp
 
 CMAKE_ARGS?=


### PR DESCRIPTION
Upstream llama.cpp (45cac7ca) renamed the CMake library target `common` to `llama-common`. Linking the old name caused `target_include_directories(... PUBLIC .)` from the common/ dir to not propagate, so `#include "common.h"` failed when building grpc-server.