### PR TITLE
fix(http): honor X-Forwarded-Prefix when proxy strips the prefix

### DIFF
--- a/core/http/app.go
+++ b/core/http/app.go
@@ -448,10 +448,18 @@ func API(application *application.Application) (*echo.Echo, error) {
 				// and would bypass the reverse-proxy prefix. Rewrite the internal
 				// path-absolute references emitted by the build so the browser
 				// requests them through the proxy under the prefix.
+				//
+				// HTML-escape the prefix before interpolating it into attributes:
+				// BasePathPrefix already gates X-Forwarded-Prefix via
+				// SafeForwardedPrefix, but the validator only blocks open-redirect
+				// shapes (// prefix, backslashes, control chars), not attribute
+				// breakout characters like `"`. Escaping makes this resilient
+				// even if the validator ever loosens.
 				if prefix := httpMiddleware.BasePathPrefix(c); prefix != "/" {
+					safePrefix := httpMiddleware.SecureBaseHref(prefix)
 					html := string(indexHTML)
-					html = strings.ReplaceAll(html, `="/assets/`, `="`+prefix+`assets/`)
-					html = strings.ReplaceAll(html, `="/favicon.svg"`, `="`+prefix+`favicon.svg"`)
+					html = strings.ReplaceAll(html, `="/assets/`, `="`+safePrefix+`assets/`)
+					html = strings.ReplaceAll(html, `="/favicon.svg"`, `="`+safePrefix+`favicon.svg"`)
 					indexHTML = []byte(html)
 				}
 				return c.HTMLBlob(http.StatusOK, indexHTML)

--- a/core/http/app.go
+++ b/core/http/app.go
@@ -443,6 +443,17 @@ func API(application *application.Application) (*echo.Echo, error) {
 					baseTag := `<base href="` + httpMiddleware.SecureBaseHref(baseURL) + `" />`
 					indexHTML = []byte(strings.Replace(string(indexHTML), "<head>", "<head>\n  "+baseTag, 1))
 				}
+				// <base href> only changes how relative URLs resolve; path-absolute
+				// URLs (those starting with `/`) still resolve against the origin
+				// and would bypass the reverse-proxy prefix. Rewrite the internal
+				// path-absolute references emitted by the build so the browser
+				// requests them through the proxy under the prefix.
+				if prefix := httpMiddleware.BasePathPrefix(c); prefix != "/" {
+					html := string(indexHTML)
+					html = strings.ReplaceAll(html, `="/assets/`, `="`+prefix+`assets/`)
+					html = strings.ReplaceAll(html, `="/favicon.svg"`, `="`+prefix+`favicon.svg"`)
+					indexHTML = []byte(html)
+				}
 				return c.HTMLBlob(http.StatusOK, indexHTML)
 			}
 

--- a/core/http/app_test.go
+++ b/core/http/app_test.go
@@ -465,6 +465,23 @@ var _ = Describe("API test", func() {
 				Expect(string(body)).ToNot(ContainSubstring(`="/assets/`), "asset URLs must include the prefix")
 				Expect(string(body)).ToNot(ContainSubstring(`="/favicon.svg"`), "favicon URL must include the prefix")
 			})
