### PR TITLE
fix(kokoros): implement face_verify and face_analyze trait stubs

### DIFF
--- a/backend/rust/kokoros/src/service.rs
+++ b/backend/rust/kokoros/src/service.rs
@@ -372,6 +372,20 @@ impl Backend for KokorosService {
         Err(Status::unimplemented("Not supported"))
     }
 
+    async fn face_verify(
+        &self,
+        _: Request<backend::FaceVerifyRequest>,
+    ) -> Result<Response<backend::FaceVerifyResponse>, Status> {
+        Err(Status::unimplemented("Not supported"))
+    }
+
+    async fn face_analyze(
+        &self,
+        _: Request<backend::FaceAnalyzeRequest>,
+    ) -> Result<Response<backend::FaceAnalyzeResponse>, Status> {
+        Err(Status::unimplemented("Not supported"))
+    }
+
     async fn stores_set(
         &self,
         _: Request<backend::StoresSetOptions>,


### PR DESCRIPTION
The backend.proto was updated to add FaceVerify and FaceAnalyze RPCs (face detection support), but the Rust KokorosService was never updated to match the regenerated tonic trait, breaking compilation with E0046:

    not all trait items implemented, missing: `face_verify`, `face_analyze`

Stubs both methods as unimplemented, matching the pattern used for the other RPCs Kokoros does not support.

Assisted-by: Claude:claude-opus-4-7 [Claude Code]
