### PR TITLE
fix(gallery/ltx-2.3): add diffusion_model flag to all variants

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -30844,6 +30844,7 @@
     parameters:
       model: ltx-2.3-22b-dev-UD-Q4_K_M.gguf
     options:
+      - diffusion_model
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-dev_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-dev_audio_vae.safetensors
@@ -30875,6 +30876,7 @@
     parameters:
       model: ltx-2.3-22b-dev-Q4_K_M.gguf
     options:
+      - diffusion_model
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-dev_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-dev_audio_vae.safetensors
@@ -30906,6 +30908,7 @@
     parameters:
       model: ltx-2.3-22b-dev-Q8_0.gguf
     options:
+      - diffusion_model
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-dev_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-dev_audio_vae.safetensors
@@ -30965,6 +30968,7 @@
     parameters:
       model: ltx-2.3-22b-distilled-UD-Q4_K_M.gguf
     options:
+      - diffusion_model
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-distilled_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-distilled_audio_vae.safetensors
@@ -30995,6 +30999,7 @@
     parameters:
       model: ltx-2.3-22b-distilled-Q4_K_M.gguf
     options:
+      - diffusion_model
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-distilled_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-distilled_audio_vae.safetensors
@@ -31025,6 +31030,7 @@
     parameters:
       model: ltx-2.3-22b-distilled-Q8_0.gguf
     options:
+      - diffusion_model
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-distilled_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-distilled_audio_vae.safetensors


### PR DESCRIPTION
LTX-2.3 entries (dev / distilled, UD-Q4_K_M / Q4_K_M / Q8_0) were missing the `diffusion_model` option in their overrides. Without it, gosd.cpp routes the main GGUF through the regular `model_path` code path in sd.cpp, which doesn't apply the `model.diffusion_model.` tensor prefix. sd.cpp's LTX-2.3 architecture detection (`VERSION_LTXAV`) in get_sd_version checks for prefixed tensor names — without the prefix, detection fails and load_model returns "could not load model".

This is the same bug we hit for Wan when the option was missing. Adding `- diffusion_model` to all six LTX-2.3 entries' option blocks makes load_model take the diffusion_model_path branch so detection succeeds.

Assisted-by: Claude:claude-opus-4-7

**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->