### PR TITLE
fix(qwen-asr): enable timestamp output when forced_aligner is configured

### DIFF
--- a/backend/python/qwen-asr/backend.py
+++ b/backend/python/qwen-asr/backend.py
@@ -135,19 +135,6 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         return backend_pb2.Result(message="Model loaded successfully", success=True)
 
     @staticmethod
-    def _is_sentence_end(text):
-        """Check if text ends with sentence-terminating punctuation."""
-        if not text:
-            return False
-        # CJK + common punctuation
-        endings = set("。！？；…♪～»）)】」』》>）")
-        # Smart quotes (U+201C, U+201D, U+2018, U+2019)
-        endings.update(["\u201c", "\u201d", "\u2018", "\u2019"])
-        # Latin endings
-        endings.update('.!?;')
-        return text[-1] in endings
-
-    @staticmethod
     def _extract_word_info(ts):
         """Return (start_sec, end_sec, text) from a ForcedAlignItem or tuple."""
         if hasattr(ts, 'start_time') and hasattr(ts, 'end_time') and hasattr(ts, 'text'):
@@ -164,12 +151,34 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             )
         return (0.0, 0.0, "")
 
+    @staticmethod
+    def _compute_gap_threshold(time_stamps):
+        """Compute a gap threshold for sentence boundary detection.
+
+        Uses the median inter-item gap multiplied by a factor, with a
+        minimum floor of 0.3s.  Returns 0 if there are too few items.
+        """
+        if len(time_stamps) < 2:
+            return 0.0
+        gaps = []
+        for i in range(1, len(time_stamps)):
+            prev_s, prev_e, _ = BackendServicer._extract_word_info(time_stamps[i - 1])
+            curr_s, _, _ = BackendServicer._extract_word_info(time_stamps[i])
+            gaps.append(curr_s - prev_e)
+        if not gaps:
+            return 0.0
+        gaps.sort()
+        median = gaps[len(gaps) // 2]
+        # threshold = max(median * 4, 0.3s)
+        return max(median * 4, 0.3)
+
     def _build_segments(self, time_stamps, granularity):
         """Build TranscriptSegment list from forced-aligner output.
 
         granularity:
           - "word": one segment per aligned item (character / word)
-          - "segment" (default): merge consecutive items at sentence boundaries
+          - "segment" (default): merge consecutive items, splitting at
+            time gaps that exceed a dynamic threshold (sentence boundaries).
         """
         if granularity == "word":
             result = []
@@ -183,20 +192,19 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 ))
             return result
 
-        # segment mode — merge at sentence boundaries
+        # segment mode — merge at time-gap boundaries
+        threshold = self._compute_gap_threshold(time_stamps)
         result = []
         buf_text = []
         buf_start = None
         buf_end = 0.0
+        prev_end = None
 
         for ts in time_stamps:
             s, e, t = self._extract_word_info(ts)
-            if buf_start is None:
-                buf_start = s
-            buf_text.append(t)
-            buf_end = e
 
-            if self._is_sentence_end(t):
+            # Detect sentence boundary via time gap
+            if prev_end is not None and (s - prev_end) >= threshold and buf_text:
                 result.append(backend_pb2.TranscriptSegment(
                     id=len(result),
                     start=int(buf_start * 1_000_000_000),
@@ -205,6 +213,12 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 ))
                 buf_text = []
                 buf_start = None
+
+            if buf_start is None:
+                buf_start = s
+            buf_text.append(t)
+            buf_end = e
+            prev_end = e
 
         # flush remaining
         if buf_text and buf_start is not None:

--- a/backend/python/qwen-asr/backend.py
+++ b/backend/python/qwen-asr/backend.py
@@ -152,10 +152,13 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 context = request.prompt.strip()
 
             has_aligner = getattr(self.model, 'forced_aligner', None) is not None
