### PR TITLE
fix(nix): correct flake src path and add dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,9 @@
         pname = "localai";
         version = "custom";
         
- 	src = ./sources;
+ 	src = ./.;
         proxyVendor = true;
-        vendorHash = "sha256-MdadwbUc2pwfpC9ScsiIfjGIcAOgcwSm6rt/KNlTIuA=";
+        vendorHash = "sha256-6f3adjGsoFXlUtXjBDHP4Mv9jKCOK3aeUXprm0EAVO8=";
 
         nativeBuildInputs = with pkgs; [ 
           pkg-config cmake gcc protobuf go-protobuf protoc-gen-go protoc-gen-go-grpc
@@ -55,6 +55,42 @@
 
         postInstall = ''
           [ -f $out/bin/local-ai ] && mv $out/bin/local-ai $out/bin/localai
+        '';
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
+        packages = with pkgs; [
+          # Build toolchain (stdenv already provides gcc)
+          go
+          gnumake
+          pkg-config
+          cmake
+          protobuf
+          go-protobuf
+          protoc-gen-go
+          protoc-gen-go-grpc
+
+          # React UI build (core/http/react-ui — `make react-ui`)
+          nodejs
+          bun  # alternative to npm, used by `make react-ui-docker`
+
+          # Linting / static analysis (see `make lint`)
+          golangci-lint
+          gofumpt
+          gotools  # goimports
+          go-tools # staticcheck
+
+          # Common dev conveniences
+          git
+          curl
+        ];
+
+        shellHook = ''
+          echo "LocalAI dev shell: $(go version), node $(node --version)"
+          echo "Build:       make build       (Go binary + React UI)"
+          echo "React UI:    make react-ui    (npm install && vite build)"
+          echo "Lint:        make lint        (only new issues vs master)"
+          echo "           or make lint-all   (full baseline)"
         '';
       };
     };


### PR DESCRIPTION
The flake set `src = ./sources;` referencing a non-existent subdirectory,
so `nix build` and `nix develop` both failed evaluation. Point `src` at
the repo root and refresh `vendorHash` accordingly.

Add `devShells.default` with the Go toolchain, protobuf generators,
Node.js/bun for the React UI (`make react-ui`), and the linters used by
`make lint` (golangci-lint, gofumpt, goimports, staticcheck).

Assisted-by: Claude:claude-opus-4-7
Signed-off-by: Richard Palethorpe <io@richiejp.com>

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->
