### PR TITLE
fix(ik-llama-cpp): patch clip.cpp for new ggml_quantize_chunk signature

### DIFF
--- a/backend/cpp/ik-llama-cpp/Makefile
+++ b/backend/cpp/ik-llama-cpp/Makefile
@@ -1,5 +1,5 @@
 
-IK_LLAMA_VERSION?=286ce324baed17c95faec77792eaa6bdb1c7a5f5
+IK_LLAMA_VERSION?=16996aeab772c69b6473597038b2ef0b85297e8b
 LLAMA_REPO?=https://github.com/ikawrakow/ik_llama.cpp
 
 CMAKE_ARGS?=

--- a/backend/cpp/ik-llama-cpp/patches/0002-clip-ggml-quantize-chunk-user-data.patch
+++ b/backend/cpp/ik-llama-cpp/patches/0002-clip-ggml-quantize-chunk-user-data.patch
@@ -1,0 +1,11 @@
+--- a/examples/llava/clip.cpp
++++ b/examples/llava/clip.cpp
+@@ -2494,7 +2494,7 @@
+             }
+             new_data = work.data();
+
+-            new_size = ggml_quantize_chunk(new_type, f32_data, new_data, 0, n_elms/cur->ne[0], cur->ne[0], nullptr);
++            new_size = ggml_quantize_chunk(new_type, f32_data, new_data, 0, n_elms/cur->ne[0], cur->ne[0], nullptr, nullptr);
+         } else {
+             new_type = cur->type;
+             new_data = cur->data;


### PR DESCRIPTION
Bumps ik_llama.cpp pin to 16996aeab7. Upstream 286ce32...16996ae adds a trailing `const struct quantize_user_data *` parameter to `ggml_quantize_chunk` (PR ikawrakow/ik_llama.cpp#1677) but leaves `examples/llava/clip.cpp` unchanged because their build has moved to `examples/mtmd/`. LocalAI's prepare.sh still copies from `examples/llava/`, so the dead 7-arg call reaches the grpc-server compile and fails. Patch the call site to pass `nullptr` for the new param.

Assisted-by: Claude:Opus-4.7 [Read] [Edit] [Bash]
