### PR TITLE
Validate video image URLs before download

### DIFF
--- a/core/http/endpoints/localai/video.go
+++ b/core/http/endpoints/localai/video.go
@@ -22,12 +22,19 @@ import (
 	"github.com/mudler/LocalAI/core/backend"
 
 	model "github.com/mudler/LocalAI/pkg/model"
+	"github.com/mudler/LocalAI/pkg/utils"
 	"github.com/mudler/xlog"
 )
 
+var videoDownloadClient = http.Client{Timeout: 30 * time.Second}
+
 func downloadFile(url string) (string, error) {
+	if err := utils.ValidateExternalURL(url); err != nil {
+		return "", fmt.Errorf("URL validation failed: %w", err)
+	}
+
 	// Get the data
-	resp, err := http.Get(url)
+	resp, err := videoDownloadClient.Get(url)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- validate remote video start/end image URLs before downloading them
- use a bounded HTTP client for video image downloads

## Why
The image generation path already validates external URLs before fetching them. The video endpoint accepted http(s) start/end image URLs but downloaded them directly, which left the endpoint with a less strict URL-fetching policy. Reusing ValidateExternalURL blocks private, loopback, link-local, and metadata host targets before fetching.

## Testing
- gofmt -w core/http/endpoints/localai/video.go
- git diff --check

Note: go test ./core/http/endpoints/localai currently fails in this checkout because github.com/mudler/LocalAI/pkg/grpc/proto is not present/generated.