### PR TITLE
fix(nemo): extract Hypothesis.text for TDT/RNNT ASR models

### DIFF
--- a/backend/python/nemo/backend.py
+++ b/backend/python/nemo/backend.py
@@ -99,8 +99,17 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             if not results or len(results) == 0:
                 return backend_pb2.TranscriptResult(segments=[], text="")
 
-            # Get the transcript text from the first result
-            text = results[0]
+            # Get the transcript text from the first result.
+            # CTC models return List[str], TDT/RNNT models return List[Hypothesis]
+            # where the actual text lives in Hypothesis.text.
+            result = results[0]
+            if isinstance(result, str):
+                text = result
+            elif hasattr(result, 'text'):
+                text = result.text if result.text else ""
+            else:
+                text = str(result) if result else ""
+
             if text:
                 # Create a single segment with the full transcription
                 result_segments.append(backend_pb2.TranscriptSegment(

--- a/backend/python/nemo/backend.py
+++ b/backend/python/nemo/backend.py
@@ -105,10 +105,8 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             result = results[0]
             if isinstance(result, str):
                 text = result
-            elif hasattr(result, 'text'):
-                text = result.text if result.text else ""
             else:
-                text = str(result) if result else ""
+                text = getattr(result, 'text', None) or ""
 
             if text:
                 # Create a single segment with the full transcription


### PR DESCRIPTION
## Problem

NeMo Parakeet TDT models (e.g. `parakeet-tdt-0.6b-v3`) deployed via the `nemo` backend always produce empty transcription output.

## Root Cause

NeMo's `transcribe()` returns different types depending on the model architecture:

- **CTC models** (e.g. Whisper): `List[str]` — works fine
- **TDT/RNNT models** (e.g. parakeet-tdt-0.6b-v3): `List[Hypothesis]` — the decoded text lives in the `Hypothesis.text` attribute

The backend code at `backend/python/nemo/backend.py` line 105 did:

```python
text = results[0]  # Hypothesis object, not a str!
```

This assigned the entire `Hypothesis` dataclass to the protobuf `string` field. When protobuf tried to serialize it, it either raised a `TypeError` (caught by the except block → returns empty) or silently converted to an empty string. Either way, the transcript was always blank.

## Fix

Check the return type and extract `.text` from `Hypothesis` objects when present:

```python
result = results[0]
if isinstance(result, str):
    text = result
elif hasattr(result, 'text'):
    text = result.text if result.text else 
else:
    text = str(result) if result else 
```

This is backward-compatible — CTC models still return strings and take the first branch.

## Testing

Verified by reading the NeMo source code:
- `nemo/collections/asr/parts/submodules/rnnt_decoding.py` → `rnnt_decoder_predictions_tensor()` always returns `List[Hypothesis]` even when `return_hypotheses=False`
- `nemo/collections/asr/models/rnnt_models.py` → `_transcribe_output_processing()` passes this through unchanged