### PR TITLE
fix(gallery): correct Qwen3.5 typo in qwen3.5-27b-claude-4.6 model override (closes #9362)

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -745,7 +745,7 @@
     - default
   overrides:
     parameters:
-      model: llama-cpp/models/Qwen3.-27B-Claude-4.6-Opus-Reasoning-Distilled-heretic.i1-Q4_K_M.gguf
+      model: llama-cpp/models/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-heretic.i1-Q4_K_M.gguf
     backend: llama-cpp
     template:
       use_tokenizer_template: true


### PR DESCRIPTION
## Summary

Closes #9362.

The gallery entry **`qwen3.5-27b-claude-4.6-opus-reasoning-distilled-heretic-i1`** has a typo in its `overrides.parameters.model` field — `Qwen3.-27B-Claude-...` (missing the `5`). The downloaded file is named `Qwen3.5-27B-Claude-...` (matching the `files:` entry below and the upstream HF repo), so model loads fail with:

```
Failed to load model: /models/llama-cpp/models/Qwen3.-27B-Claude-4.6-Opus-Reasoning-Distilled-heretic.i1-Q4_K_M.gguf
```

## Diff

```diff
   overrides:
     parameters:
-      model: llama-cpp/models/Qwen3.-27B-Claude-4.6-Opus-Reasoning-Distilled-heretic.i1-Q4_K_M.gguf
+      model: llama-cpp/models/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-heretic.i1-Q4_K_M.gguf
```

## Verification

After fix, `overrides.parameters.model` matches:
- the `files:` entry (`llama-cpp/models/Qwen3.5-27B-Claude-...`)
- the `mmproj` field (`...mmproj/Qwen3.5-27B-Claude-...`)
- the upstream HuggingFace repo path (`mradermacher/Qwen3.5-27B-Claude-4.6-Opus-Reasoning-Distilled-heretic-i1-GGUF`)

I grep'd `gallery/index.yaml` for similar `Qwen3.-`/`\.\-[0-9]+B` patterns; this is the only occurrence — no other entries are affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
