### PR TITLE
fix(config): ignore yaml backup files in model loader

### DIFF
--- a/core/config/model_config_loader.go
+++ b/core/config/model_config_loader.go
@@ -373,9 +373,9 @@ func (bcl *ModelConfigLoader) LoadModelConfigsFromPath(path string, opts ...Conf
 		files = append(files, info)
 	}
 	for _, file := range files {
-		// Skip templates, YAML and .keep files
-		if !strings.Contains(file.Name(), ".yaml") && !strings.Contains(file.Name(), ".yml") ||
-			strings.HasPrefix(file.Name(), ".") {
+		// Only load real YAML config files and ignore dotfiles or backup variants
+		ext := strings.ToLower(filepath.Ext(file.Name()))
+		if (ext != ".yaml" && ext != ".yml") || strings.HasPrefix(file.Name(), ".") {
 			continue
 		}
 

--- a/core/config/model_test.go
+++ b/core/config/model_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -108,6 +109,51 @@ options:
 			Expect(testModel.Description).To(Equal("test model"))
 			Expect(testModel.Options).To(ContainElements("foo", "bar", "baz"))
 
+		})
+
+		It("Only loads files ending with yaml or yml", func() {
+			tmpdir, err := os.MkdirTemp("", "model-config-loader")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(tmpdir)
+
+			err = os.WriteFile(filepath.Join(tmpdir, "foo.yaml"), []byte(
+				`name: "foo-model"
+description: "formal config"
+backend: "llama-cpp"
+parameters:
+  model: "foo.gguf"
+`), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(tmpdir, "foo.yaml.bak"), []byte(
+				`name: "foo-model"
+description: "backup config"
+backend: "llama-cpp"
+parameters:
+  model: "foo-backup.gguf"
+`), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(tmpdir, "foo.yaml.bak.123"), []byte(
+				`name: "foo-backup-only"
+description: "timestamped backup config"
+backend: "llama-cpp"
+parameters:
+  model: "foo-timestamped.gguf"
+`), 0644)
+			Expect(err).ToNot(HaveOccurred())
+
+			bcl := NewModelConfigLoader(tmpdir)
+			err = bcl.LoadModelConfigsFromPath(tmpdir)
+			Expect(err).ToNot(HaveOccurred())
+
+			configs := bcl.GetAllModelsConfigs()
+			Expect(configs).To(HaveLen(1))
+			Expect(configs[0].Name).To(Equal("foo-model"))
+			Expect(configs[0].Description).To(Equal("formal config"))
+
+			_, exists := bcl.GetModelConfig("foo-backup-only")
+			Expect(exists).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
**Description**

This PR fixes #9442.

It tightens `LoadModelConfigsFromPath()` so only files whose actual extension is `.yaml` or `.yml` are loaded as model configs. Backup files such as `model.yaml.bak` and `model.yaml.bak.<timestamp>` are now ignored.

It also adds a regression test covering:
- loading a normal `.yaml` config
- ignoring `.yaml.bak`
- ignoring `.yaml.bak.<timestamp>`
- preventing backup configs from overriding the active config

**Notes for Reviewers**

- Reproduced in a live distributed deployment where stale `*.yaml.bak*` files in `/models` overrode the active config with the same `name:`.
- Verified locally in Docker with:
  - `make protogen-go`
  - copying `tests/models_fixtures/*` into `test-models`
  - `go test ./core/config`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
