### PR TITLE
fix: use SetFunctionCallNameString when forcing a specific tool (3 sites)

### DIFF
--- a/core/http/endpoints/anthropic/messages.go
+++ b/core/http/endpoints/anthropic/messages.go
@@ -880,7 +880,7 @@ func convertAnthropicTools(input *schema.AnthropicRequest, cfg *config.ModelConf
 			if tcType, ok := tc["type"].(string); ok && tcType == "tool" {
 				if name, ok := tc["name"].(string); ok {
 					// Force specific tool
-					cfg.SetFunctionCallString(name)
+					cfg.SetFunctionCallNameString(name)
 				}
 			}
 		}

--- a/core/http/endpoints/openai/realtime_model.go
+++ b/core/http/endpoints/openai/realtime_model.go
@@ -168,7 +168,7 @@ func (m *wrappedModel) Predict(ctx context.Context, messages schema.Messages, im
 			}
 		} else if toolChoice.Function != nil {
 			// Specific function specified
-			m.LLMConfig.SetFunctionCallString(toolChoice.Function.Name)
+			m.LLMConfig.SetFunctionCallNameString(toolChoice.Function.Name)
 		}
 	}
 

--- a/core/http/endpoints/openresponses/responses.go
+++ b/core/http/endpoints/openresponses/responses.go
@@ -773,7 +773,7 @@ func convertORToolsToFunctions(input *schema.OpenResponsesRequest, cfg *config.M
 		case map[string]any:
 			if tcType, ok := tc["type"].(string); ok && tcType == "function" {
 				if name, ok := tc["name"].(string); ok {
-					cfg.SetFunctionCallString(name)
+					cfg.SetFunctionCallNameString(name)
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

Follows up on #9509 (merged) which fixed the same bug in `MergeOpenResponsesConfig`.

Three additional call sites were using `SetFunctionCallString(name)` (which writes the **mode** field, e.g. `"none"/"auto"/"required"`) when they should be using `SetFunctionCallNameString(name)` (which writes the **specific function name** field read by `ShouldCallSpecificFunction` / `FunctionToCall`).

Net effect of the original code: when a caller sends `tool_choice: {type: "function", function: {name: "my_tool"}}` via these three endpoints, the grammar-based forcing is silently never engaged because the name ends up in the wrong config field.

### Sites fixed

| File | Line | Endpoint |
|------|------|----------|
| `core/http/endpoints/anthropic/messages.go` | 883 | Anthropic `/v1/messages` |
| `core/http/endpoints/openai/realtime_model.go` | 171 | OpenAI Realtime |
| `core/http/endpoints/openresponses/responses.go` | 776 | `/v1/responses` (non-middleware path) |

In each case the change is:
```go
- cfg.SetFunctionCallString(name)
+ cfg.SetFunctionCallNameString(name)
```

Tracked in issue #9508.

## Test plan
- [ ] Send `tool_choice: {"type": "function", "function": {"name": "my_tool"}}` via Anthropic `/v1/messages` endpoint and verify grammar-based forcing engages
- [ ] Same via OpenAI Realtime endpoint  
- [ ] Same via `/v1/responses` endpoint

🤖 Generated with [Claude Code](https://claude.ai/claude-code)