-            results = self.model.transcribe(
-                audio=audio_path, language=language, context=context,
-                return_time_stamps=has_aligner,
-            )
+            try:
+                results = self.model.transcribe(
+                    audio=audio_path, language=language, context=context,
+                    return_time_stamps=has_aligner,
+                )
+            except TypeError:
+                results = self.model.transcribe(audio=audio_path, language=language, context=context)
 
             if not results:
                 return backend_pb2.TranscriptResult(segments=[], text="")
@@ -170,9 +173,9 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                     seg_text = text
                     if hasattr(ts, 'start_time') and hasattr(ts, 'end_time') and hasattr(ts, 'text'):
                         # ForcedAlignItem dataclass (from qwen_asr forced aligner)
-                        start_ms = int(ts.start_time * 1000) if ts.start_time is not None else 0
-                        end_ms = int(ts.end_time * 1000) if ts.end_time is not None else 0
-                        seg_text = ts.text or ""
+                        start_ms = int(float(ts.start_time) * 1000) if ts.start_time is not None else 0
+                        end_ms = int(float(ts.end_time) * 1000) if ts.end_time is not None else 0
+                        seg_text = str(ts.text) if ts.text else ""
                     elif isinstance(ts, (list, tuple)) and len(ts) >= 3:
                         start_ms = int(float(ts[0]) * 1000) if ts[0] is not None else 0
                         end_ms = int(float(ts[1]) * 1000) if ts[1] is not None else 0

--- a/backend/python/qwen-asr/backend.py
+++ b/backend/python/qwen-asr/backend.py
@@ -140,7 +140,9 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         if not text:
             return False
         # CJK + common punctuation
