### PR TITLE
fix(importer): emit all shards for multi-part GGUF models

### DIFF
--- a/core/gallery/importers/llama-cpp.go
+++ b/core/gallery/importers/llama-cpp.go
@@ -3,7 +3,6 @@ package importers
 import (
 	"encoding/json"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/mudler/LocalAI/core/config"
@@ -11,6 +10,7 @@ import (
 	"github.com/mudler/LocalAI/core/schema"
 	"github.com/mudler/LocalAI/pkg/downloader"
 	"github.com/mudler/LocalAI/pkg/functions"
+	hfapi "github.com/mudler/LocalAI/pkg/huggingface-api"
 	"github.com/mudler/xlog"
 	"go.yaml.in/yaml/v2"
 )
@@ -203,59 +203,34 @@ func (i *LlamaCPPImporter) Import(details Details) (gallery.ModelConfig, error) 
 			},
 		}
 	case details.HuggingFace != nil:
-		// We want to:
-		// Get first the chosen quants that match filenames
-		// OR the first mmproj/gguf file found
-		var lastMMProjFile *gallery.File
-		var lastGGUFFile *gallery.File
-		foundPreferedQuant := false
-		foundPreferedMMprojQuant := false
-
-		for _, file := range details.HuggingFace.Files {
-			// Get the mmproj prefered quants
-			if strings.Contains(strings.ToLower(file.Path), "mmproj") {
-				lastMMProjFile = &gallery.File{
-					URI:      file.URL,
-					Filename: filepath.Join("llama-cpp", "mmproj", name, filepath.Base(file.Path)),
-					SHA256:   file.SHA256,
-				}
-				if slices.ContainsFunc(mmprojQuantsList, func(quant string) bool {
-					return strings.Contains(strings.ToLower(file.Path), strings.ToLower(quant))
-				}) {
-					cfg.Files = append(cfg.Files, *lastMMProjFile)
-					foundPreferedMMprojQuant = true
-				}
-			} else if strings.HasSuffix(strings.ToLower(file.Path), "gguf") {
-				lastGGUFFile = &gallery.File{
-					URI:      file.URL,
-					Filename: filepath.Join("llama-cpp", "models", name, filepath.Base(file.Path)),
-					SHA256:   file.SHA256,
-				}
-				// get the files of the prefered quants
-				if slices.ContainsFunc(quants, func(quant string) bool {
-					return strings.Contains(strings.ToLower(file.Path), strings.ToLower(quant))
-				}) {
-					foundPreferedQuant = true
-					cfg.Files = append(cfg.Files, *lastGGUFFile)
-				}
+		// Split the repo listing into mmproj vs plain GGUF files, then group
+		// shards so every multi-part GGUF (llama.cpp `-NNNNN-of-MMMMM.gguf`
+		// pattern) is treated as one logical selection candidate. The
+		// previous implementation picked files one at a time, so sharded
+		// models ended up with only the last part referenced in the gallery
+		// entry — useless to llama.cpp, which needs shard 1 and the whole
+		// set to load a split model.
+		var mmprojFiles, ggufFiles []hfapi.ModelFile
+		for _, f := range details.HuggingFace.Files {
+			lowerPath := strings.ToLower(f.Path)
+			switch {
+			case strings.Contains(lowerPath, "mmproj"):
+				mmprojFiles = append(mmprojFiles, f)
+			case strings.HasSuffix(lowerPath, ".gguf"):
+				ggufFiles = append(ggufFiles, f)
 			}
 		}
 
-		// Make sure to add at least one file if not already present (which is the latest one)
-		if lastMMProjFile != nil && !foundPreferedMMprojQuant {
-			if !slices.ContainsFunc(cfg.Files, func(f gallery.File) bool {
-				return f.Filename == lastMMProjFile.Filename
-			}) {
-				cfg.Files = append(cfg.Files, *lastMMProjFile)
-			}
-		}
+		mmprojGroups := hfapi.GroupShards(mmprojFiles)
+		ggufGroups := hfapi.GroupShards(ggufFiles)
 
-		if lastGGUFFile != nil && !foundPreferedQuant {
-			if !slices.ContainsFunc(cfg.Files, func(f gallery.File) bool {
-				return f.Filename == lastGGUFFile.Filename
-			}) {
-				cfg.Files = append(cfg.Files, *lastGGUFFile)
-			}
+		// Emit the model group first so cfg.Files[0] is the model — callers
+		// and tests rely on the model file preceding any mmproj companion.
+		if group := pickPreferredGroup(ggufGroups, quants); group != nil {
+			appendShardGroup(&cfg, *group, filepath.Join("llama-cpp", "models", name))
+		}
+		if group := pickPreferredGroup(mmprojGroups, mmprojQuantsList); group != nil {
+			appendShardGroup(&cfg, *group, filepath.Join("llama-cpp", "mmproj", name))
 		}
 
 		// Find first mmproj file and configure it in the config file
@@ -267,7 +242,9 @@ func (i *LlamaCPPImporter) Import(details Details) (gallery.ModelConfig, error) 
 			break
 		}
 
-		// Find first non-mmproj file and configure it in the config file
+		// Find first non-mmproj file and configure it in the config file.
+		// For sharded models this is shard 1 — llama.cpp's split loader
+		// discovers the remaining shards by filename pattern from there.
 		for _, file := range cfg.Files {
 			if strings.Contains(strings.ToLower(file.Filename), "mmproj") {
 				continue
@@ -292,4 +269,49 @@ func (i *LlamaCPPImporter) Import(details Details) (gallery.ModelConfig, error) 
 	cfg.ConfigFile = string(data)
 
 	return cfg, nil
+}
+
+// pickPreferredGroup walks the preference list in priority order and returns
+// the first group whose base filename contains any preference. When nothing
+// matches, the last group wins — this preserves the historical "if the user
+// asked for a quant we don't have, fall back to whatever's available"
+// behaviour, lifted to whole shard sets.
+func pickPreferredGroup(groups []hfapi.ShardGroup, prefs []string) *hfapi.ShardGroup {
+	if len(groups) == 0 {
+		return nil
+	}
+	for _, pref := range prefs {
+		lower := strings.ToLower(pref)
+		for i := range groups {
+			if strings.Contains(strings.ToLower(groups[i].Base), lower) {
+				return &groups[i]
+			}
+		}
+	}
+	return &groups[len(groups)-1]
+}
+
+// appendShardGroup copies every shard of group into cfg.Files under dest,
+// skipping any entry whose target filename is already present so repeated
+// calls (e.g. the rare case of mmproj + model picking the same group)
+// don't produce duplicates.
+func appendShardGroup(cfg *gallery.ModelConfig, group hfapi.ShardGroup, dest string) {
+	for _, f := range group.Files {
+		target := filepath.Join(dest, filepath.Base(f.Path))
+		duplicate := false
+		for _, existing := range cfg.Files {
+			if existing.Filename == target {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		cfg.Files = append(cfg.Files, gallery.File{
+			URI:      f.URL,
+			Filename: target,
+			SHA256:   f.SHA256,
+		})
+	}
 }

--- a/core/gallery/importers/llama-cpp_test.go
+++ b/core/gallery/importers/llama-cpp_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mudler/LocalAI/core/gallery/importers"
 	. "github.com/mudler/LocalAI/core/gallery/importers"
+	hfapi "github.com/mudler/LocalAI/pkg/huggingface-api"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -193,6 +194,183 @@ var _ = Describe("LlamaCPPImporter", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(modelConfig.ConfigFile).To(ContainSubstring("backend: llama-cpp"), fmt.Sprintf("Model config: %+v", modelConfig))
+		})
+	})
+
+	Context("Import from HuggingFace file listing", func() {
+		// These tests exercise the HF branch of Import() without touching
+		// the network — they construct a fake *hfapi.ModelDetails and
+		// assert the emitted gallery entry directly. Historically the HF
+		// branch was only covered by live-API integration specs in
+		// importers_test.go; anything that happened in between (shard
+		// grouping, quant fallback) had no unit-level regression net.
+
+		const repoBase = "https://huggingface.co/acme/example-GGUF/resolve/main/"
+
+		hfFile := func(path, sha string) hfapi.ModelFile {
+			return hfapi.ModelFile{
+				Path:   path,
+				SHA256: sha,
+				URL:    repoBase + path,
+			}
+		}
+
+		withHF := func(preferences string, files ...hfapi.ModelFile) Details {
+			d := Details{
+				URI: "https://huggingface.co/acme/example-GGUF",
+				HuggingFace: &hfapi.ModelDetails{
+					ModelID: "acme/example-GGUF",
+					Files:   files,
+				},
+			}
+			if preferences != "" {
+				d.Preferences = json.RawMessage(preferences)
+			}
+			return d
+		}
+
+		It("picks the preferred quant in a single-file repo", func() {
+			details := withHF(`{"name":"example","quantizations":"Q4_K_M"}`,
+				hfFile("model-Q4_K_M.gguf", "aaa"),
+				hfFile("model-Q3_K_M.gguf", "bbb"),
+				hfFile("README.md", ""),
+			)
+
+			modelConfig, err := importer.Import(details)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelConfig.Files).To(HaveLen(1), fmt.Sprintf("%+v", modelConfig))
+			Expect(modelConfig.Files[0].Filename).To(Equal("llama-cpp/models/example/model-Q4_K_M.gguf"))
+			Expect(modelConfig.Files[0].URI).To(Equal(repoBase + "model-Q4_K_M.gguf"))
+			Expect(modelConfig.Files[0].SHA256).To(Equal("aaa"))
+			Expect(modelConfig.ConfigFile).To(ContainSubstring("model: llama-cpp/models/example/model-Q4_K_M.gguf"))
+		})
+
+		It("falls back to the last group when no preference matches", func() {
+			// Default preference is q4_k_m; the repo has only Q8_0 and
+			// Q3_K_M. The old implementation would emit exactly the last
+			// file seen — this test pins the fallback behaviour so the
+			// group-level fallback keeps matching the historical intent.
+			details := withHF(`{"name":"example"}`,
+				hfFile("model-Q8_0.gguf", "aaa"),
+				hfFile("model-Q3_K_M.gguf", "bbb"),
+			)
+
+			modelConfig, err := importer.Import(details)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelConfig.Files).To(HaveLen(1), fmt.Sprintf("%+v", modelConfig))
+			Expect(modelConfig.Files[0].Filename).To(Equal("llama-cpp/models/example/model-Q3_K_M.gguf"))
+		})
+
+		It("emits all shards of a multi-part GGUF and points Model at shard 1", func() {
+			// Regression for PR #9510: unsloth/Kimi-K2.6-GGUF ships 14
+			// Q8_K_XL shards. Default prefs are q4_k_m; none match, so the
+			// fallback must take the whole shard group (not just the last
+			// shard) and the config's `model:` must point at shard 1 so
+			// llama.cpp's split loader can walk the rest.
+			files := make([]hfapi.ModelFile, 0, 14)
+			// Deliberately add shards out of order to prove sorting works.
+			for _, idx := range []int{7, 1, 14, 2, 8, 3, 9, 4, 10, 5, 11, 6, 12, 13} {
+				files = append(files, hfFile(
+					fmt.Sprintf("Kimi-K2.6-UD-Q8_K_XL-%05d-of-00014.gguf", idx),
+					fmt.Sprintf("sha-%02d", idx),
+				))
+			}
+
+			details := withHF(`{"name":"Kimi-K2.6-GGUF"}`, files...)
+
+			modelConfig, err := importer.Import(details)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelConfig.Files).To(HaveLen(14), fmt.Sprintf("%+v", modelConfig))
+
+			// All 14 shards must be present, in order, under the models dir.
+			for i := 1; i <= 14; i++ {
+				expected := fmt.Sprintf("llama-cpp/models/Kimi-K2.6-GGUF/Kimi-K2.6-UD-Q8_K_XL-%05d-of-00014.gguf", i)
+				Expect(modelConfig.Files[i-1].Filename).To(Equal(expected))
+				Expect(modelConfig.Files[i-1].SHA256).To(Equal(fmt.Sprintf("sha-%02d", i)))
+			}
+
+			// The configured model path must be shard 1 — this is the file
+			// llama.cpp's split loader expects to be pointed at.
+			Expect(modelConfig.ConfigFile).To(ContainSubstring(
+				"model: llama-cpp/models/Kimi-K2.6-GGUF/Kimi-K2.6-UD-Q8_K_XL-00001-of-00014.gguf",
+			))
+		})
+
+		It("emits all shards of the preferred quant alongside an mmproj", func() {
+			// Sharded multimodal model: mmproj is single-file, the text
+			// model is split in 3 parts and matches the user preference.
+			details := withHF(`{"name":"VL-GGUF","quantizations":"Q4_K_M","mmproj_quantizations":"F16"}`,
+				hfFile("mmproj-F16.gguf", "mm"),
+				hfFile("model-Q4_K_M-00001-of-00003.gguf", "p1"),
+				hfFile("model-Q4_K_M-00002-of-00003.gguf", "p2"),
+				hfFile("model-Q4_K_M-00003-of-00003.gguf", "p3"),
+			)
+
+			modelConfig, err := importer.Import(details)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelConfig.Files).To(HaveLen(4), fmt.Sprintf("%+v", modelConfig))
+
+			// Model shards come first, in order, then the mmproj.
+			Expect(modelConfig.Files[0].Filename).To(Equal("llama-cpp/models/VL-GGUF/model-Q4_K_M-00001-of-00003.gguf"))
+			Expect(modelConfig.Files[1].Filename).To(Equal("llama-cpp/models/VL-GGUF/model-Q4_K_M-00002-of-00003.gguf"))
+			Expect(modelConfig.Files[2].Filename).To(Equal("llama-cpp/models/VL-GGUF/model-Q4_K_M-00003-of-00003.gguf"))
+			Expect(modelConfig.Files[3].Filename).To(Equal("llama-cpp/mmproj/VL-GGUF/mmproj-F16.gguf"))
+
+			Expect(modelConfig.ConfigFile).To(ContainSubstring(
+				"model: llama-cpp/models/VL-GGUF/model-Q4_K_M-00001-of-00003.gguf",
+			))
+			Expect(modelConfig.ConfigFile).To(ContainSubstring(
+				"mmproj: llama-cpp/mmproj/VL-GGUF/mmproj-F16.gguf",
+			))
+		})
+
+		It("does not emit duplicate entries when called repeatedly on the same group", func() {
+			// Guards appendShardGroup's dedup: if a shard ends up in the
+			// Files slice via more than one code path (e.g. a future
+			// refactor that processes mmproj and model candidates through
+			// the same path), we must not accidentally duplicate downloads.
+			details := withHF(`{"name":"dup","quantizations":"Q4_K_M,Q4_K_M"}`,
+				hfFile("model-Q4_K_M.gguf", "aaa"),
+			)
+
+			modelConfig, err := importer.Import(details)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelConfig.Files).To(HaveLen(1), fmt.Sprintf("%+v", modelConfig))
+			Expect(modelConfig.Files[0].Filename).To(Equal("llama-cpp/models/dup/model-Q4_K_M.gguf"))
+		})
+
+		It("ignores non-gguf files in the repo listing", func() {
+			// Real HF repos ship READMEs, tokenizer json, images, etc.
+			// Only .gguf entries should surface as downloadable files.
+			details := withHF(`{"name":"noise"}`,
+				hfFile("README.md", ""),
+				hfFile("config.json", ""),
+				hfFile("logo.png", ""),
+				hfFile("model-Q4_K_M.gguf", "aaa"),
+			)
+
+			modelConfig, err := importer.Import(details)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelConfig.Files).To(HaveLen(1))
+			Expect(modelConfig.Files[0].Filename).To(Equal("llama-cpp/models/noise/model-Q4_K_M.gguf"))
+		})
+
+		It("produces no files when the repo contains no .gguf", func() {
+			details := withHF(`{"name":"empty"}`,
+				hfFile("README.md", ""),
+				hfFile("config.json", ""),
+			)
+
+			modelConfig, err := importer.Import(details)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(modelConfig.Files).To(BeEmpty())
 		})
 	})
 

