### PR TITLE
fix(gallery/ltx-2.3): add vae_decode_only:false for i2v / flf2v

### DIFF
--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -30845,6 +30845,7 @@
       model: ltx-2.3-22b-dev-UD-Q4_K_M.gguf
     options:
       - diffusion_model
+      - "vae_decode_only:false"
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-dev_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-dev_audio_vae.safetensors
@@ -30877,6 +30878,7 @@
       model: ltx-2.3-22b-dev-Q4_K_M.gguf
     options:
       - diffusion_model
+      - "vae_decode_only:false"
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-dev_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-dev_audio_vae.safetensors
@@ -30909,6 +30911,7 @@
       model: ltx-2.3-22b-dev-Q8_0.gguf
     options:
       - diffusion_model
+      - "vae_decode_only:false"
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-dev_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-dev_audio_vae.safetensors
@@ -30969,6 +30972,7 @@
       model: ltx-2.3-22b-distilled-UD-Q4_K_M.gguf
     options:
       - diffusion_model
+      - "vae_decode_only:false"
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-distilled_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-distilled_audio_vae.safetensors
@@ -31000,6 +31004,7 @@
       model: ltx-2.3-22b-distilled-Q4_K_M.gguf
     options:
       - diffusion_model
+      - "vae_decode_only:false"
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-distilled_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-distilled_audio_vae.safetensors
@@ -31031,6 +31036,7 @@
       model: ltx-2.3-22b-distilled-Q8_0.gguf
     options:
       - diffusion_model
+      - "vae_decode_only:false"
       - llm_path:gemma-3-12b-it-qat-UD-Q4_K_XL.gguf
       - vae_path:ltx-2.3-22b-distilled_video_vae.safetensors
       - audio_vae_path:ltx-2.3-22b-distilled_audio_vae.safetensors


### PR DESCRIPTION
LTX-2.3 i2v inference fails inside generate_video with:

  [ERROR] LTXAV image conditioning requires VAE encoder weights;
  create the context with vae_decode_only=false

Without vae_decode_only:false in the options block, gosd.cpp creates the sd_ctx with VAE encoder weights freed, so latent encoding of the init_image is impossible. Adding the option mirrors what we already do for Wan i2v entries.

Affects all six LTX-2.3 entries (dev/distilled × UD-Q4_K_M, Q4_K_M, Q8_0). T2V wasn't impacted by the missing option since it has no init image to encode, which is why the T2V smoke earlier passed.

Assisted-by: Claude:claude-opus-4-7

**Description**

This PR fixes #

**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->