### PR TITLE
fix(embeddings): support dimensions parameter

### DIFF
--- a/core/http/endpoints/openai/embeddings.go
+++ b/core/http/endpoints/openai/embeddings.go
@@ -4,7 +4,9 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"math"
+	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -40,6 +42,19 @@ func embeddingItem(embeddings []float32, index int, encodingFormat string) schem
 	return schema.Item{Embedding: embeddings, Index: index, Object: "embedding"}
 }
 
+func applyEmbeddingDimensions(embeddings []float32, dimensions int) ([]float32, error) {
+	if dimensions < 0 {
+		return nil, fmt.Errorf("embedding dimensions must be non-negative, got %d", dimensions)
+	}
+	if dimensions == 0 || len(embeddings) == dimensions {
+		return embeddings, nil
+	}
+	if len(embeddings) < dimensions {
+		return nil, fmt.Errorf("embedding dimensions requested %d but backend returned %d", dimensions, len(embeddings))
+	}
+	return append([]float32(nil), embeddings[:dimensions]...), nil
+}
+
 // EmbeddingsEndpoint is the OpenAI Embeddings API endpoint https://platform.openai.com/docs/api-reference/embeddings
 // @Summary Get a vector representation of a given input that can be easily consumed by machine learning models and algorithms.
 // @Tags embeddings
@@ -72,6 +87,10 @@ func EmbeddingsEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, app
 			if err != nil {
 				return err
 			}
+			embeddings, err = applyEmbeddingDimensions(embeddings, input.Dimensions)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
+			}
 			items = append(items, embeddingItem(embeddings, i, input.EncodingFormat))
 		}
 
@@ -85,6 +104,10 @@ func EmbeddingsEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, app
 			embeddings, err := embedFn()
 			if err != nil {
 				return err
+			}
+			embeddings, err = applyEmbeddingDimensions(embeddings, input.Dimensions)
+			if err != nil {
+				return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 			}
 			items = append(items, embeddingItem(embeddings, i, input.EncodingFormat))
 		}

--- a/core/http/endpoints/openai/embeddings_test.go
+++ b/core/http/endpoints/openai/embeddings_test.go
@@ -1,0 +1,58 @@
+package openai
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"math"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("applyEmbeddingDimensions", func() {
+	It("truncates embeddings locally when dimensions are configured", func() {
+		embedding := []float32{1, 2, 3, 4}
+
+		truncated, err := applyEmbeddingDimensions(embedding, 2)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(truncated).To(Equal([]float32{1, 2}))
+		Expect(embedding).To(Equal([]float32{1, 2, 3, 4}))
+	})
+
+	It("keeps embeddings unchanged when dimensions are not configured", func() {
+		embedding := []float32{1, 2, 3}
+
+		result, err := applyEmbeddingDimensions(embedding, 0)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result).To(Equal(embedding))
+	})
+
+	It("fails clearly when the backend embedding is shorter than requested", func() {
+		_, err := applyEmbeddingDimensions([]float32{1, 2}, 4)
+
+		Expect(err).To(MatchError("embedding dimensions requested 4 but backend returned 2"))
+	})
+
+	It("rejects negative dimensions", func() {
+		_, err := applyEmbeddingDimensions([]float32{1, 2}, -1)
+
+		Expect(err).To(MatchError("embedding dimensions must be non-negative, got -1"))
+	})
+})
+
+var _ = Describe("embeddingItem", func() {
+	It("base64-encodes the locally truncated embedding", func() {
+		embedding, err := applyEmbeddingDimensions([]float32{1, 2, 3}, 2)
+		Expect(err).ToNot(HaveOccurred())
+
+		item := embeddingItem(embedding, 0, "base64")
+		raw, err := base64.StdEncoding.DecodeString(item.EmbeddingBase64)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(raw).To(HaveLen(8))
+		Expect(math.Float32frombits(binary.LittleEndian.Uint32(raw[0:4]))).To(Equal(float32(1)))
+		Expect(math.Float32frombits(binary.LittleEndian.Uint32(raw[4:8]))).To(Equal(float32(2)))
+	})
+})

--- a/core/schema/openai.go
+++ b/core/schema/openai.go
@@ -215,6 +215,11 @@ type OpenAIRequest struct {
 	// StreamOptions opts into OpenAI streaming extensions, e.g. include_usage.
 	StreamOptions *StreamOptions `json:"stream_options,omitempty" yaml:"stream_options,omitempty"`
 
+	// Embeddings API: requested output dimensionality. The HTTP layer applies
+	// this locally after backend inference so non-Matryoshka providers do not
+	// receive an unsupported upstream field.
+	Dimensions int `json:"dimensions,omitempty" yaml:"dimensions,omitempty"`
+
 	// Image (not supported by OpenAI)
 	Quality string `json:"quality"`
 	Step    int    `json:"step"`

--- a/core/schema/openai_test.go
+++ b/core/schema/openai_test.go
@@ -1,0 +1,23 @@
+package schema_test
+
+import (
+	"encoding/json"
+
+	. "github.com/mudler/LocalAI/core/schema"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OpenAIRequest JSON unmarshaling", func() {
+	It("accepts the embeddings dimensions parameter", func() {
+		body := []byte(`{"model":"m","input":"hello","dimensions":128}`)
+
+		var req OpenAIRequest
+		Expect(json.Unmarshal(body, &req)).To(Succeed())
+
+		Expect(req.Model).To(Equal("m"))
+		Expect(req.Input).To(Equal("hello"))
+		Expect(req.Dimensions).To(Equal(128))
+	})
+})

--- a/docs/content/features/embeddings.md
+++ b/docs/content/features/embeddings.md
@@ -39,6 +39,10 @@ curl http://localhost:8080/embeddings -X POST -H "Content-Type: application/json
 }'
 ```
 
+When `dimensions` is set, LocalAI truncates the returned embedding locally
+instead of forwarding the parameter to the backend. If the vector is too short,
+the request fails clearly.
+
 ## Manual Setup
 
 Create a `YAML` config file in the `models` directory. Specify the `backend` and the model file.


### PR DESCRIPTION
**Description**

This PR fixes the embeddings `dimensions` parameter being documented but not applied by LocalAI.

LocalAI now parses `dimensions` on OpenAI-compatible embeddings requests and truncates the returned embedding locally after backend inference. The parameter is not forwarded to the backend/provider, which keeps the request compatible with providers that reject unsupported `dimensions` fields.

This PR fixes #

**Notes for Reviewers**

Changed behavior:
- `/v1/embeddings` and `/embeddings` now honor `dimensions`.
- `dimensions: 0` keeps the previous full-vector behavior.
- If the backend returns fewer values than requested, LocalAI returns a clear bad-request error.
- Backend config, gRPC proto, provider selection, secrets, and permissions are unchanged.

Tests added:
- Request unmarshaling accepts `dimensions`.
- Embeddings are truncated locally.
- Short returned vectors fail clearly.
- Base64 embedding responses use the truncated vector.

Verification:
- `go test ./core/schema -run TestSchema --ginkgo.focus "OpenAIRequest JSON unmarshaling"`
- `go test ./core/http/endpoints/openai -run TestOpenAI --ginkgo.focus "applyEmbeddingDimensions|embeddingItem"`

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.