### PR TITLE
fix(openai): stop streaming tool-call double-emission when autoparser is active

### DIFF
--- a/core/http/endpoints/openai/chat_stream_workers.go
+++ b/core/http/endpoints/openai/chat_stream_workers.go
@@ -341,6 +341,19 @@ func processStreamWithTools(
 			}
 		}
 
+		// Issue #9722: when the C++ autoparser is already producing tool
+		// calls (it delivers them via ChatDeltas, which are flushed at
+		// end-of-stream by ToolCallsFromChatDeltas -> buildDeferredToolCallChunks),
+		// skip the Go-side iterative parser below. Running both parsers makes
+		// the same logical tool call surface at multiple `index` values.
+		// The deferred flush is guarded by lastEmittedCount, so the race where
+		// the Go parser already emitted before this flag flipped also stays
+		// single-emission. Backends without an autoparser (e.g. vLLM) keep
+		// hasChatDeltaToolCalls=false and are unaffected.
+		if hasChatDeltaToolCalls {
+			return true
+		}
+
 		// Try incremental XML parsing for streaming support using iterative parser
 		// This allows emitting partial tool calls as they're being generated
 		cleanedResult := functions.CleanupLLMResult(result, cfg.FunctionsConfig)


### PR DESCRIPTION
**Description**

Addresses #9722.

Streaming `/v1/chat/completions` could emit the same logical tool call at multiple `index` values. In `processStreamWithTools` (`core/http/endpoints/openai/chat_stream_workers.go`) the Go-side iterative parser (`ParseXMLIterative` / `ParseJSONIterative`) runs on every token and emits tool-call deltas, while the C++ chat-template autoparser delivers its own tool calls via `ChatDeltas`, which are flushed at end-of-stream by `ToolCallsFromChatDeltas` → `buildDeferredToolCallChunks`. With both paths active the same call is emitted twice at different indices, so OpenAI clients that accumulate tool calls by `index` end up dispatching the tool N times.

This skips the Go-side iterative parser once the autoparser is producing tool calls (`hasChatDeltaToolCalls`). The deferred flush stays guarded by `lastEmittedCount`, so the race where the Go parser emitted before the flag flipped also remains single-emission. Backends without an autoparser (e.g. vLLM) keep `hasChatDeltaToolCalls=false` and are unaffected.

**Notes for Reviewers**

- **Scope:** this targets the default autoparser-on path from #9722 (the llama.cpp chat-template autoparser, which is what the reporter ran). The issue also mentions a `disable_peg_parser: true` variant where the Go iterative parser *alone* produces multiple indices — that path keeps `hasChatDeltaToolCalls=false`, so it is intentionally left untouched here and would need a separate change.
- **Verification:** `go build ./core/http/endpoints/openai/`, `go vet`, `gofmt -l`, and the existing `core/http/endpoints/openai` test suite all pass. I was **not** able to reproduce against a live llama.cpp model in my environment, so a maintainer sanity-check with a tool-calling GGUF (the repro in #9722) would be appreciated. The change is intentionally minimal and mirrors the existing `preferAutoparser` philosophy already used in this file, so non-autoparser backends are unaffected.
- I'm happy to adjust the approach — the issue lists alternatives (tracking autoparser emissions in `lastEmittedCount`, or a `(name, arguments)` dedupe net) if you prefer one of those.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
