### PR TITLE
Add n_cpu_moe and cpu_moe options to llama-cpp backend

### DIFF
--- a/backend/cpp/llama-cpp/grpc-server.cpp
+++ b/backend/cpp/llama-cpp/grpc-server.cpp
@@ -984,6 +984,30 @@ static void params_parse(server_context& /*ctx_server*/, const backend::ModelOpt
                 } catch (...) {}
             }
 
+        // --- main model MoE on CPU (upstream --cpu-moe / --n-cpu-moe) ---
+        } else if (!strcmp(optname, "cpu_moe")) {
+            // Bool-style flag: keep all MoE weights on CPU
+            const bool enable = (optval == NULL) ||
+                optval_str == "true" || optval_str == "1" || optval_str == "yes" ||
+                optval_str == "on" || optval_str == "enabled";
+            if (enable) {
+                params.tensor_buft_overrides.push_back(llm_ffn_exps_cpu_override());
+            }
+        } else if (!strcmp(optname, "n_cpu_moe")) {
+            if (optval != NULL) {
+                try {
+                    int n = std::stoi(optval_str);
+                    if (n < 0) n = 0;
+                    // Keep override-name storage alive for the lifetime of the params struct
+                    static std::list<std::string> buft_overrides_main;
+                    for (int i = 0; i < n; ++i) {
+                        buft_overrides_main.push_back(llm_ffn_exps_block_regex(i));
+                        params.tensor_buft_overrides.push_back(
+                            {buft_overrides_main.back().c_str(), ggml_backend_cpu_buffer_type()});
+                    }
+                } catch (...) {}
+            }
+
         // --- draft model MoE on CPU (upstream --spec-draft-cpu-moe / --spec-draft-n-cpu-moe) ---
         } else if (!strcmp(optname, "draft_cpu_moe") || !strcmp(optname, "spec_draft_cpu_moe")) {
             // Bool-style flag: optval may be missing, "true"/"1"/"yes" enables.


### PR DESCRIPTION
This PR adds support for `n_cpu_moe` and `cpu_moe` options in the llama-cpp backend options parsing table.

These options allow users to control MoE (Mixture of Experts) layer placement via YAML model configs:

- `n_cpu_moe: N` - Keep the first N MoE layers on CPU
- `cpu_moe: true` - Keep all MoE layers on CPU

This enables better VRAM management for MoE models like DeepSeek and Qwen3.6-35B-A3B.

Assisted-by: Hermes:Qwen_V3.6_27B_c256_g0_mtp [file] [terminal]