### PR TITLE
fix(backend-monitor): accept model as a query parameter

### DIFF
--- a/core/http/endpoints/localai/backend_monitor.go
+++ b/core/http/endpoints/localai/backend_monitor.go
@@ -9,19 +9,26 @@ import (
 // BackendMonitorEndpoint returns the status of the specified backend
 // @Summary Backend monitor endpoint
 // @Tags monitoring
-// @Param request body schema.BackendMonitorRequest true "Backend statistics request"
+// @Param model query string true "Name of the model to monitor"
 // @Success 200 {object} proto.StatusResponse "Response"
 // @Router /backend/monitor [get]
 func BackendMonitorEndpoint(bm *monitoring.BackendMonitorService) echo.HandlerFunc {
 	return func(c echo.Context) error {
-
-		input := new(schema.BackendMonitorRequest)
-		// Get input data from the request body
-		if err := c.Bind(input); err != nil {
-			return err
+		model := c.QueryParam("model")
+		// Fall back to binding the request body so pre-existing clients that
+		// sent `{"model": "..."}` with GET keep working.
+		if model == "" {
+			input := new(schema.BackendMonitorRequest)
+			if err := c.Bind(input); err != nil {
+				return err
+			}
+			model = input.Model
+		}
+		if model == "" {
+			return echo.NewHTTPError(400, "model query parameter is required")
 		}
 
-		resp, err := bm.CheckAndSample(input.Model)
+		resp, err := bm.CheckAndSample(model)
 		if err != nil {
 			return err
 		}

--- a/docs/content/features/backend-monitor.md
+++ b/docs/content/features/backend-monitor.md
@@ -14,11 +14,13 @@ LocalAI provides endpoints to monitor and manage running backends. The `/backend
 
 ### Request
 
-The request body is JSON:
+The model to monitor is passed as a query parameter:
 
-| Parameter | Type     | Required | Description                    |
-|-----------|----------|----------|--------------------------------|
-| `model`   | `string` | Yes      | Name of the model to monitor   |
+| Parameter | Type     | Required | Location | Description                    |
+|-----------|----------|----------|----------|--------------------------------|
+| `model`   | `string` | Yes      | query    | Name of the model to monitor   |
+
+For backwards compatibility, a JSON body with the same field is still accepted when the `model` query parameter is not set, but new clients should use the query parameter.
 
 ### Response
 
@@ -42,9 +44,7 @@ If the gRPC status call fails, the endpoint falls back to local process metrics:
 ### Usage
 
 ```bash
-curl http://localhost:8080/backend/monitor \
-  -H "Content-Type: application/json" \
-  -d '{"model": "my-model"}'
+curl "http://localhost:8080/backend/monitor?model=my-model"
 ```
 
 ### Example response

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -985,13 +985,11 @@ const docTemplate = `{
                 "summary": "Backend monitor endpoint",
                 "parameters": [
                     {
-                        "description": "Backend statistics request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/schema.BackendMonitorRequest"
-                        }
+                        "type": "string",
+                        "description": "Name of the model to monitor",
+                        "name": "model",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -982,13 +982,11 @@
                 "summary": "Backend monitor endpoint",
                 "parameters": [
                     {
-                        "description": "Backend statistics request",
-                        "name": "request",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/schema.BackendMonitorRequest"
-                        }
+                        "type": "string",
+                        "description": "Name of the model to monitor",
+                        "name": "model",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -2363,12 +2363,11 @@ paths:
   /backend/monitor:
     get:
       parameters:
-      - description: Backend statistics request
-        in: body
-        name: request
+      - description: Name of the model to monitor
+        in: query
+        name: model
         required: true
-        schema:
-          $ref: '#/definitions/schema.BackendMonitorRequest'
+        type: string
       responses:
         "200":
           description: Response


### PR DESCRIPTION
**Description**

This PR fixes #9207.

The `/backend/monitor` endpoint is routed as `GET` but its handler bound the model name from a request body, which is invalid per REST and breaks Swagger UI and OpenAPI codegen tools that refuse to send a body with GET (the issue reporter hit this while building a Home Assistant integration).

Changes:
- `core/http/endpoints/localai/backend_monitor.go` — read `?model=<name>` from the query string; update the Swagger `@Param` annotation accordingly. Returns 400 when no model is provided.
- `docs/content/features/backend-monitor.md` — document the query-parameter form and update the `curl` example.
- `swagger/*` — regenerated via `make protogen-go && make swagger` (no hand edits).

To keep this non-breaking, the handler falls back to binding the request body when the `model` query parameter is empty, so existing clients sending `{"model": "..."}` with GET continue to work. Happy to drop the fallback and make it a clean break if you'd prefer that.

The POST `/backend/shutdown` endpoint is left untouched — as the issue notes, it correctly uses a body per REST conventions.

**Notes for Reviewers**

- Manually verified with `curl "http://localhost:8080/backend/monitor?model=<name>"` and with the legacy body form to confirm backwards compatibility.
- Swagger files are machine-generated from the annotation; not hand-edited.
- Side note unrelated to this PR: `/v1/backend/monitor` and `/v1/backend/shutdown` are registered in the router but don't appear in the Swagger spec. Happy to file a follow-up issue if that's useful.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.