### PR TITLE
fix(faster-whisper): cast segment timestamps to int after multiplication

### DIFF
--- a/backend/python/faster-whisper/backend.py
+++ b/backend/python/faster-whisper/backend.py
@@ -59,7 +59,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             id = 0
             for segment in segments:
                 print("[%.2fs -> %.2fs] %s" % (segment.start, segment.end, segment.text))
-                resultSegments.append(backend_pb2.TranscriptSegment(id=id, start=int(segment.start)*1e9, end=int(segment.end)*1e9, text=segment.text))
+                resultSegments.append(backend_pb2.TranscriptSegment(id=id, start=int(segment.start*1e9), end=int(segment.end*1e9), text=segment.text))
                 text += segment.text
                 id += 1
         except Exception as err:


### PR DESCRIPTION
## Summary

Every audio transcription request through the `faster-whisper` backend currently fails with:

```
TypeError: 'float' object cannot be interpreted as an integer
```

### Root cause

In `backend/python/faster-whisper/backend.py`:

```python
backend_pb2.TranscriptSegment(id=id, start=int(segment.start)*1e9, end=int(segment.end)*1e9, ...)
```

`int(x) * 1e9` produces a **float** because `1e9` is a float literal in Python. The protobuf `TranscriptSegment.start` / `.end` fields are integers, so the gRPC call raises a `TypeError` and the whole request fails.

### Fix

Multiply first, then cast to int — `int(x * 1e9)`. One-character-positions changed.

## Test plan

- [x] Reproduced the bug locally with `Systran/faster-whisper-tiny` on v4.1.3 — every request returns `'float' object cannot be interpreted as an integer`.
- [x] Verified the patched backend transcribes audio successfully end-to-end via `/v1/audio/transcriptions`.
- [ ] CI passes.