+
+			// X-Forwarded-Prefix is attacker controllable on misconfigured
+			// proxy chains. A value like "//evil.com" would otherwise turn the
+			// asset URL rewrite into a protocol-relative URL that loads JS
+			// from a foreign origin. BasePathPrefix must reject these via
+			// SafeForwardedPrefix and fall back to "/".
+			It("Should ignore an unsafe X-Forwarded-Prefix and not poison asset URLs", func() {
+				err, sc, body := getRequest("http://127.0.0.1:9090/app", http.Header{
+					"X-Forwarded-Proto":  {"https"},
+					"X-Forwarded-Host":   {"example.org"},
+					"X-Forwarded-Prefix": {"//evil.com"},
+				})
+				Expect(err).To(BeNil(), "error")
+				Expect(sc).To(Equal(200), "status code")
+				Expect(string(body)).ToNot(ContainSubstring("evil.com"), "unsafe prefix must not leak into the response")
+				Expect(string(body)).ToNot(ContainSubstring(`="//`), "asset URLs must not become protocol-relative")
+			})
 		})
 
 		Context("Applying models", func() {

--- a/core/http/app_test.go
+++ b/core/http/app_test.go
@@ -446,6 +446,25 @@ var _ = Describe("API test", func() {
 				Expect(sc).To(Equal(200), "status code")
 				Expect(string(body)).To(ContainSubstring(`<base href="https://example.org/myprefix/" />`), "body")
 			})
+
+			// Caddy's `handle_path` (and similar directives) strip the matched
+			// prefix before forwarding upstream, so LocalAI receives the
+			// already-stripped path together with X-Forwarded-Prefix. The base
+			// href and asset URLs must still include the prefix so the browser
+			// requests them through the proxy.
+			It("Should support reverse-proxy when prefix is stripped by the proxy", func() {
+
+				err, sc, body := getRequest("http://127.0.0.1:9090/app", http.Header{
+					"X-Forwarded-Proto":  {"https"},
+					"X-Forwarded-Host":   {"example.org"},
+					"X-Forwarded-Prefix": {"/myprefix"},
+				})
+				Expect(err).To(BeNil(), "error")
+				Expect(sc).To(Equal(200), "status code")
+				Expect(string(body)).To(ContainSubstring(`<base href="https://example.org/myprefix/" />`), "body")
+				Expect(string(body)).ToNot(ContainSubstring(`="/assets/`), "asset URLs must include the prefix")
+				Expect(string(body)).ToNot(ContainSubstring(`="/favicon.svg"`), "favicon URL must include the prefix")
+			})
 		})
 
 		Context("Applying models", func() {

--- a/core/http/middleware/baseurl.go
+++ b/core/http/middleware/baseurl.go
@@ -6,31 +6,20 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-// BaseURL returns the base URL for the given HTTP request context.
-// It takes into account that the app may be exposed by a reverse-proxy under a different protocol, host and path.
-// The returned URL is guaranteed to end with `/`.
-// The method should be used in conjunction with the StripPathPrefix middleware.
-func BaseURL(c echo.Context) string {
+// BasePathPrefix returns the URL path prefix that the request was reached
+// under (e.g. "/myprefix/"). It always returns a value that starts and ends
+// with `/`, defaulting to "/" when the app is not behind a path prefix.
+//
+// It first looks at the path StripPathPrefix removed (when the proxy forwards
+// the prefix in the URL), then falls back to the X-Forwarded-Prefix header
+// (when the proxy strips the prefix before forwarding, e.g. Caddy's
+// handle_path).
+func BasePathPrefix(c echo.Context) string {
 	path := c.Path()
 	origPath := c.Request().URL.Path
 
-	// Check if StripPathPrefix middleware stored the original path
 	if storedPath, ok := c.Get("_original_path").(string); ok && storedPath != "" {
 		origPath = storedPath
-	}
-
-	// Check X-Forwarded-Proto for scheme
-	scheme := "http"
-	if c.Request().Header.Get("X-Forwarded-Proto") == "https" {
-		scheme = "https"
-	} else if c.Request().TLS != nil {
-		scheme = "https"
-	}
-
-	// Check X-Forwarded-Host for host
-	host := c.Request().Host
-	if forwardedHost := c.Request().Header.Get("X-Forwarded-Host"); forwardedHost != "" {
-		host = forwardedHost
 	}
 
 	if path != origPath && strings.HasSuffix(origPath, path) && len(path) > 0 {
@@ -40,9 +29,39 @@ func BaseURL(c echo.Context) string {
 			if !strings.HasSuffix(pathPrefix, "/") {
 				pathPrefix += "/"
 			}
-			return scheme + "://" + host + pathPrefix
+			return pathPrefix
 		}
 	}
 
-	return scheme + "://" + host + "/"
+	if forwardedPrefix := c.Request().Header.Get("X-Forwarded-Prefix"); forwardedPrefix != "" {
+		if !strings.HasPrefix(forwardedPrefix, "/") {
+			forwardedPrefix = "/" + forwardedPrefix
+		}
+		if !strings.HasSuffix(forwardedPrefix, "/") {
+			forwardedPrefix += "/"
+		}
+		return forwardedPrefix
+	}
+
+	return "/"
+}
+
+// BaseURL returns the base URL for the given HTTP request context.
+// It takes into account that the app may be exposed by a reverse-proxy under a different protocol, host and path.
+// The returned URL is guaranteed to end with `/`.
+// The method should be used in conjunction with the StripPathPrefix middleware.
+func BaseURL(c echo.Context) string {
+	scheme := "http"
+	if c.Request().Header.Get("X-Forwarded-Proto") == "https" {
+		scheme = "https"
+	} else if c.Request().TLS != nil {
+		scheme = "https"
+	}
+
+	host := c.Request().Host
+	if forwardedHost := c.Request().Header.Get("X-Forwarded-Host"); forwardedHost != "" {
+		host = forwardedHost
+	}
+
+	return scheme + "://" + host + BasePathPrefix(c)
 }

--- a/core/http/middleware/baseurl.go
+++ b/core/http/middleware/baseurl.go
@@ -14,6 +14,13 @@ import (
 // the prefix in the URL), then falls back to the X-Forwarded-Prefix header
 // (when the proxy strips the prefix before forwarding, e.g. Caddy's
 // handle_path).
+//
+// The header fallback is gated through SafeForwardedPrefix because the value
+// flows into the SPA HTML response (both <base href> and the path-absolute
+// asset URL rewrite in serveIndex). X-Forwarded-Prefix is attacker
+// controllable on misconfigured proxy chains; without that gate a value like
+// "//evil.com" turns the asset rewrite into a protocol-relative URL that
+// loads JS from a foreign origin.
 func BasePathPrefix(c echo.Context) string {
 	path := c.Path()
 	origPath := c.Request().URL.Path
@@ -24,7 +31,7 @@ func BasePathPrefix(c echo.Context) string {
 
 	if path != origPath && strings.HasSuffix(origPath, path) && len(path) > 0 {
 		prefixLen := len(origPath) - len(path)
-		if prefixLen > 0 && prefixLen <= len(origPath) {
+		if prefixLen > 0 {
 			pathPrefix := origPath[:prefixLen]
 			if !strings.HasSuffix(pathPrefix, "/") {
 				pathPrefix += "/"
@@ -33,14 +40,11 @@ func BasePathPrefix(c echo.Context) string {
 		}
 	}
 
-	if forwardedPrefix := c.Request().Header.Get("X-Forwarded-Prefix"); forwardedPrefix != "" {
-		if !strings.HasPrefix(forwardedPrefix, "/") {
-			forwardedPrefix = "/" + forwardedPrefix
+	if validated, ok := SafeForwardedPrefix(c.Request().Header.Get("X-Forwarded-Prefix")); ok {
+		if !strings.HasSuffix(validated, "/") {
+			validated += "/"
 		}
-		if !strings.HasSuffix(forwardedPrefix, "/") {
-			forwardedPrefix += "/"
-		}
-		return forwardedPrefix
+		return validated
 	}
 
 	return "/"

--- a/core/http/middleware/baseurl_test.go
+++ b/core/http/middleware/baseurl_test.go
@@ -100,4 +100,39 @@ var _ = Describe("BaseURL", func() {
 			Expect(actualURL).To(Equal("http://example.com/localai/"), "base URL")
 		})
 	})
+
+	// X-Forwarded-Prefix is attacker controllable on misconfigured proxy
+	// chains, and the value flows into the SPA HTML response (<base href>
+	// and asset URLs). BasePathPrefix must gate the header through
+	// SafeForwardedPrefix so values that turn the prefix into an open
+	// redirect or a protocol-relative URL are ignored and the base falls
+	// back to "/".
+	Context("with unsafe X-Forwarded-Prefix header", func() {
+		DescribeTable("falls back to / when the header is unsafe",
+			func(header string) {
+				app := echo.New()
+				actualURL := ""
+
+				app.GET("/app", func(c echo.Context) error {
+					actualURL = BaseURL(c)
+					return nil
+				})
+
+				req := httptest.NewRequest("GET", "/app", nil)
+				req.Header.Set("X-Forwarded-Prefix", header)
+				rec := httptest.NewRecorder()
+				app.ServeHTTP(rec, req)
+
+				Expect(rec.Code).To(Equal(200), "response status code")
+				Expect(actualURL).To(Equal("http://example.com/"), "base URL")
+			},
+			Entry("protocol-relative URL", "//evil.com"),
+			Entry("protocol-relative URL with path", "//evil.com/assets"),
+			Entry("backslash path", `/foo\bar`),
+			Entry("embedded NUL", "/foo\x00bar"),
+			Entry("CR injection", "/foo\rbar"),
+			Entry("LF injection", "/foo\nbar"),
+			Entry("missing leading slash", "evil"),
+		)
+	})
 })

--- a/core/http/middleware/baseurl_test.go
+++ b/core/http/middleware/baseurl_test.go
@@ -55,4 +55,49 @@ var _ = Describe("BaseURL", func() {
 			Expect(actualURL).To(Equal("http://example.com/myprefix/"), "base URL")
 		})
 	})
+
+	// Caddy's handle_path (and similar reverse-proxy directives) strips the
+	// matched prefix before forwarding upstream, so LocalAI receives the
+	// already-stripped path together with X-Forwarded-Prefix. In that case
+	// StripPathPrefix never stores _original_path, but BaseURL must still
+	// honor the header so that <base href> and asset URLs include the prefix.
+	Context("with X-Forwarded-Prefix header but pre-stripped path", func() {
+		It("should return base URL with prefix from header", func() {
+			app := echo.New()
+			actualURL := ""
+
+			routePath := "/app"
+			app.GET(routePath, func(c echo.Context) error {
+				actualURL = BaseURL(c)
+				return nil
+			})
+
+			req := httptest.NewRequest("GET", "/app", nil)
+			req.Header.Set("X-Forwarded-Prefix", "/localai")
+			rec := httptest.NewRecorder()
+			app.ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(200), "response status code")
+			Expect(actualURL).To(Equal("http://example.com/localai/"), "base URL")
+		})
+
+		It("should normalize a prefix that already ends with a slash", func() {
+			app := echo.New()
+			actualURL := ""
+
+			routePath := "/app"
+			app.GET(routePath, func(c echo.Context) error {
+				actualURL = BaseURL(c)
+				return nil
+			})
+
+			req := httptest.NewRequest("GET", "/app", nil)
+			req.Header.Set("X-Forwarded-Prefix", "/localai/")
+			rec := httptest.NewRecorder()
+			app.ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(200), "response status code")
+			Expect(actualURL).To(Equal("http://example.com/localai/"), "base URL")
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Closes #9145.

The React UI failed to load when LocalAI was exposed through a reverse proxy that **strips the matched path prefix before forwarding** (e.g. Caddy's `handle_path /localai/*`). Two issues combined to break this:

1. **`BaseURL` ignored `X-Forwarded-Prefix` when `StripPathPrefix` had nothing to strip.** It only computed a prefix from the request path the middleware had rewritten, so when the proxy already stripped the prefix upstream the base URL came back without one. Extracted a `BasePathPrefix(c)` helper and added an `X-Forwarded-Prefix` header fallback so the prefix is recovered in either flow.
2. **Even with `<base href>` correct, path-absolute references bypass it.** Per the HTML spec, URLs starting with `/` resolve against the base **origin**, not the base **path**, so the `="/assets/..."` and `="/favicon.svg"` references emitted by the build went straight to the origin and bypassed the proxy prefix. `serveIndex` now rewrites those references to include the prefix when one is present.

## Test plan

- [x] `go test ./core/http/middleware/...` — 19/19 specs pass, including new `BaseURL` cases for the pre-stripped path scenario (with and without trailing slash on the header).
- [x] New integration test in `core/http/app_test.go` asserts both `<base href>` and asset URLs are correct when the prefix arrives only via `X-Forwarded-Prefix`.
- [ ] Manual verification behind Caddy `handle_path` with the reproducer from #9145.

🤖 Generated with [Claude Code](https://claude.com/claude-code)