### PR TITLE
fix(mlx-vlm): pin upstream to v0.4.4 to unblock CUDA builds

### DIFF
--- a/backend/python/mlx-vlm/requirements-cpu.txt
+++ b/backend/python/mlx-vlm/requirements-cpu.txt
@@ -1,2 +1,2 @@
-git+https://github.com/Blaizzy/mlx-vlm
+git+https://github.com/Blaizzy/mlx-vlm@v0.4.4
 mlx[cpu]

--- a/backend/python/mlx-vlm/requirements-cublas12.txt
+++ b/backend/python/mlx-vlm/requirements-cublas12.txt
@@ -1,2 +1,2 @@
-git+https://github.com/Blaizzy/mlx-vlm
+git+https://github.com/Blaizzy/mlx-vlm@v0.4.4
 mlx[cuda12]

--- a/backend/python/mlx-vlm/requirements-cublas13.txt
+++ b/backend/python/mlx-vlm/requirements-cublas13.txt
@@ -1,2 +1,2 @@
-git+https://github.com/Blaizzy/mlx-vlm
+git+https://github.com/Blaizzy/mlx-vlm@v0.4.4
 mlx[cuda13]

--- a/backend/python/mlx-vlm/requirements-l4t12.txt
+++ b/backend/python/mlx-vlm/requirements-l4t12.txt
@@ -1,2 +1,2 @@
-git+https://github.com/Blaizzy/mlx-vlm
+git+https://github.com/Blaizzy/mlx-vlm@v0.4.4
 mlx[cuda12]

--- a/backend/python/mlx-vlm/requirements-l4t13.txt
+++ b/backend/python/mlx-vlm/requirements-l4t13.txt
@@ -1,2 +1,2 @@
-git+https://github.com/Blaizzy/mlx-vlm
+git+https://github.com/Blaizzy/mlx-vlm@v0.4.4
 mlx[cuda13]

--- a/backend/python/mlx-vlm/requirements-mps.txt
+++ b/backend/python/mlx-vlm/requirements-mps.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Blaizzy/mlx-vlm
+git+https://github.com/Blaizzy/mlx-vlm@v0.4.4


### PR DESCRIPTION
Blaizzy/mlx-vlm git HEAD bumped its constraint to mlx>=0.31.2, but mlx-cuda-12 and mlx-cuda-13 are only published up to 0.31.1 on PyPI. Since mlx[cudaXX]==0.31.2 forces a sibling wheel that doesn't exist, pip backtracks through every older mlx[cudaXX], none of which satisfy mlx>=0.31.2, producing ResolutionImpossible.

Pin all variants to the v0.4.4 tag (mlx>=0.30.0), which resolves cleanly against mlx[cuda13]==0.31.1. cpu/mps weren't broken yet but are pinned for consistency.

Assisted-by: Claude:claude-opus-4-7