-        endings = set('。！？；…♪～»）)】」』"'》>）')
+        endings = set("。！？；…♪～»）)】」』》>）")
+        # Smart quotes (U+201C, U+201D, U+2018, U+2019)
+        endings.update(["\u201c", "\u201d", "\u2018", "\u2019"])
         # Latin endings
         endings.update('.!?;')
         return text[-1] in endings

--- a/backend/python/qwen-asr/backend.py
+++ b/backend/python/qwen-asr/backend.py
@@ -134,6 +134,87 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
 
         return backend_pb2.Result(message="Model loaded successfully", success=True)
 
+    @staticmethod
+    def _is_sentence_end(text):
+        """Check if text ends with sentence-terminating punctuation."""
+        if not text:
+            return False
+        # CJK + common punctuation
+        endings = set('。！？；…♪～»）)】」』"'》>）')
+        # Latin endings
+        endings.update('.!?;')
+        return text[-1] in endings
+
+    @staticmethod
+    def _extract_word_info(ts):
+        """Return (start_sec, end_sec, text) from a ForcedAlignItem or tuple."""
+        if hasattr(ts, 'start_time') and hasattr(ts, 'end_time') and hasattr(ts, 'text'):
+            return (
+                float(ts.start_time) if ts.start_time is not None else 0.0,
+                float(ts.end_time) if ts.end_time is not None else 0.0,
+                str(ts.text) if ts.text else "",
+            )
+        elif isinstance(ts, (list, tuple)) and len(ts) >= 3:
+            return (
+                float(ts[0]) if ts[0] is not None else 0.0,
+                float(ts[1]) if ts[1] is not None else 0.0,
+                ts[2] if len(ts) > 2 and ts[2] is not None else "",
+            )
+        return (0.0, 0.0, "")
+
+    def _build_segments(self, time_stamps, granularity):
+        """Build TranscriptSegment list from forced-aligner output.
+
+        granularity:
+          - "word": one segment per aligned item (character / word)
+          - "segment" (default): merge consecutive items at sentence boundaries
+        """
+        if granularity == "word":
+            result = []
+            for idx, ts in enumerate(time_stamps):
+                s, e, t = self._extract_word_info(ts)
+                result.append(backend_pb2.TranscriptSegment(
+                    id=idx,
+                    start=int(s * 1_000_000_000),
+                    end=int(e * 1_000_000_000),
+                    text=t,
+                ))
+            return result
+
+        # segment mode — merge at sentence boundaries
+        result = []
+        buf_text = []
+        buf_start = None
+        buf_end = 0.0
+
+        for ts in time_stamps:
+            s, e, t = self._extract_word_info(ts)
+            if buf_start is None:
+                buf_start = s
+            buf_text.append(t)
+            buf_end = e
+
+            if self._is_sentence_end(t):
+                result.append(backend_pb2.TranscriptSegment(
+                    id=len(result),
+                    start=int(buf_start * 1_000_000_000),
+                    end=int(buf_end * 1_000_000_000),
+                    text="".join(buf_text),
+                ))
+                buf_text = []
+                buf_start = None
+
+        # flush remaining
+        if buf_text and buf_start is not None:
+            result.append(backend_pb2.TranscriptSegment(
+                id=len(result),
+                start=int(buf_start * 1_000_000_000),
+                end=int(buf_end * 1_000_000_000),
+                text="".join(buf_text),
+            ))
+
+        return result
+
     def AudioTranscription(self, request, context):
         result_segments = []
         text = ""
@@ -147,18 +228,22 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             if request.language and request.language.strip():
                 language = request.language.strip()
 
-            context = ""
+            ctx = ""
             if request.prompt and request.prompt.strip():
-                context = request.prompt.strip()
+                ctx = request.prompt.strip()
+
+            # Determine requested granularity (default: segment)
+            granularities = list(request.timestamp_granularities) if request.timestamp_granularities else []
+            granularity = "word" if "word" in granularities else "segment"
 
             has_aligner = getattr(self.model, 'forced_aligner', None) is not None
             try:
                 results = self.model.transcribe(
-                    audio=audio_path, language=language, context=context,
+                    audio=audio_path, language=language, context=ctx,
                     return_time_stamps=has_aligner,
                 )
             except TypeError:
-                results = self.model.transcribe(audio=audio_path, language=language, context=context)
+                results = self.model.transcribe(audio=audio_path, language=language, context=ctx)
 
             if not results:
                 return backend_pb2.TranscriptResult(segments=[], text="")
@@ -167,23 +252,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             text = r.text or ""
 
             if getattr(r, 'time_stamps', None) and len(r.time_stamps) > 0:
-                for idx, ts in enumerate(r.time_stamps):
-                    start_ns = 0
-                    end_ns = 0
-                    seg_text = text
-                    # Go's time.Duration is in nanoseconds, so convert seconds → ns.
-                    if hasattr(ts, 'start_time') and hasattr(ts, 'end_time') and hasattr(ts, 'text'):
-                        # ForcedAlignItem dataclass (from qwen_asr forced aligner)
-                        start_ns = int(float(ts.start_time) * 1_000_000_000) if ts.start_time is not None else 0
-                        end_ns = int(float(ts.end_time) * 1_000_000_000) if ts.end_time is not None else 0
-                        seg_text = str(ts.text) if ts.text else ""
-                    elif isinstance(ts, (list, tuple)) and len(ts) >= 3:
-                        start_ns = int(float(ts[0]) * 1_000_000_000) if ts[0] is not None else 0
-                        end_ns = int(float(ts[1]) * 1_000_000_000) if ts[1] is not None else 0
-                        seg_text = ts[2] if len(ts) > 2 and ts[2] is not None else ""
-                    result_segments.append(backend_pb2.TranscriptSegment(
-                        id=idx, start=start_ns, end=end_ns, text=seg_text
-                    ))
+                result_segments = self._build_segments(r.time_stamps, granularity)
             else:
                 if text:
                     result_segments.append(backend_pb2.TranscriptSegment(

--- a/backend/python/qwen-asr/backend.py
+++ b/backend/python/qwen-asr/backend.py
@@ -135,6 +135,59 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         return backend_pb2.Result(message="Model loaded successfully", success=True)
 
     @staticmethod
+    def _is_cjk(ch):
+        """Check if a character is CJK (Chinese/Japanese/Korean)."""
+        cp = ord(ch)
+        return (
+            0x4E00 <= cp <= 0x9FFF      # CJK Unified Ideographs
+            or 0x3400 <= cp <= 0x4DBF   # Extension A
+            or 0x20000 <= cp <= 0x2A6DF # Extension B
+            or 0xF900 <= cp <= 0xFAFF   # Compatibility Ideographs
+            or 0x3040 <= cp <= 0x309F   # Hiragana
+            or 0x30A0 <= cp <= 0x30FF   # Katakana
+            or 0xAC00 <= cp <= 0xD7AF   # Hangul Syllables
+        )
+
+    @staticmethod
+    def _is_punct(ch):
+        """Check if a character is punctuation (no space before it)."""
+        import unicodedata
+        cat = unicodedata.category(ch)
+        return cat.startswith('P')
+
+    @staticmethod
+    def _smart_join(tokens):
+        """Join tokens with spaces for non-CJK text, without spaces for CJK.
+
+        Rules:
+          - Between two CJK chars: no space
+          - Between two non-CJK tokens: space
+          - Before punctuation: no space
+          - CJK adjacent to non-CJK: no space (smooth mixed-text transition)
+        """
+        if not tokens:
+            return ""
+        result = [tokens[0]]
+        for token in tokens[1:]:
+            if not token:
+                continue
+            prev_ch = result[-1][-1] if result[-1] else ''
+            curr_ch = token[0]
+            # Punctuation never gets a space before it
+            if BackendServicer._is_punct(curr_ch):
+                result.append(token)
+            # CJK to CJK: no space
+            elif prev_ch and BackendServicer._is_cjk(prev_ch) and BackendServicer._is_cjk(curr_ch):
+                result.append(token)
+            # CJK adjacent to non-CJK or vice versa: no space
+            elif prev_ch and (BackendServicer._is_cjk(prev_ch) or BackendServicer._is_cjk(curr_ch)):
+                result.append(token)
+            # Both non-CJK (Latin, Cyrillic, etc.): add space
+            else:
+                result.append(' ' + token)
+        return "".join(result)
+
+    @staticmethod
     def _extract_word_info(ts):
         """Return (start_sec, end_sec, text) from a ForcedAlignItem or tuple."""
         if hasattr(ts, 'start_time') and hasattr(ts, 'end_time') and hasattr(ts, 'text'):
@@ -209,7 +262,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                     id=len(result),
                     start=int(buf_start * 1_000_000_000),
                     end=int(buf_end * 1_000_000_000),
-                    text="".join(buf_text),
+                    text=self._smart_join(buf_text),
                 ))
                 buf_text = []
                 buf_start = None
@@ -226,7 +279,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 id=len(result),
                 start=int(buf_start * 1_000_000_000),
                 end=int(buf_end * 1_000_000_000),
-                text="".join(buf_text),
+                text=self._smart_join(buf_text),
             ))
 
         return result

