### PR TITLE
fix: inject text-file content into chat completions messages

### DIFF
--- a/core/http/react-ui/src/hooks/useChat.js
+++ b/core/http/react-ui/src/hooks/useChat.js
@@ -218,9 +218,15 @@ export function useChat(initialModel = '') {
           })
           userFiles.push({ name: file.name, type: 'audio' })
         } else {
-          // Text/PDF files - append to content
-          userFiles.push({ name: file.name, type: 'file', content: file.textContent || '' })
-        }
+			// Text/PDF files - append to content
+			if (file.textContent) {
+				messageContent.push({
+					type: 'text',
+					text: `\n\n--- File: ${file.name} ---\n${file.textContent}\n--- End of ${file.name} ---`,
+				})
+			}
+			userFiles.push({ name: file.name, type: 'file', content: file.textContent || '' })
+		}
       }
     } else {
       messageContent = content

--- a/core/http/react-ui/src/pages/Home.jsx
+++ b/core/http/react-ui/src/pages/Home.jsx
@@ -161,7 +161,11 @@ export default function Home() {
     const newFiles = []
     for (const file of fileList) {
       const base64 = await fileToBase64(file)
-      newFiles.push({ name: file.name, type: file.type, base64 })
+      const entry = { name: file.name, type: file.type, base64 }
+      if (!file.type.startsWith('image/') && !file.type.startsWith('audio/')) {
+        entry.textContent = await file.text().catch(() => '')
+      }
+      newFiles.push(entry)
     }
     setter(prev => [...prev, ...newFiles])
   }, [])


### PR DESCRIPTION
 ## Problem

 When attaching a .txt, .md, .csv, or .json file in the chat UI, I noticed that the model never saw the file content. Images and audio worked correctly.

 ## Root cause

In `useChat.js`, the file-type loop correctly adds images as `image_url` content blocks and audio as `audio_url` content blocks, but the `else` branch (all other file types) only pushes metadata into `userFiles`  it never adds the text content to `messageContent`. The `files` field on history messages is also not processed by the backend, so the content is lost on every turn.

Separately, `Home.jsx`'s `addFiles` never calls `file.text()`, so `textContent` is always undefined for files attached from the home screen.

## Fix

 - `useChat.js`: add a text content block to `messageContent` when `file.textContent` is present
 - `Home.jsx`: read `textContent` for non-image/non-audio files, matching the existing pattern in `Chat.jsx`'s `handleFileChange`
 
 ### Before
 <img width="1162" height="301" alt="image" src="https://github.com/user-attachments/assets/8fa3e8dc-f5fa-4516-96ab-8bcb49a1adee" />

### After
<img width="1622" height="520" alt="image" src="https://github.com/user-attachments/assets/412db469-804c-4c46-8c14-245c62f5bc12" />


## Limitations

PDF files use the browser's `file.text()` which returns raw bytes, not parsed text. So proper PDF support would require something like PDF.js integration or server-side extraction. This is a known limitation and not addressed here.

## Testing

Attach a .txt or .md file in the chat, send a message asking the model to summarise it and the model should now see the content.