### PR TITLE
[utils] Fail immediately on extraction errors

### DIFF
--- a/pkg/utils/untar.go
+++ b/pkg/utils/untar.go
@@ -36,7 +36,7 @@ func ExtractArchive(archive, dst string) error {
 		OverwriteExisting:      true,
 		MkdirAll:               true,
 		ImplicitTopLevelFolder: false,
-		ContinueOnError:        true,
+		ContinueOnError:        false,
 	}
 
 	switch v := uaIface.(type) {


### PR DESCRIPTION
Ensuring archive extraction integrity is critical for maintaining a stable runtime environment. This change modifies `ExtractArchive` to disable the `ContinueOnError` flag. By failing immediately upon any extraction error, we prevent models or backends from being left in a partially extracted and inconsistent state, which could otherwise lead to undefined behavior or silent failures during model loading.

**Notes for Reviewers**
The modification is focused strictly on the `mytar` configuration within `pkg/utils/untar.go`. Existing archive tests were verified to ensure no regressions in path validation or standard extraction logic.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.