### PR TITLE
Close Hugging Face scan response body

### DIFF
--- a/pkg/downloader/huggingface.go
+++ b/pkg/downloader/huggingface.go
@@ -33,6 +33,7 @@ func HuggingFaceScan(uri URI) (*HuggingFaceScanResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer results.Body.Close()
 	if results.StatusCode != 200 {
 		return nil, fmt.Errorf("unexpected status code during HuggingFaceScan: %d", results.StatusCode)
 	}


### PR DESCRIPTION
## Summary
- close the Hugging Face scan API response body after a successful request

## Why
HuggingFaceScan reads the response body but did not close it. Deferring Body.Close() after a successful http.Get releases the underlying connection resources on both success and error status paths.

## Testing
- gofmt -w pkg/downloader/huggingface.go
- git diff --check