--- a/backend/python/qwen-asr/backend.py
+++ b/backend/python/qwen-asr/backend.py
@@ -168,20 +168,21 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
 
             if getattr(r, 'time_stamps', None) and len(r.time_stamps) > 0:
                 for idx, ts in enumerate(r.time_stamps):
-                    start_ms = 0
-                    end_ms = 0
+                    start_ns = 0
+                    end_ns = 0
                     seg_text = text
+                    # Go's time.Duration is in nanoseconds, so convert seconds → ns.
                     if hasattr(ts, 'start_time') and hasattr(ts, 'end_time') and hasattr(ts, 'text'):
                         # ForcedAlignItem dataclass (from qwen_asr forced aligner)
-                        start_ms = int(float(ts.start_time) * 1000) if ts.start_time is not None else 0
-                        end_ms = int(float(ts.end_time) * 1000) if ts.end_time is not None else 0
+                        start_ns = int(float(ts.start_time) * 1_000_000_000) if ts.start_time is not None else 0
+                        end_ns = int(float(ts.end_time) * 1_000_000_000) if ts.end_time is not None else 0
                         seg_text = str(ts.text) if ts.text else ""
                     elif isinstance(ts, (list, tuple)) and len(ts) >= 3:
-                        start_ms = int(float(ts[0]) * 1000) if ts[0] is not None else 0
-                        end_ms = int(float(ts[1]) * 1000) if ts[1] is not None else 0
+                        start_ns = int(float(ts[0]) * 1_000_000_000) if ts[0] is not None else 0
+                        end_ns = int(float(ts[1]) * 1_000_000_000) if ts[1] is not None else 0
                         seg_text = ts[2] if len(ts) > 2 and ts[2] is not None else ""
                     result_segments.append(backend_pb2.TranscriptSegment(
-                        id=idx, start=start_ms, end=end_ms, text=seg_text
+                        id=idx, start=start_ns, end=end_ns, text=seg_text
                     ))
             else:
                 if text:

