### PR TITLE
fix(llama-cpp): adapt grpc-server.cpp to upstream API changes

### DIFF
--- a/backend/cpp/llama-cpp/grpc-server.cpp
+++ b/backend/cpp/llama-cpp/grpc-server.cpp
@@ -1660,7 +1660,6 @@ public:
                         ctx_server.impl->vocab,
                         params_base,
                         ctx_server.get_meta().slot_n_ctx,
-                        ctx_server.get_meta().logit_bias_eog,
                         data);
                 task.id_slot = json_value(data, "id_slot", -1);
 
@@ -2444,7 +2443,6 @@ public:
                         ctx_server.impl->vocab,
                         params_base,
                         ctx_server.get_meta().slot_n_ctx,
-                        ctx_server.get_meta().logit_bias_eog,
                         data);
                 task.id_slot = json_value(data, "id_slot", -1);
 
@@ -2841,7 +2839,7 @@ public:
         // same string when rendering prompts outside the tokenizer-template path.
         // Only meaningful when an mtmd context was initialized (vision/audio models).
         if (ctx_server.impl->mctx != nullptr) {
-            response->set_media_marker(get_media_marker());
+            response->set_media_marker(mtmd_default_marker());
         }
 
         // Check if chat templates are initialized


### PR DESCRIPTION
## Summary

The llama.cpp pin at `187a45637054` (2026-04-23) tightened the upstream server API in two ways that break `backend/cpp/llama-cpp/grpc-server.cpp`. This PR adapts the call sites so the rocm-7.x / hipblas build (and presumably any other build that pulls this pin) compiles again.

## What broke

```
grpc-server.cpp:1648:47: error: no member named 'logit_bias_eog' in 'server_context_meta'
grpc-server.cpp:2432:47: error: no member named 'logit_bias_eog' in 'server_context_meta'
grpc-server.cpp:2838:40: error: use of undeclared identifier 'get_media_marker'
```

## Root cause

1. **`server_task::params_from_json_cmpl`** was reduced from five parameters to four. The `logit_bias_eog` vector argument was removed and `server_context_meta` no longer carries the field — it now lives only on `common_params` / `sampling`. The upstream `server-context.cpp` was updated accordingly (`task.params = server_task::params_from_json_cmpl(ctx_server.vocab, params, meta->slot_n_ctx, data);`) but `grpc-server.cpp` was not.

2. **`get_media_marker()`** is no longer a member of the server context accessor surface. The MTMD module exposes `mtmd_default_marker()` (declared in `tools/mtmd/mtmd.h`, line 104) which returns the same default marker string the upstream server uses internally. `mtmd.h` is already included transitively by `server-context.cpp`, so no new include is required.

## Fix

```diff
diff --git a/backend/cpp/llama-cpp/grpc-server.cpp b/backend/cpp/llama-cpp/grpc-server.cpp
@@ -1645,7 +1645,6 @@
                         ctx_server.impl->vocab,
                         params_base,
                         ctx_server.get_meta().slot_n_ctx,
-                        ctx_server.get_meta().logit_bias_eog,
                         data);
                 task.id_slot = json_value(data, "id_slot", -1);
@@ -2429,7 +2428,6 @@
                         ctx_server.impl->vocab,
                         params_base,
                         ctx_server.get_meta().slot_n_ctx,
-                        ctx_server.get_meta().logit_bias_eog,
                         data);
                 task.id_slot = json_value(data, "id_slot", -1);
@@ -2835,7 +2833,7 @@
         if (ctx_server.impl->mctx != nullptr) {
-            response->set_media_marker(get_media_marker());
+            response->set_media_marker(mtmd_default_marker());
         }
```

## Test plan

- [x] Rebuilt the `rocm7-llama-cpp` backend image against this patch on AMD gfx1151 / Strix Halo. Earlier build with the same llama.cpp pin failed at `grpc-server.cpp:1648` with the error above (9m56s wall, exit 2). After the patch the same build completes cleanly: `Backends fertig: 1 OK, 0 FEHLER (3m10s)`.
- [x] No behavioural change intended: the upstream API drop simply means `logit_bias_eog` is sourced from `params_base.sampling.logit_bias_eog` inside `params_from_json_cmpl` (where the upstream `server-context.cpp` reads it from), and `mtmd_default_marker()` returns the same string `get_media_marker()` previously returned.
- [ ] CI matrix on other backends (cuda, vulkan, metal) — same call sites, same fix, expected to pass.
