### PR TITLE
chore(model gallery): add chroma1-hd diffusers model

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -1,4 +1,28 @@
 ---
+- name: "chroma1-hd"
+  url: "github:mudler/LocalAI/gallery/virtual.yaml@master"
+  license: apache-2.0
+  tags:
+    - chroma
+    - text-to-image
+    - image-generation
+    - diffusers
+  urls:
+    - https://huggingface.co/lodestones/Chroma1-HD
+  description: |
+    Chroma1-HD is an 8.9B-parameter text-to-image foundation model derived from FLUX.1-schnell with reduced parameter count via architectural optimizations. Designed as a base for creators, researchers, and downstream fine-tuning. Recommended inference: 40 steps, CFG 3.0, bfloat16.
+  overrides:
+    cfg_scale: 3.0
+    parameters:
+      model: lodestones/Chroma1-HD
+    backend: diffusers
+    known_usecases:
+      - FLAG_IMAGE
+    diffusers:
+      pipeline_type: ChromaPipeline
+    step: 40
+    options:
+      - torch_dtype:bf16
 - name: "nemotron-3-nano-omni-30b-a3b-reasoning-apex"
   url: "github:mudler/LocalAI/gallery/virtual.yaml@master"
   urls:


### PR DESCRIPTION
## Summary

Adds **Chroma1-HD** ([`lodestones/Chroma1-HD`](https://huggingface.co/lodestones/Chroma1-HD)) to the LocalAI model gallery as requested in #9604.

Chroma1-HD is an 8.9B-parameter text-to-image foundation model derived from FLUX.1-schnell. It is served via the upstream `diffusers` `ChromaPipeline`, which is the dedicated pipeline class for Chroma checkpoints (introduced in `src/diffusers/pipelines/chroma/`).

The entry follows the same shape as the existing `z-image-diffusers` entry and uses `gallery/virtual.yaml` as the base config.

## Inference defaults

| Parameter | Value | Source |
|-----------|-------|--------|
| `pipeline_type` | `ChromaPipeline` | upstream `diffusers.ChromaPipeline` |
| `step` | 40 | model card example |
| `cfg_scale` | 3.0 | model card example |
| `torch_dtype` | `bf16` | model card example |
| `backend` | `diffusers` | image-generation backend |
| `known_usecases` | `FLAG_IMAGE` | matches z-image entry |

## Testing

- YAML parsed cleanly with PyYAML (`safe_load`); `len(entries) = 976` (was 975).
- New entry appears as the first item in `gallery/index.yaml`.
- `pipeline_type: ChromaPipeline` matches the upstream class exported from `src/diffusers/pipelines/chroma/__init__.py`.

## Closes
Resolves #9604

---

Assisted-by: claude-code:opus-4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)