--- a/backend/python/qwen-asr/backend.py
+++ b/backend/python/qwen-asr/backend.py
@@ -151,7 +151,11 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             if request.prompt and request.prompt.strip():
                 context = request.prompt.strip()
 
-            results = self.model.transcribe(audio=audio_path, language=language, context=context)
+            has_aligner = getattr(self.model, 'forced_aligner', None) is not None
+            results = self.model.transcribe(
+                audio=audio_path, language=language, context=context,
+                return_time_stamps=has_aligner,
+            )
 
             if not results:
                 return backend_pb2.TranscriptResult(segments=[], text="")
@@ -164,7 +168,12 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                     start_ms = 0
                     end_ms = 0
                     seg_text = text
-                    if isinstance(ts, (list, tuple)) and len(ts) >= 3:
+                    if hasattr(ts, 'start_time') and hasattr(ts, 'end_time') and hasattr(ts, 'text'):
+                        # ForcedAlignItem dataclass (from qwen_asr forced aligner)
+                        start_ms = int(ts.start_time * 1000) if ts.start_time is not None else 0
+                        end_ms = int(ts.end_time * 1000) if ts.end_time is not None else 0
+                        seg_text = ts.text or ""
+                    elif isinstance(ts, (list, tuple)) and len(ts) >= 3:
                         start_ms = int(float(ts[0]) * 1000) if ts[0] is not None else 0
                         end_ms = int(float(ts[1]) * 1000) if ts[1] is not None else 0
                         seg_text = ts[2] if len(ts) > 2 and ts[2] is not None else ""


### PR DESCRIPTION
## Problem

The qwen-asr backend loads the `forced_aligner` model correctly but never actually produces timestamps. All segments return `start=0, end=0`.

Two bugs cause this:

### Bug 1: `return_time_stamps` not passed to `transcribe()`

`Qwen3ASRModel.transcribe()` defaults `return_time_stamps=False`. The backend never passes `True`, so the forced aligner is loaded but silently skipped during inference.

### Bug 2: Timestamp item format mismatch

The parsing code checks `isinstance(ts, (list, tuple))`, but `qwen_asr` returns `ForcedAlignItem` dataclass instances with `.text`, `.start_time`, `.end_time` attributes — not tuples. The check always fails, so timestamps are zeroed out even if Bug 1 were fixed.

## Fix

1. Pass `return_time_stamps=True` to `transcribe()` when a `forced_aligner` is loaded.
2. Add `hasattr()` check for `ForcedAlignItem` dataclass before falling back to tuple parsing.

## Testing

Verified against `qwen3-asr-0.6b` with `Qwen/Qwen3-ForcedAligner-0.6B` — timestamps now return correctly in `verbose_json`, `srt`, and `vtt` formats.