### PR TITLE
fix(model): track intentional stops, stop misreading clean shutdowns as crashes

### DIFF
--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -53,6 +53,13 @@ type ModelLoader struct {
 	modelRouter              ModelRouter // distributed mode: route to remote node
 	backendLogs              *BackendLogStore
 	backendLoggingEnabled    atomic.Bool
+	// stoppingProcs marks backend processes that LocalAI is stopping on
+	// purpose (model unload / graceful shutdown), keyed by the
+	// *process.Process pointer. The exit-watcher goroutine in startProcess
+	// consults it to decide whether an exit is an expected stop or a crash —
+	// the exit code can't, since a child killed by our own SIGTERM/SIGKILL
+	// reports -1, indistinguishable from a signal-induced crash.
+	stoppingProcs sync.Map
 }
 
 // NewModelLoader creates a new ModelLoader instance.

--- a/pkg/model/process.go
+++ b/pkg/model/process.go
@@ -75,6 +75,9 @@ func (ml *ModelLoader) deleteProcess(s string) error {
 		return nil
 	}
 
+	// Mark the stop as intentional so the exit-watcher logs it as an
+	// expected stop, not a crash (signal-terminated children report -1).
+	ml.stoppingProcs.Store(process, struct{}{})
 	err := process.Stop()
 	if err != nil {
 		xlog.Error("(deleteProcess) error while deleting process", "error", err, "model", s)
@@ -171,8 +174,16 @@ func (ml *ModelLoader) startProcess(grpcProcess, id string, serverAddress string
 	xlog.Debug("GRPC Service state dir", "dir", grpcControlProcess.StateDir())
 
 	signals.RegisterGracefulTerminationHandler(func() {
-		err := grpcControlProcess.Stop()
-		if err != nil {
+		// StopAllGRPC (the deleteProcess path) is registered earlier and runs
+		// first for store-tracked backends, stopping this process and removing
+		// its pidfile. Calling Stop again then fails with "failed to read PID".
+		// Skip when it's already gone; this handler still covers processes that
+		// StopAllGRPC doesn't track (e.g. worker-supervised backends).
+		if !grpcControlProcess.IsAlive() {
+			return
+		}
+		ml.stoppingProcs.Store(grpcControlProcess, struct{}{})
+		if err := grpcControlProcess.Stop(); err != nil {
 			xlog.Error("error while shutting down grpc process", "error", err)
 		}
 	})
@@ -211,20 +222,27 @@ func (ml *ModelLoader) startProcess(grpcProcess, id string, serverAddress string
 	// whether the child is alive.
 	go func() {
 		<-grpcControlProcess.Done()
+		// LoadAndDelete both reads the intentional-stop marker and frees the
+		// map entry so it doesn't accumulate across the process's lifetime.
+		_, intentional := ml.stoppingProcs.LoadAndDelete(grpcControlProcess)
 		fields := []any{
 			"id", id,
 			"address", serverAddress,
 			"process", filepath.Base(grpcProcess),
 		}
-		code, codeErr := grpcControlProcess.ExitCode()
-		if codeErr == nil {
+		// Report the raw exit code without interpreting it: a child killed by
+		// our own SIGTERM/SIGKILL surfaces as -1 (Go reports -1 for signal
+		// termination, not the shell's 128+signal convention), so the code
+		// alone can't tell an intended stop from a crash. The stoppingProcs
+		// marker is the reliable signal for that, so it picks the log level.
+		if code, codeErr := grpcControlProcess.ExitCode(); codeErr == nil {
 			fields = append(fields, "exitCode", code)
 		}
-		// 143 = 128 + SIGTERM, the signal sent during graceful stop / model unload.
-		// Treat that and a clean 0 as expected; everything else is a likely crash.
-		if codeErr == nil && (code == "0" || code == "143") {
-			xlog.Info("Backend process exited", fields...)
+		if intentional {
+			xlog.Info("Backend process stopped", fields...)
 		} else {
+			// A stop we didn't initiate — a SIGSEGV from a missing shared
+			// library, a Python ImportError, an OOM kill, an unexpected self-exit.
 			xlog.Warn("Backend process exited unexpectedly", fields...)
 		}
 	}()


### PR DESCRIPTION
**Description**

Track when we intentionally kill a backend and use that to decide if its death is unexpected.
Otherwise we get error messages because the backend process returned a non-zero status we didn't
expect and there are no standards for status codes so we'd have to ensure every backend handles signals
in the same way and explicitly uses the exit codes we expect.

**Notes for Reviewers**

Two separate issues made graceful backend shutdown look ungraceful in the
logs, even though the processes were being terminated correctly
(go-processmanager defaults to process-group SIGTERM + 15s grace + SIGKILL):

1. "failed to read PID" — startProcess registers a per-process graceful-
   termination handler that calls Stop(), but StopAllGRPC (registered
   earlier, via app.Shutdown) already stopped and released store-tracked
   backends first. The second Stop() then failed reading the removed
   pidfile. Guard the handler with IsAlive() so it skips already-stopped
   processes; it still covers backends StopAllGRPC doesn't track (worker-
   supervised ones).

2. "Backend process exited unexpectedly" exitCode=-1 — the exit watcher
   treated only exit codes 0/143 as clean. But a child killed by our own
   SIGTERM/SIGKILL is reported by Go as exitCode -1 (signal termination),
   not the shell's 128+signal convention, so every intentional stop logged
   a false crash warning. The exit code can't distinguish an intended stop
   from a signal-induced crash.

Track intent directly instead: a stoppingProcs sync.Map (keyed by the
*process.Process pointer) is marked wherever LocalAI calls Stop() on
purpose, and the exit watcher uses it to pick the log level — Info
"stopped" when intentional, Warn "exited unexpectedly" otherwise (still
catching real crashes). The raw exit code is reported as a field but no
longer interpreted.

Assisted-by: Claude:claude-opus-4-8 [Claude Code]
Signed-off-by: Richard Palethorpe <io@richiejp.com>


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->