--- a/pkg/huggingface-api/client.go
+++ b/pkg/huggingface-api/client.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -409,13 +412,111 @@ func FilterFilesByQuantization(files []ModelFile, quantization string) []ModelFi
 	return filtered
 }
 
-// FindPreferredModelFile finds the preferred model file based on quantization preferences
+// shardSuffixRegex matches the `-NNNNN-of-MMMMM.gguf` suffix that llama.cpp
+// uses to split large GGUF models across multiple files. Widths of 1–6 digits
+// are accepted because shard counts seen in the wild range from single digits
+// (unusual) to the common 5-digit zero-padded form (e.g. `-00001-of-00014`).
+var shardSuffixRegex = regexp.MustCompile(`(?i)-(\d{1,6})-of-(\d{1,6})\.gguf$`)
+
+// SplitShardSuffix detects llama.cpp-style sharded GGUF filenames. When the
+// filename ends with `-NNNNN-of-MMMMM.gguf` it returns the base filename
+// (with `.gguf` re-appended), the 1-based shard index, the total shard
+// count, and ok=true. Non-sharded filenames return zero values and ok=false.
+func SplitShardSuffix(fileName string) (base string, index, total int, ok bool) {
+	loc := shardSuffixRegex.FindStringSubmatchIndex(fileName)
+	if loc == nil {
+		return "", 0, 0, false
+	}
+	idx, err := strconv.Atoi(fileName[loc[2]:loc[3]])
+	if err != nil {
+		return "", 0, 0, false
+	}
+	tot, err := strconv.Atoi(fileName[loc[4]:loc[5]])
+	if err != nil {
+		return "", 0, 0, false
+	}
+	return fileName[:loc[0]] + ".gguf", idx, tot, true
+}
+
+// ShardGroup bundles every file that belongs to the same logical GGUF model.
+// Single-file models produce a one-entry group; multi-part shard sets produce
+// one group holding every part in shard-index order.
+type ShardGroup struct {
+	// Base is the logical filename: for sharded groups this is the common
+	// prefix with `.gguf` re-appended; for single-file groups it equals the
+	// sole entry's basename.
+	Base string
+	// Sharded is true when the group represents a multi-part shard set.
+	Sharded bool
+	// Total is the declared shard count (0 when Sharded is false).
+	Total int
+	// Files are the group's entries; sharded groups are sorted by index.
+	Files []ModelFile
+}
+
+// GroupShards buckets ModelFile entries by their shard base. Files that do
+// not match the sharded-filename pattern become one-entry groups. Group
+// order follows the first appearance of each group in the input (so the
+// historical "last-seen wins" fallback logic in the llama-cpp importer
+// keeps producing the same group); shards within a group are sorted by
+// their 1-based index so downstream consumers can rely on Files[0] being
+// shard 1.
+func GroupShards(files []ModelFile) []ShardGroup {
+	groupIdx := make(map[string]int)
+	var groups []ShardGroup
+
+	for _, file := range files {
+		name := filepath.Base(file.Path)
+		base, _, total, isShard := SplitShardSuffix(name)
+		if !isShard {
+			groups = append(groups, ShardGroup{
+				Base:  name,
+				Files: []ModelFile{file},
+			})
+			continue
+		}
+		if idx, ok := groupIdx[base]; ok {
+			groups[idx].Files = append(groups[idx].Files, file)
+			if total > groups[idx].Total {
+				groups[idx].Total = total
+			}
+			continue
+		}
+		groupIdx[base] = len(groups)
+		groups = append(groups, ShardGroup{
+			Base:    base,
+			Sharded: true,
+			Total:   total,
+			Files:   []ModelFile{file},
+		})
+	}
+
+	for i := range groups {
+		if !groups[i].Sharded {
+			continue
+		}
+		sort.SliceStable(groups[i].Files, func(a, b int) bool {
+			_, ai, _, _ := SplitShardSuffix(filepath.Base(groups[i].Files[a].Path))
+			_, bi, _, _ := SplitShardSuffix(filepath.Base(groups[i].Files[b].Path))
+			return ai < bi
+		})
+	}
+	return groups
+}
+
+// FindPreferredModelFile returns shard #1 of the first group whose base
+// filename contains any of the quantization preferences, checking each
+// preference in priority order. For single-file models this collapses to
+// "the first file whose name contains the preference", preserving the
+// historical behaviour while correctly pointing at shard 1 for multi-part
+// GGUF models — llama.cpp's split loader needs shard 1 to walk the set.
 func FindPreferredModelFile(files []ModelFile, preferences []string) *ModelFile {
+	groups := GroupShards(files)
 	for _, preference := range preferences {
-		for i := range files {
-			fileName := filepath.Base(files[i].Path)
-			if strings.Contains(strings.ToLower(fileName), strings.ToLower(preference)) {
-				return &files[i]
+		lowerPref := strings.ToLower(preference)
+		for i := range groups {
+			if strings.Contains(strings.ToLower(groups[i].Base), lowerPref) {
+				return &groups[i].Files[0]
 			}
 		}
 	}

--- a/pkg/huggingface-api/client_test.go
+++ b/pkg/huggingface-api/client_test.go
@@ -670,6 +670,137 @@ var _ = Describe("HuggingFace API Client", func() {
 
 			Expect(preferred).To(BeNil())
 		})
+
+		It("should return shard 1 when the preferred quant is multi-part", func() {
+			// Regression coverage for PR #9510: an unsloth-style sharded
+			// GGUF repo listed shards in mixed order — the old implementation
+			// returned whichever shard happened to come first in the slice.
+			// We now always return shard 1 so llama.cpp can discover the set.
+			files := []hfapi.ModelFile{
+				{Path: "Kimi-K2.6-UD-Q8_K_XL-00003-of-00014.gguf"},
+				{Path: "Kimi-K2.6-UD-Q8_K_XL-00001-of-00014.gguf"},
+				{Path: "Kimi-K2.6-UD-Q8_K_XL-00002-of-00014.gguf"},
+				{Path: "README.md", IsReadme: true},
+			}
+
+			preferred := hfapi.FindPreferredModelFile(files, []string{"Q8_K_XL"})
+
+			Expect(preferred).ToNot(BeNil())
+			Expect(preferred.Path).To(Equal("Kimi-K2.6-UD-Q8_K_XL-00001-of-00014.gguf"))
+		})
+
+		It("should honour priority order for sharded repos", func() {
+			// Two shard sets live in the repo (Q4_K_M and Q8_0). Callers
+			// pass a priority list; the first preference that has a matching
+			// group wins, and its shard 1 is returned.
+			files := []hfapi.ModelFile{
+				{Path: "model-Q8_0-00001-of-00002.gguf"},
+				{Path: "model-Q8_0-00002-of-00002.gguf"},
+				{Path: "model-Q4_K_M-00001-of-00002.gguf"},
+				{Path: "model-Q4_K_M-00002-of-00002.gguf"},
+			}
+
+			preferred := hfapi.FindPreferredModelFile(files, []string{"Q4_K_M", "Q8_0"})
+
+			Expect(preferred).ToNot(BeNil())
+			Expect(preferred.Path).To(Equal("model-Q4_K_M-00001-of-00002.gguf"))
+		})
+	})
+
+	Context("shard grouping", func() {
+		DescribeTable("SplitShardSuffix",
+			func(name, expectedBase string, expectedIdx, expectedTotal int, expectedOK bool) {
+				base, idx, total, ok := hfapi.SplitShardSuffix(name)
+				Expect(ok).To(Equal(expectedOK))
+				Expect(base).To(Equal(expectedBase))
+				Expect(idx).To(Equal(expectedIdx))
+				Expect(total).To(Equal(expectedTotal))
+			},
+			Entry("5-digit zero-padded (canonical)",
+				"Kimi-K2.6-UD-Q8_K_XL-00001-of-00014.gguf",
+				"Kimi-K2.6-UD-Q8_K_XL.gguf", 1, 14, true),
+			Entry("5-digit, last shard",
+				"Kimi-K2.6-UD-Q8_K_XL-00014-of-00014.gguf",
+				"Kimi-K2.6-UD-Q8_K_XL.gguf", 14, 14, true),
+			Entry("2-digit width",
+				"model-01-of-03.gguf",
+				"model.gguf", 1, 3, true),
+			Entry("mixed-case extension",
+				"model-00001-of-00002.GGUF",
+				"model.gguf", 1, 2, true),
+			Entry("single-file model returns ok=false",
+				"model-Q4_K_M.gguf", "", 0, 0, false),
+			Entry("mmproj is not a shard",
+				"mmproj-F16.gguf", "", 0, 0, false),
+			Entry("non-gguf extension is not a shard",
+				"model-00001-of-00002.bin", "", 0, 0, false),
+			Entry("naked suffix without leading dash is not matched",
+				"00001-of-00002.gguf", "", 0, 0, false),
+			// Guard against over-greedy matching: the pattern looks only at
+			// the suffix, so numbers earlier in the name must be ignored.
+			Entry("digits earlier in the name don't confuse the match",
+				"model-v2-Q4_K_M-00003-of-00005.gguf",
+				"model-v2-Q4_K_M.gguf", 3, 5, true),
+		)
+
+		It("groups sharded GGUF files by base and sorts by shard index", func() {
+			// Feed shards in unsorted order and interleaved with other
+			// files to exercise both the grouping and the sort.
+			files := []hfapi.ModelFile{
+				{Path: "Kimi-K2.6-UD-Q8_K_XL-00014-of-00014.gguf"},
+				{Path: "mmproj-F32.gguf"},
+				{Path: "Kimi-K2.6-UD-Q8_K_XL-00001-of-00014.gguf"},
+				{Path: "Kimi-K2.6-UD-Q8_K_XL-00002-of-00014.gguf"},
+			}
+
+			groups := hfapi.GroupShards(files)
+			Expect(groups).To(HaveLen(2))
+
+			// First group: the sharded Kimi set — first appearance was the
+			// 14-of-14 shard, so this group leads.
+			Expect(groups[0].Sharded).To(BeTrue())
+			Expect(groups[0].Base).To(Equal("Kimi-K2.6-UD-Q8_K_XL.gguf"))
+			Expect(groups[0].Total).To(Equal(14))
+			Expect(groups[0].Files).To(HaveLen(3))
+			Expect(groups[0].Files[0].Path).To(Equal("Kimi-K2.6-UD-Q8_K_XL-00001-of-00014.gguf"))
+			Expect(groups[0].Files[1].Path).To(Equal("Kimi-K2.6-UD-Q8_K_XL-00002-of-00014.gguf"))
+			Expect(groups[0].Files[2].Path).To(Equal("Kimi-K2.6-UD-Q8_K_XL-00014-of-00014.gguf"))
+
+			// Second group: the mmproj singleton.
+			Expect(groups[1].Sharded).To(BeFalse())
+			Expect(groups[1].Base).To(Equal("mmproj-F32.gguf"))
+			Expect(groups[1].Files).To(HaveLen(1))
+		})
+
+		It("preserves non-shard files as one-entry groups", func() {
+			files := []hfapi.ModelFile{
+				{Path: "model-Q4_K_M.gguf"},
+				{Path: "model-Q3_K_M.gguf"},
+			}
+			groups := hfapi.GroupShards(files)
+
+			Expect(groups).To(HaveLen(2))
+			Expect(groups[0].Sharded).To(BeFalse())
+			Expect(groups[0].Files[0].Path).To(Equal("model-Q4_K_M.gguf"))
+			Expect(groups[1].Sharded).To(BeFalse())
+			Expect(groups[1].Files[0].Path).To(Equal("model-Q3_K_M.gguf"))
+		})
+
+		It("groups files that live in subfolders by their basename", func() {
+			// HuggingFace repos often place shards in a per-quant subfolder
+			// (bartowski/* is a common example). The Path includes the
+			// folder but we must still group by basename.
+			files := []hfapi.ModelFile{
+				{Path: "Q4_K_M/model-Q4_K_M-00001-of-00002.gguf"},
+				{Path: "Q4_K_M/model-Q4_K_M-00002-of-00002.gguf"},
+			}
+			groups := hfapi.GroupShards(files)
+
+			Expect(groups).To(HaveLen(1))
+			Expect(groups[0].Sharded).To(BeTrue())
+			Expect(groups[0].Total).To(Equal(2))
+			Expect(groups[0].Files).To(HaveLen(2))
+		})
 	})
 
 	Context("integration test with real HuggingFace API", func() {


### PR DESCRIPTION
The llama-cpp HuggingFace importer iterated files one at a time and kept overwriting `lastGGUFFile`, so sharded repos such as `unsloth/Kimi-K2.6-GGUF` (14 `Q8_K_XL` parts) produced a gallery entry pointing only at the final shard — useless to llama.cpp's split loader, which needs shard 1 to discover the set.

Group shards up front via new helpers in `pkg/huggingface-api` (`SplitShardSuffix`, `ShardGroup`, `GroupShards`). The llama-cpp importer now picks a group (preferred quant, then last-group fallback) and emits every shard, with `Model:` pointing at shard 1. `FindPreferredModelFile` returns shard 1 of the first matching group so the gallery agent's preview stays coherent for sharded repos.

Adds unit coverage for the HuggingFace branch of the importer (which had none), plus shard-detection tests in the hfapi package.

Assisted-by: Claude:Opus-4.7 [Read] [Edit] [Bash]
