### PR TITLE
feat(backends/python): use tempfile.gettempdir() instead of hardcoded /tmp

### DIFF
--- a/backend/python/pocket-tts/backend.py
+++ b/backend/python/pocket-tts/backend.py
@@ -8,6 +8,7 @@ import argparse
 import signal
 import sys
 import os
+import tempfile
 import traceback
 import scipy.io.wavfile
 import backend_pb2
@@ -204,7 +205,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             # Save audio to file
             output_path = request.dst
             if not output_path:
-                output_path = "/tmp/pocket-tts-output.wav"
+                output_path = os.path.join(tempfile.gettempdir(), "pocket-tts-output.wav")
 
             # Ensure output directory exists
             output_dir = os.path.dirname(output_path)

--- a/backend/python/tinygrad/backend.py
+++ b/backend/python/tinygrad/backend.py
@@ -33,6 +33,7 @@ import json
 import os
 import signal
 import sys
+import tempfile
 import time
 from concurrent import futures
 from pathlib import Path
@@ -668,7 +669,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             )
             arr = img_tensor.numpy()
             image = Image.fromarray(arr)
-            dst = request.dst or "/tmp/tinygrad_image.png"
+            dst = request.dst or os.path.join(tempfile.gettempdir(), "tinygrad_image.png")
             image.save(dst)
             return backend_pb2.Result(success=True, message=dst)
         except Exception as exc:

--- a/backend/python/vllm-omni/backend.py
+++ b/backend/python/vllm-omni/backend.py
@@ -19,6 +19,7 @@ import base64
 import io
 import json
 import gc
+import tempfile
 
 from PIL import Image
 import torch
@@ -117,7 +118,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         # Try base64 decode
         try:
             timestamp = str(int(time.time() * 1000))
-            p = f"/tmp/vl-{timestamp}.data"
+            p = os.path.join(tempfile.gettempdir(), f"vl-{timestamp}.data")
             with open(p, "wb") as f:
                 f.write(base64.b64decode(video_path))
             video = VideoAsset(name=p).np_ndarrays
@@ -137,7 +138,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             audio_data = base64.b64decode(audio_path)
             # Save to temp file and load
             timestamp = str(int(time.time() * 1000))
-            p = f"/tmp/audio-{timestamp}.wav"
+            p = os.path.join(tempfile.gettempdir(), f"audio-{timestamp}.wav")
             with open(p, "wb") as f:
                 f.write(audio_data)
             audio_signal, sr = librosa.load(p, sr=16000)

--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -10,6 +10,7 @@ import os
 import json
 import time
 import gc
+import tempfile
 from typing import List
 from PIL import Image
 
@@ -602,7 +603,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         """
         try:
             timestamp = str(int(time.time() * 1000))  # Generate timestamp
-            p = f"/tmp/vl-{timestamp}.data"  # Use timestamp in filename
+            p = os.path.join(tempfile.gettempdir(), f"vl-{timestamp}.data")
             with open(p, "wb") as f:
                 f.write(base64.b64decode(video_path))
             video = VideoAsset(name=p).np_ndarrays


### PR DESCRIPTION
Closes #9601

## Problem

The Python backends `vllm`, `vllm-omni`, `tinygrad`, and `pocket-tts` hardcode `/tmp` as the directory for scratch files (base64-decoded video/audio buffers, generated image/TTS outputs when no destination is provided). On systems where `/` is a small or read-only partition (containers with size-limited overlays, locked-down hosts, automation environments where the user can manage data volume but not root), there is no escape hatch: even with `LOCALAI_GENERATED_CONTENT_PATH` and `LOCALAI_UPLOAD_PATH` already configurable for the Go side, these Python backends still go to `/tmp`.

Reporter on #9601:
> default `/tmp` is on the root partition which has limit size; the size limit is because of automation and manageability ... tried out a few parameters to no avail.

## Fix

Replace the five hardcoded `"/tmp/..."` literals with `os.path.join(tempfile.gettempdir(), ...)`. `tempfile.gettempdir()` honors the standard `TMPDIR` env var (and `TMP`/`TEMP` on Windows), so users can simply set e.g. `TMPDIR=/data/tmp` and these scratch files relocate accordingly. Behavior is unchanged when `TMPDIR` is unset (Linux default is still `/tmp`).

This is a deliberately minimal change — it lets the existing `tempfile` standard-library mechanism solve the issue without inventing a new LocalAI-specific config knob. It composes cleanly with the existing `LOCALAI_GENERATED_CONTENT_PATH` / `LOCALAI_UPLOAD_PATH` options (which target different code paths on the Go side).

## Sites changed

| File | Line (orig) | Before | After |
|------|------|--------|-------|
| `backend/python/vllm/backend.py` | 605 | `f"/tmp/vl-{timestamp}.data"` | `os.path.join(tempfile.gettempdir(), f"vl-{timestamp}.data")` |
| `backend/python/tinygrad/backend.py` | 671 | `request.dst or "/tmp/tinygrad_image.png"` | `request.dst or os.path.join(tempfile.gettempdir(), "tinygrad_image.png")` |
| `backend/python/pocket-tts/backend.py` | 207 | `output_path = "/tmp/pocket-tts-output.wav"` | `output_path = os.path.join(tempfile.gettempdir(), "pocket-tts-output.wav")` |
| `backend/python/vllm-omni/backend.py` | 121 | `f"/tmp/vl-{timestamp}.data"` | `os.path.join(tempfile.gettempdir(), f"vl-{timestamp}.data")` |
| `backend/python/vllm-omni/backend.py` | 141 | `f"/tmp/audio-{timestamp}.wav"` | `os.path.join(tempfile.gettempdir(), f"audio-{timestamp}.wav")` |

Plus an `import tempfile` added to each file (next to the existing stdlib imports). All 4 modified files parse cleanly with `python -m py_compile`.

## Why not switch to `NamedTemporaryFile`?

The existing code uses `time.time() * 1000`-based filenames and explicit `os.remove(p)` cleanup; switching to `NamedTemporaryFile` would be a larger behavior change (collision-safe naming, RAII cleanup) that's worth doing on its own merit but is out of scope for this `/tmp`-relocation fix.

## Test plan

- [x] `python -m py_compile` on all 4 modified files passes
- [x] `grep -n '"/tmp\|f"/tmp' backend/python/{vllm,tinygrad,pocket-tts,vllm-omni}/backend.py` returns no hits after the change
- Behavior (manual): with `TMPDIR=/data/tmp` set, vllm video base64 fallback writes `/data/tmp/vl-<ts>.data` instead of `/tmp/vl-<ts>.data`. With `TMPDIR` unset, behavior is identical to before on Linux (`/tmp/...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
