### PR TITLE
[test] chore(turboquant): bump fork pin to rebase/upstream-sync-april-2026

### DIFF
--- a/backend/cpp/turboquant/Makefile
+++ b/backend/cpp/turboquant/Makefile
@@ -1,7 +1,7 @@
 
-# Pinned to the HEAD of feature/turboquant-kv-cache on https://github.com/TheTom/llama-cpp-turboquant.
+# Pinned to the HEAD of rebase/upstream-sync-april-2026 on https://github.com/TheTom/llama-cpp-turboquant.
 # Auto-bumped nightly by .github/workflows/bump_deps.yaml.
-TURBOQUANT_VERSION?=627ebbc6e27727bd4f65422d8aa60b13404993c8
+TURBOQUANT_VERSION?=7f320bb89f68096240a517783674cc17c66b7ad2
 LLAMA_REPO?=https://github.com/TheTom/llama-cpp-turboquant
 
 CMAKE_ARGS?=


### PR DESCRIPTION
Move the TurboQuant llama.cpp fork pin from feature/turboquant-kv-cache (627ebbc6) to rebase/upstream-sync-april-2026 (7f320bb8), picking up the upstream-sync work on the fork.

Testing https://github.com/TheTom/llama-cpp-turboquant/pull/101


cc @TheTom