### PR TITLE
feat: surface distributed backend management errors

### DIFF
--- a/core/http/react-ui/e2e/nodes-per-node-backend-actions.spec.js
+++ b/core/http/react-ui/e2e/nodes-per-node-backend-actions.spec.js
@@ -1,0 +1,160 @@
+import { test, expect } from '@playwright/test'
+
+// These specs cover the per-node backend row in the Nodes page:
+//   - the upgrade affordance is self-explanatory (icon + tooltip)
+//   - a delete affordance is present and goes through ConfirmDialog
+//
+// We mock the distributed-mode API so the tests can run against the
+// standalone ui-test-server without spinning up workers/NATS.
+
+const NODE_ID = 'test-node-1'
+const NODE_NAME = 'worker-test'
+const BACKEND_NAME = 'cuda12-vllm-development'
+
+async function mockDistributedNodes(page, { onDelete } = {}) {
+  await page.route('**/api/nodes', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          id: NODE_ID,
+          name: NODE_NAME,
+          node_type: 'backend',
+          address: '10.0.0.1:50051',
+          http_address: '10.0.0.1:8090',
+          status: 'healthy',
+          total_vram: 0,
+          available_vram: 0,
+          total_ram: 8_000_000_000,
+          available_ram: 4_000_000_000,
+          gpu_vendor: '',
+          last_heartbeat: new Date().toISOString(),
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ]),
+    })
+  })
+
+  await page.route('**/api/nodes/scheduling', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    })
+  })
+
+  await page.route(`**/api/nodes/${NODE_ID}/models`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: '[]',
+    })
+  })
+
+  await page.route(`**/api/nodes/${NODE_ID}/backends`, (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([
+        {
+          name: BACKEND_NAME,
+          is_system: false,
+          is_meta: false,
+          installed_at: new Date().toISOString(),
+        },
+      ]),
+    })
+  })
+
+  await page.route(`**/api/nodes/${NODE_ID}/backends/delete`, async (route) => {
+    if (onDelete) {
+      await onDelete(route)
+    }
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'backend deleted' }),
+    })
+  })
+}
+
+async function expandNodeAndWaitForBackends(page) {
+  await page.goto('/app/nodes')
+  // Click the row to expand it. The chevron toggle and the row both work,
+  // but clicking the name cell is the most user-like.
+  await page.getByText(NODE_NAME).first().click()
+  await expect(page.getByRole('cell', { name: BACKEND_NAME, exact: true })).toBeVisible({ timeout: 10_000 })
+}
+
+test.describe('Nodes page — per-node backend actions', () => {
+  test('upgrade affordance is self-explanatory (not "Reinstall backend" with a sync icon)', async ({ page }) => {
+    await mockDistributedNodes(page)
+    await expandNodeAndWaitForBackends(page)
+
+    // Negative: the old, ambiguous wording must not be used.
+    await expect(page.locator('button[title="Reinstall backend"]')).toHaveCount(0)
+    await expect(page.locator('button[title="Reinstall backend"] i.fa-sync-alt')).toHaveCount(0)
+
+    // Positive: a self-explanatory upgrade affordance is rendered next to the
+    // backend row. We accept either an arrow-up or arrows-rotate glyph; both
+    // map to "upgrade" semantics in FontAwesome 6 unambiguously.
+    const upgradeBtn = page.locator('button[title="Upgrade backend on this node"]')
+    await expect(upgradeBtn).toBeVisible()
+    const iconClass = await upgradeBtn.locator('i').getAttribute('class')
+    expect(iconClass).toMatch(/fa-(arrow-up|arrows-rotate|up-long)/)
+  })
+
+  test('per-node backend row shows a delete (trash) button next to upgrade', async ({ page }) => {
+    await mockDistributedNodes(page)
+    await expandNodeAndWaitForBackends(page)
+
+    const deleteBtn = page.locator('button[title="Delete backend from this node"]')
+    await expect(deleteBtn).toBeVisible()
+    await expect(deleteBtn.locator('i.fa-trash')).toBeVisible()
+  })
+
+  test('clicking delete opens the confirm dialog and POSTs to the per-node delete endpoint', async ({ page }) => {
+    let postedBody = null
+    await mockDistributedNodes(page, {
+      onDelete: async (route) => {
+        postedBody = route.request().postDataJSON()
+      },
+    })
+    await expandNodeAndWaitForBackends(page)
+
+    await page.locator('button[title="Delete backend from this node"]').click()
+
+    // ConfirmDialog uses role="alertdialog" and a danger confirm button.
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible()
+    const confirmBtn = dialog.locator('button.btn-danger')
+    await expect(confirmBtn).toBeVisible()
+    await confirmBtn.click()
+
+    // Wait until the POST landed.
+    await expect.poll(() => postedBody, { timeout: 5_000 }).toEqual({ backend: BACKEND_NAME })
+  })
+
+  test('clicking delete and cancelling does not POST', async ({ page }) => {
+    let deleteCalls = 0
+    await mockDistributedNodes(page, {
+      onDelete: () => {
+        deleteCalls += 1
+      },
+    })
+    await expandNodeAndWaitForBackends(page)
+
+    await page.locator('button[title="Delete backend from this node"]').click()
+
+    const dialog = page.getByRole('alertdialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: /cancel/i }).click()
+    await expect(dialog).toBeHidden()
+
+    // Give any errant request a moment to fire so a regression would be caught.
+    await page.waitForTimeout(500)
+    expect(deleteCalls).toBe(0)
+  })
+})

--- a/core/http/react-ui/src/pages/Nodes.jsx
+++ b/core/http/react-ui/src/pages/Nodes.jsx
@@ -269,6 +269,7 @@ export default function Nodes() {
   const [nodeBackends, setNodeBackends] = useState({})
   const [confirmDelete, setConfirmDelete] = useState(null)
   const [confirmUnload, setConfirmUnload] = useState(null)
+  const [confirmDeleteBackend, setConfirmDeleteBackend] = useState(null)
   const [showTips, setShowTips] = useState(false)
   const [activeTab, setActiveTab] = useState('backend') // 'backend', 'agent', or 'scheduling'
   const [schedulingConfigs, setSchedulingConfigs] = useState([])
@@ -341,13 +342,23 @@ export default function Nodes() {
     }
   }
 
-  const handleReinstallBackend = async (nodeId, backendName) => {
+  const handleUpgradeBackend = async (nodeId, backendName) => {
     try {
       await nodesApi.installBackend(nodeId, backendName)
-      addToast(`Backend "${backendName}" reinstalled`, 'success')
+      addToast(`Backend "${backendName}" upgraded`, 'success')
       fetchBackends(nodeId)
     } catch (err) {
-      addToast(`Failed to reinstall backend: ${err.message}`, 'error')
+      addToast(`Failed to upgrade backend: ${err.message}`, 'error')
+    }
+  }
+
+  const handleDeleteBackendOnNode = async (nodeId, backendName) => {
+    try {
+      await nodesApi.deleteBackend(nodeId, backendName)
+      addToast(`Backend "${backendName}" deleted`, 'success')
+      fetchBackends(nodeId)
+    } catch (err) {
+      addToast(`Failed to delete backend: ${err.message}`, 'error')
     }
   }
 
@@ -897,13 +908,22 @@ export default function Nodes() {
                                       </td>
                                       <td style={{ textAlign: 'right' }}>
                                         {!b.is_system && (
-                                          <button
-                                            className="btn btn-secondary btn-sm"
-                                            onClick={() => handleReinstallBackend(node.id, b.name)}
-                                            title="Reinstall backend"
-                                          >
-                                            <i className="fas fa-sync-alt" />
-                                          </button>
+                                          <div style={{ display: 'inline-flex', gap: 'var(--spacing-xs)' }}>
+                                            <button
+                                              className="btn btn-secondary btn-sm"
+                                              onClick={() => handleUpgradeBackend(node.id, b.name)}
+                                              title="Upgrade backend on this node"
+                                            >
+                                              <i className="fas fa-arrow-up" />
+                                            </button>
+                                            <button
+                                              className="btn btn-danger-ghost btn-sm"
+                                              onClick={() => setConfirmDeleteBackend({ nodeId: node.id, nodeName: node.name, backend: b.name })}
+                                              title="Delete backend from this node"
+                                            >
+                                              <i className="fas fa-trash" />
+                                            </button>
+                                          </div>
                                         )}
                                       </td>
                                     </tr>
@@ -1075,6 +1095,21 @@ export default function Nodes() {
         danger
         onConfirm={() => confirmDelete && handleDelete(confirmDelete.id)}
         onCancel={() => setConfirmDelete(null)}
+      />
+
+      <ConfirmDialog
+        open={!!confirmDeleteBackend}
+        title="Delete Backend"
+        message={confirmDeleteBackend ? `Delete "${confirmDeleteBackend.backend}" from ${confirmDeleteBackend.nodeName}? This removes the backend files from this node only.` : ''}
+        confirmLabel="Delete"
+        danger
+        onConfirm={() => {
+          if (confirmDeleteBackend) {
+            handleDeleteBackendOnNode(confirmDeleteBackend.nodeId, confirmDeleteBackend.backend)
+          }
+          setConfirmDeleteBackend(null)
+        }}
+        onCancel={() => setConfirmDeleteBackend(null)}
       />
 
       <ConfirmDialog

--- a/core/services/nodes/managers_distributed.go
+++ b/core/services/nodes/managers_distributed.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/mudler/LocalAI/core/config"
 	"github.com/mudler/LocalAI/core/gallery"
@@ -81,6 +82,25 @@ type NodeOpStatus struct {
 // BackendOpResult aggregates per-node outcomes.
 type BackendOpResult struct {
 	Nodes []NodeOpStatus `json:"nodes"`
+}
+
+// Err returns a non-nil error aggregating per-node hard failures
+// (Status == "error"). Queued nodes (waiting for reconciler retry) are not
+// failures — surfacing them as errors would mislead users about durable
+// intent. Used by Install/Upgrade/Delete so reply.Success=false from
+// workers reaches OpStatus.Error and the UI, instead of being silently
+// dropped on the way up.
+func (r BackendOpResult) Err() error {
+	var failures []string
+	for _, n := range r.Nodes {
+		if n.Status == "error" {
+			failures = append(failures, fmt.Sprintf("%s: %s", n.NodeName, n.Error))
+		}
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+	return errors.New(strings.Join(failures, "; "))
 }
 
 // enqueueAndDrainBackendOp is the shared scaffolding for
@@ -198,11 +218,20 @@ func (d *DistributedBackendManager) DeleteBackend(name string) error {
 	}
 
 	ctx := context.Background()
-	_, err := d.enqueueAndDrainBackendOp(ctx, OpBackendDelete, name, nil, func(node BackendNode) error {
-		_, err := d.adapter.DeleteBackend(node.ID, name)
-		return err
+	result, err := d.enqueueAndDrainBackendOp(ctx, OpBackendDelete, name, nil, func(node BackendNode) error {
+		reply, err := d.adapter.DeleteBackend(node.ID, name)
+		if err != nil {
+			return err
+		}
+		if !reply.Success {
+			return fmt.Errorf("delete failed: %s", reply.Error)
+		}
+		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return result.Err()
 }
 
 // DeleteBackendDetailed is the per-node-result variant called by the HTTP
@@ -213,8 +242,14 @@ func (d *DistributedBackendManager) DeleteBackendDetailed(ctx context.Context, n
 		return BackendOpResult{}, err
 	}
 	return d.enqueueAndDrainBackendOp(ctx, OpBackendDelete, name, nil, func(node BackendNode) error {
-		_, err := d.adapter.DeleteBackend(node.ID, name)
-		return err
+		reply, err := d.adapter.DeleteBackend(node.ID, name)
+		if err != nil {
+			return err
+		}
+		if !reply.Success {
+			return fmt.Errorf("delete failed: %s", reply.Error)
+		}
+		return nil
 	})
 }
 
@@ -292,7 +327,7 @@ func (d *DistributedBackendManager) InstallBackend(ctx context.Context, op *gall
 	galleriesJSON, _ := json.Marshal(op.Galleries)
 	backendName := op.GalleryElementName
 
-	_, err := d.enqueueAndDrainBackendOp(ctx, OpBackendInstall, backendName, galleriesJSON, func(node BackendNode) error {
+	result, err := d.enqueueAndDrainBackendOp(ctx, OpBackendInstall, backendName, galleriesJSON, func(node BackendNode) error {
 		reply, err := d.adapter.InstallBackend(node.ID, backendName, "", string(galleriesJSON), op.ExternalURI, op.ExternalName, op.ExternalAlias)
 		if err != nil {
 			return err
@@ -302,7 +337,10 @@ func (d *DistributedBackendManager) InstallBackend(ctx context.Context, op *gall
 		}
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return result.Err()
 }
 
 // UpgradeBackend reuses the install NATS subject (the worker re-downloads
@@ -310,7 +348,7 @@ func (d *DistributedBackendManager) InstallBackend(ctx context.Context, op *gall
 func (d *DistributedBackendManager) UpgradeBackend(ctx context.Context, name string, progressCb galleryop.ProgressCallback) error {
 	galleriesJSON, _ := json.Marshal(d.backendGalleries)
 
-	_, err := d.enqueueAndDrainBackendOp(ctx, OpBackendUpgrade, name, galleriesJSON, func(node BackendNode) error {
+	result, err := d.enqueueAndDrainBackendOp(ctx, OpBackendUpgrade, name, galleriesJSON, func(node BackendNode) error {
 		reply, err := d.adapter.InstallBackend(node.ID, name, "", string(galleriesJSON), "", "", "")
 		if err != nil {
 			return err
@@ -320,7 +358,10 @@ func (d *DistributedBackendManager) UpgradeBackend(ctx context.Context, name str
 		}
 		return nil
 	})
-	return err
+	if err != nil {
+		return err
+	}
+	return result.Err()
 }
 
 // CheckUpgrades checks for available backend upgrades across the cluster.

--- a/core/services/nodes/managers_distributed_test.go
+++ b/core/services/nodes/managers_distributed_test.go
@@ -1,0 +1,300 @@
+package nodes
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gorm.io/gorm"
+
+	"github.com/mudler/LocalAI/core/gallery"
+	"github.com/mudler/LocalAI/core/services/galleryop"
+	"github.com/mudler/LocalAI/core/services/messaging"
+	"github.com/mudler/LocalAI/core/services/testutil"
+)
+
+// scriptedMessagingClient maps a NATS subject to a canned reply payload
+// (or error). Used so each fan-out request can simulate a different worker
+// outcome without spinning up real NATS.
+type scriptedMessagingClient struct {
+	mu      sync.Mutex
+	replies map[string][]byte
+	errs    map[string]error
+	calls   []requestCall
+}
+
+func newScriptedMessagingClient() *scriptedMessagingClient {
+	return &scriptedMessagingClient{
+		replies: map[string][]byte{},
+		errs:    map[string]error{},
+	}
+}
+
+func (s *scriptedMessagingClient) scriptReply(subject string, reply any) {
+	raw, err := json.Marshal(reply)
+	Expect(err).ToNot(HaveOccurred())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.replies[subject] = raw
+}
+
+func (s *scriptedMessagingClient) scriptErr(subject string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errs[subject] = err
+}
+
+func (s *scriptedMessagingClient) Request(subject string, data []byte, _ time.Duration) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, requestCall{Subject: subject, Data: data})
+	if err, ok := s.errs[subject]; ok && err != nil {
+		return nil, err
+	}
+	if reply, ok := s.replies[subject]; ok {
+		return reply, nil
+	}
+	// Simulate ErrNoResponders for any unscripted subject so tests fail
+	// loudly when they forget to script a node.
+	return nil, &fakeNoRespondersErr{}
+}
+
+func (s *scriptedMessagingClient) Publish(_ string, _ any) error { return nil }
+func (s *scriptedMessagingClient) Subscribe(_ string, _ func([]byte)) (messaging.Subscription, error) {
+	return &fakeSubscription{}, nil
+}
+func (s *scriptedMessagingClient) QueueSubscribe(_ string, _ string, _ func([]byte)) (messaging.Subscription, error) {
+	return &fakeSubscription{}, nil
+}
+func (s *scriptedMessagingClient) QueueSubscribeReply(_ string, _ string, _ func([]byte, func([]byte))) (messaging.Subscription, error) {
+	return &fakeSubscription{}, nil
+}
+func (s *scriptedMessagingClient) SubscribeReply(_ string, _ func([]byte, func([]byte))) (messaging.Subscription, error) {
+	return &fakeSubscription{}, nil
+}
+func (s *scriptedMessagingClient) IsConnected() bool { return true }
+func (s *scriptedMessagingClient) Close()            {}
+
+// fakeNoRespondersErr matches nats.ErrNoResponders by name only — we don't
+// import nats here to avoid pulling the whole client. The distributed
+// manager treats it via errors.Is, so the concrete type matters for the
+// "mark unhealthy" path; here we just want a non-nil error.
+type fakeNoRespondersErr struct{}
+
+func (e *fakeNoRespondersErr) Error() string { return "no responders" }
+
+// stubLocalBackendManager satisfies galleryop.BackendManager for the
+// distributed manager's `local` field. The DeleteBackend path expects to
+// call into local first; in distributed mode the frontend rarely has
+// backends installed, so returning gallery.ErrBackendNotFound from
+// DeleteBackend reproduces the common production case (caller falls
+// through to the NATS fan-out, which is what these tests exercise).
+type stubLocalBackendManager struct{}
+
+func (stubLocalBackendManager) InstallBackend(_ context.Context, _ *galleryop.ManagementOp[gallery.GalleryBackend, any], _ galleryop.ProgressCallback) error {
+	return nil
+}
+func (stubLocalBackendManager) DeleteBackend(_ string) error { return gallery.ErrBackendNotFound }
+func (stubLocalBackendManager) ListBackends() (gallery.SystemBackends, error) {
+	return gallery.SystemBackends{}, nil
+}
+func (stubLocalBackendManager) UpgradeBackend(_ context.Context, _ string, _ galleryop.ProgressCallback) error {
+	return nil
+}
+func (stubLocalBackendManager) CheckUpgrades(_ context.Context) (map[string]gallery.UpgradeInfo, error) {
+	return nil, nil
+}
+
+var _ = Describe("DistributedBackendManager", func() {
+	var (
+		db       *gorm.DB
+		registry *NodeRegistry
+		mc       *scriptedMessagingClient
+		adapter  *RemoteUnloaderAdapter
+		mgr      *DistributedBackendManager
+		ctx      context.Context
+	)
+
+	BeforeEach(func() {
+		if runtime.GOOS == "darwin" {
+			Skip("testcontainers requires Docker, not available on macOS CI")
+		}
+		db = testutil.SetupTestDB()
+		var err error
+		registry, err = NewNodeRegistry(db)
+		Expect(err).ToNot(HaveOccurred())
+
+		mc = newScriptedMessagingClient()
+		adapter = NewRemoteUnloaderAdapter(nil, mc)
+		mgr = &DistributedBackendManager{
+			local:    stubLocalBackendManager{},
+			adapter:  adapter,
+			registry: registry,
+		}
+		ctx = context.Background()
+	})
+
+	// registerHealthyBackend registers an auto-approved backend node and
+	// returns it after a fresh fetch (so the ID/Status is correct).
+	registerHealthyBackend := func(name, address string) *BackendNode {
+		node := &BackendNode{Name: name, NodeType: NodeTypeBackend, Address: address}
+		Expect(registry.Register(ctx, node, true)).To(Succeed())
+		fetched, err := registry.GetByName(ctx, name)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(fetched.Status).To(Equal(StatusHealthy))
+		return fetched
+	}
+
+	registerUnhealthyBackend := func(name, address string) *BackendNode {
+		node := registerHealthyBackend(name, address)
+		Expect(registry.MarkUnhealthy(ctx, node.ID)).To(Succeed())
+		fetched, err := registry.Get(ctx, node.ID)
+		Expect(err).ToNot(HaveOccurred())
+		return fetched
+	}
+
+	op := func(name string) *galleryop.ManagementOp[gallery.GalleryBackend, any] {
+		return &galleryop.ManagementOp[gallery.GalleryBackend, any]{
+			GalleryElementName: name,
+		}
+	}
+
+	Describe("InstallBackend", func() {
+		Context("when every healthy node replies Success=true", func() {
+			It("returns nil", func() {
+				n1 := registerHealthyBackend("worker-a", "10.0.0.1:50051")
+				n2 := registerHealthyBackend("worker-b", "10.0.0.2:50051")
+
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(n1.ID),
+					messaging.BackendInstallReply{Success: true, Address: "10.0.0.1:50100"})
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(n2.ID),
+					messaging.BackendInstallReply{Success: true, Address: "10.0.0.2:50100"})
+
+				Expect(mgr.InstallBackend(ctx, op("vllm-development"), nil)).To(Succeed())
+			})
+		})
+
+		Context("when every node replies Success=false with a distinct error", func() {
+			It("returns an aggregated error mentioning each node and message", func() {
+				n1 := registerHealthyBackend("dgx-casa", "10.0.0.1:50051")
+				n2 := registerHealthyBackend("nvidia-thor", "10.0.0.2:50051")
+
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(n1.ID),
+					messaging.BackendInstallReply{Success: false, Error: "no child with platform linux/arm64 in index quay.io/...master-cpu-vllm"})
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(n2.ID),
+					messaging.BackendInstallReply{Success: false, Error: "disk full"})
+
+				err := mgr.InstallBackend(ctx, op("vllm-development"), nil)
+				Expect(err).To(HaveOccurred())
+				msg := err.Error()
+				Expect(msg).To(ContainSubstring("dgx-casa"))
+				Expect(msg).To(ContainSubstring("no child with platform linux/arm64"))
+				Expect(msg).To(ContainSubstring("nvidia-thor"))
+				Expect(msg).To(ContainSubstring("disk full"))
+			})
+		})
+
+		Context("when one node succeeds and another fails", func() {
+			It("returns an error describing the failing node", func() {
+				ok := registerHealthyBackend("worker-ok", "10.0.0.1:50051")
+				bad := registerHealthyBackend("worker-bad", "10.0.0.2:50051")
+
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(ok.ID),
+					messaging.BackendInstallReply{Success: true, Address: "10.0.0.1:50100"})
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(bad.ID),
+					messaging.BackendInstallReply{Success: false, Error: "out of memory"})
+
+				err := mgr.InstallBackend(ctx, op("vllm-development"), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("worker-bad"))
+				Expect(err.Error()).To(ContainSubstring("out of memory"))
+				Expect(err.Error()).ToNot(ContainSubstring("worker-ok"))
+			})
+		})
+
+		Context("when every node is unhealthy at fan-out time", func() {
+			It("returns nil — queued nodes are pending retry, not failures", func() {
+				registerUnhealthyBackend("worker-a", "10.0.0.1:50051")
+				registerUnhealthyBackend("worker-b", "10.0.0.2:50051")
+
+				// No replies scripted: if the manager tried to call Request,
+				// it would hit the "no responders" default and we'd see it.
+				Expect(mgr.InstallBackend(ctx, op("vllm-development"), nil)).To(Succeed())
+				mc.mu.Lock()
+				calls := len(mc.calls)
+				mc.mu.Unlock()
+				Expect(calls).To(Equal(0))
+			})
+		})
+
+		Context("when there are no nodes registered at all", func() {
+			It("returns nil", func() {
+				Expect(mgr.InstallBackend(ctx, op("vllm-development"), nil)).To(Succeed())
+			})
+		})
+	})
+
+	Describe("UpgradeBackend", func() {
+		Context("when every node fails to upgrade", func() {
+			It("returns an aggregated error", func() {
+				n1 := registerHealthyBackend("worker-a", "10.0.0.1:50051")
+				n2 := registerHealthyBackend("worker-b", "10.0.0.2:50051")
+
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(n1.ID),
+					messaging.BackendInstallReply{Success: false, Error: "image manifest not found"})
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(n2.ID),
+					messaging.BackendInstallReply{Success: false, Error: "registry unauthorized"})
+
+				err := mgr.UpgradeBackend(ctx, "vllm-development", nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("worker-a"))
+				Expect(err.Error()).To(ContainSubstring("image manifest not found"))
+				Expect(err.Error()).To(ContainSubstring("worker-b"))
+				Expect(err.Error()).To(ContainSubstring("registry unauthorized"))
+			})
+		})
+
+		Context("when every node succeeds", func() {
+			It("returns nil", func() {
+				n1 := registerHealthyBackend("worker-a", "10.0.0.1:50051")
+				mc.scriptReply(messaging.SubjectNodeBackendInstall(n1.ID),
+					messaging.BackendInstallReply{Success: true})
+				Expect(mgr.UpgradeBackend(ctx, "vllm-development", nil)).To(Succeed())
+			})
+		})
+	})
+
+	Describe("DeleteBackend", func() {
+		Context("when every node fails to delete", func() {
+			It("returns an aggregated error", func() {
+				n1 := registerHealthyBackend("worker-a", "10.0.0.1:50051")
+				n2 := registerHealthyBackend("worker-b", "10.0.0.2:50051")
+
+				mc.scriptReply(messaging.SubjectNodeBackendDelete(n1.ID),
+					messaging.BackendDeleteReply{Success: false, Error: "backend not installed"})
+				mc.scriptReply(messaging.SubjectNodeBackendDelete(n2.ID),
+					messaging.BackendDeleteReply{Success: false, Error: "permission denied"})
+
+				err := mgr.DeleteBackend("vllm-development")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("worker-a"))
+				Expect(err.Error()).To(ContainSubstring("backend not installed"))
+				Expect(err.Error()).To(ContainSubstring("worker-b"))
+				Expect(err.Error()).To(ContainSubstring("permission denied"))
+			})
+		})
+
+		Context("when every node succeeds", func() {
+			It("returns nil", func() {
+				n1 := registerHealthyBackend("worker-a", "10.0.0.1:50051")
+				mc.scriptReply(messaging.SubjectNodeBackendDelete(n1.ID),
+					messaging.BackendDeleteReply{Success: true})
+				Expect(mgr.DeleteBackend("vllm-development")).To(Succeed())
+			})
+		})
+	})
+})


### PR DESCRIPTION
**Description**

DistributedBackendManager.{Install,Upgrade,Delete}Backend discarded the
per-node BackendOpResult from enqueueAndDrainBackendOp with `_, err :=`.
When workers replied Success=false (e.g. an OCI image with no arm64
variant on a Jetson host), the per-node Error string was recorded in
result.Nodes[].Error but never reached the toplevel return value, so
OpStatus.Error stayed empty and the UI reported the install as
"completed" while the backend was nowhere on the cluster.

Add BackendOpResult.Err() that aggregates per-node Status=="error"
entries into a single error. Queued nodes (waiting for reconciler retry)
are deliberately not treated as failures. Wire the three callers and
DeleteBackendDetailed to call result.Err() so reply.Success=false
finally reaches OpStatus.Error → /api/backends/job/:uid → the UI.

The Delete closures had a related bug: they discarded the reply with
`_` and only checked the NATS round-trip error, so reply.Success=false
was a silent success even with the new aggregation. Check both.

=**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->