### PR TITLE
fix(streaming): prevent glm-4.5 XML auto-detect from emitting Hermes tool_call JSON blob as function name (#9722)

### DIFF
--- a/pkg/functions/parse.go
+++ b/pkg/functions/parse.go
@@ -618,6 +618,24 @@ func buildContent(before string, parser *ChatMsgParser) string {
 // This provides better streaming and partial parsing support.
 // When format is nil or when format is set, tries "find scope/tool start, split, parse suffix"
 // first (llama.cpp PEG order) so that content before the tool block does not cause parse failure.
+// filterMalformedXMLToolCalls discards any FuncCallResults whose Name begins with
+// '{'. This guards against the glm-4.5 format auto-detecting Hermes-style
+// <tool_call>{"name":"...","arguments":{...}}</tool_call> output: the iterative
+// parser treats the entire JSON object as the function name because it can't find
+// the expected <arg_key> element inside the scope.  Such results would cause the
+// streaming callback to emit a delta with the raw JSON blob as the tool name.
+// The JSON fallback path (ParseJSONIterative) handles Hermes format correctly, so
+// we drop these false positives and let auto-detection continue.
+func filterMalformedXMLToolCalls(calls []FuncCallResults) []FuncCallResults {
+	var out []FuncCallResults
+	for _, c := range calls {
+		if !strings.HasPrefix(strings.TrimSpace(c.Name), "{") {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
 func ParseXMLIterative(s string, format *XMLToolCallFormat, isPartial bool) ([]FuncCallResults, error) {
 	// Try split-on-scope first so reasoning/content before tool block is skipped
 	if format != nil {
@@ -629,7 +647,14 @@ func ParseXMLIterative(s string, format *XMLToolCallFormat, isPartial bool) ([]F
 		for _, fmtPreset := range formats {
 			if fmtPreset.format != nil {
 				if pr, ok := tryParseXMLFromScopeStart(s, fmtPreset.format, isPartial); ok {
-					return pr.ToolCalls, nil
+					// Discard results where the function name is a JSON object —
+					// those are false positives from formats like glm-4.5 that
+					// mis-parse Hermes-style <tool_call>JSON</tool_call> blocks.
+					valid := filterMalformedXMLToolCalls(pr.ToolCalls)
+					if len(valid) > 0 {
+						return valid, nil
+					}
+					// All results were malformed; try the next format.
 				}
 			}
 		}
@@ -649,14 +674,23 @@ func ParseXMLIterative(s string, format *XMLToolCallFormat, isPartial bool) ([]F
 				if err != nil {
 					// Check if it's a partial exception (recoverable)
 					if _, ok := err.(*ChatMsgPartialException); ok {
-						// Partial parse, return what we have
-						return parser.ToolCalls(), nil
+						// Partial parse, return what we have (filtered).
+						// If all results are malformed (e.g., glm-4.5 false positive),
+						// fall through to try the next format rather than returning garbage.
+						valid := filterMalformedXMLToolCalls(parser.ToolCalls())
+						if len(valid) > 0 {
+							return valid, nil
+						}
 					}
 					// Try next format
 					continue
 				}
 				if success && len(parser.ToolCalls()) > 0 {
-					return parser.ToolCalls(), nil
+					valid := filterMalformedXMLToolCalls(parser.ToolCalls())
+					if len(valid) > 0 {
+						return valid, nil
+					}
+					// All malformed; try next format
 				}
 			}
 		}

--- a/pkg/functions/parse_test.go
+++ b/pkg/functions/parse_test.go
@@ -253,6 +253,58 @@ Some text after the JSON
 			Expect(results[1].Name).To(Equal("subtract"))
 			Expect(results[1].Arguments).To(Equal(`{"x":10,"y":7}`))
 		})
+
+		// Regression test for https://github.com/mudler/LocalAI/issues/9722
+		// Hermes/NousResearch models wrap a single JSON tool call in <tool_call> tags
+		// without JSONRegexMatch. Multiple parsers (extractJSON + PEG) must not produce
+		// duplicate FuncCallResults that then appear at different streaming indices.
+		It("should return exactly one result for a bare Hermes-style tool_call without JSONRegexMatch", func() {
+			input := "<tool_call>\n{\"name\": \"bash\", \"arguments\": {\"script\": \"ls /tmp | wc -l\"}}\n</tool_call>"
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(1), "multiple parsers must not produce duplicate entries for the same call")
+			Expect(results[0].Name).To(Equal("bash"))
+			Expect(results[0].Arguments).To(Equal(`{"script":"ls /tmp | wc -l"}`))
+		})
+
+		It("should return exactly one result for a bare Hermes-style tool_call with complex arguments", func() {
+			input := "<tool_call>\n{\"name\": \"search\", \"arguments\": {\"query\": \"golang channels\", \"max_results\": 5}}\n</tool_call>"
+
+			results := ParseFunctionCall(input, functionConfig)
+			Expect(results).To(HaveLen(1), "multiple parsers must not produce duplicate entries for the same call")
+			Expect(results[0].Name).To(Equal("search"))
+		})
+
+		// Regression test for https://github.com/mudler/LocalAI/issues/9722
+		// The glm-4.5 XML format auto-detects <tool_call>...</tool_call> blocks and,
+		// when no <arg_key> element is present, treats the entire content as the function
+		// name. For Hermes-style output, that content is a JSON object, causing the
+		// streaming callback to emit a delta with '{"name":"bash",...}' as the tool name.
+		// ParseXMLIterative must discard such results so the JSON fallback path fires.
+		It("should not auto-detect Hermes tool_call as glm-4.5 format with JSON function name", func() {
+			input := "<tool_call>\n{\"name\": \"bash\", \"arguments\": {\"script\": \"ls\"}}\n</tool_call>"
+
+			// ParseXMLIterative with nil format (auto-detect) must not return a result
+			// where the function name is the raw JSON blob.
+			results, err := ParseXMLIterative(input, nil, false)
+			Expect(err).ToNot(HaveOccurred())
+			for _, r := range results {
+				Expect(r.Name).NotTo(HavePrefix("{"),
+					"auto-detected XML result must not have a JSON blob as function name, got: %s", r.Name)
+			}
+		})
+
+		It("should not auto-detect partial Hermes tool_call as glm-4.5 format during streaming", func() {
+			// Partial output — </tool_call> not yet received.
+			partial := "<tool_call>\n{\"name\": \"bash\", \"arguments\": {\"script\": \"ls\"}}"
+
+			results, err := ParseXMLIterative(partial, nil, true)
+			Expect(err).ToNot(HaveOccurred())
+			for _, r := range results {
+				Expect(r.Name).NotTo(HavePrefix("{"),
+					"streaming partial XML result must not have a JSON blob as function name")
+			}
+		})
 	})
 	Context("ParseTextContent", func() {
 		It("Can extract notes from the LLM result", func() {


### PR DESCRIPTION
## Summary

Closes #9722.

When `/v1/chat/completions` streams a response from a Hermes/NousResearch-format model (output looks like `<tool_call>\n{"name":"bash","arguments":{...}}\n</tool_call>`), the Go-side XML auto-detector incorrectly picks up the **glm-4.5** format and treats the entire JSON blob as the function name.

**Root cause**: `ParseXMLIterative` with `format=nil` tries every XML preset in order. glm-4.5 uses `<tool_call>` as `ToolStart` (not a ScopeStart). When it finds `<tool_call>` but no `<arg_key>` inside, it falls into the *empty-tool-call path* that extracts everything between `<tool_call>` and `</tool_call>` as the function name. For Hermes output that content is a full JSON object, so `Name` ends up as `'{"name":"bash","arguments":{...}}'`. Because the XML branch returned a non-empty result, the JSON fallback (`ParseJSONIterative`) — which correctly handles Hermes — was suppressed, and the client received a malformed streaming chunk.

## Fix

Added `filterMalformedXMLToolCalls()` that discards any auto-detected `FuncCallResult` whose `Name` starts with `{`. Applied in all three auto-detect branches of `ParseXMLIterative`:

1. `tryParseXMLFromScopeStart` loop (fast path)
2. `TryConsumeXMLToolCalls` loop (fallback path)
3. Partial-exception recovery in the same loop

When all results from a format are filtered, the loop continues to the next format. Hermes output falls through all XML formats and is picked up correctly by `ParseJSONIterative`.

The user-specified format path (`xmlFormat != nil`) is intentionally left unfiltered.

## Test plan

- [x] Added `ParseXMLIterative` regression tests: auto-detect must not return a JSON-blob function name for Hermes-style `<tool_call>JSON</tool_call>` input (both full and partial streaming).
- [x] Existing `ParseFunctionCall` Hermes tests still pass (`HaveLen(1)`, correct name/args).
- [x] Full `pkg/functions` test suite: 175/176 specs pass (1 pre-existing pending spec).
- [x] `go build ./core/http/... ./pkg/functions/...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)