### PR TITLE
fix(kokoros): implement audio_transcription_stream trait stub

### DIFF
--- a/backend/rust/kokoros/src/service.rs
+++ b/backend/rust/kokoros/src/service.rs
@@ -341,6 +341,16 @@ impl Backend for KokorosService {
         Err(Status::unimplemented("Not supported"))
     }
 
+    type AudioTranscriptionStreamStream =
+        ReceiverStream<Result<backend::TranscriptStreamResponse, Status>>;
+
+    async fn audio_transcription_stream(
+        &self,
+        _: Request<backend::TranscriptRequest>,
+    ) -> Result<Response<Self::AudioTranscriptionStreamStream>, Status> {
+        Err(Status::unimplemented("Not supported"))
+    }
+
     async fn sound_generation(
         &self,
         _: Request<backend::SoundGenerationRequest>,


### PR DESCRIPTION
The backend.proto was updated to add AudioTranscriptionStream RPC, but the Rust KokorosService was never updated to match the regenerated tonic trait, breaking compilation with E0046.

Stubs the new streaming method as unimplemented, matching the pattern used for the other streaming RPCs Kokoros does not support.