### PR TITLE
fix(deps): bump cogito to fix MCP image-content panic (#10101)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/modelcontextprotocol/go-sdk v1.5.0
-	github.com/mudler/cogito v0.9.5-0.20260315222927-63abdec7189b
+	github.com/mudler/cogito v0.9.5-0.20260531081147-2c13b6ac29cf
 	github.com/mudler/edgevpn v0.32.2
 	github.com/mudler/go-processmanager v0.1.1
 	github.com/mudler/memory v0.0.0-20260406210934-424c1ecf2cf8

--- a/go.sum
+++ b/go.sum
@@ -972,6 +972,8 @@ github.com/mudler/LocalAGI v0.0.0-20260508125235-37810d918a87 h1:az+2umaD/sT1rRv
 github.com/mudler/LocalAGI v0.0.0-20260508125235-37810d918a87/go.mod h1:x77p9W1zKZr+W+UcEwg8/qdp00p4XXOI69wE7WlXZc0=
 github.com/mudler/cogito v0.9.5-0.20260315222927-63abdec7189b h1:A74T2Lauvg61KodYqsjTYDY05kPLcW+efVZjd23dghU=
 github.com/mudler/cogito v0.9.5-0.20260315222927-63abdec7189b/go.mod h1:6sfja3lcu2nWRzEc0wwqGNu/eCG3EWgij+8s7xyUeQ4=
+github.com/mudler/cogito v0.9.5-0.20260531081147-2c13b6ac29cf h1:njoYjFON9qXKcErNvPl1WoxmSzl4zE9Wexyk2YN82FM=
+github.com/mudler/cogito v0.9.5-0.20260531081147-2c13b6ac29cf/go.mod h1:6sfja3lcu2nWRzEc0wwqGNu/eCG3EWgij+8s7xyUeQ4=
 github.com/mudler/edgevpn v0.32.2 h1:umTPyyZgkom/A81Bk4HbP0p1ZSEU5EFPW3Bg+YPxI8A=
 github.com/mudler/edgevpn v0.32.2/go.mod h1:UaMc8MORbcRsAjuO5gVJj9Bn3Nq2AP5U9NTb6epVyv8=
 github.com/mudler/go-piper v0.0.0-20241023091659-2494246fd9fc h1:RxwneJl1VgvikiX28EkpdAyL4yQVnJMrbquKospjHyA=


### PR DESCRIPTION
## Summary

Fixes #10101 — the API container crashes with a Go panic whenever an MCP tool returns non-text content (images, audio, resources):

```
panic: interface conversion: mcp.Content is *mcp.ImageContent, not *mcp.TextContent
github.com/mudler/cogito@v0.9.5.../mcp.go:52
```

The panic happens on an agent goroutine with no `recover`, which takes the whole process down.

**Root cause**: `mcpTool.Execute` in cogito unconditionally asserted every `mcp.Content` item to `*mcp.TextContent`. Any tool returning image/audio/resource content (e.g. the `get_map_image` tool in osmmcp, NASA MCP image tools) triggers the panic.

**Fix**: mudler/cogito#50 replaces the hard assertion with a type switch. Non-text blocks are summarised with descriptive markers (`[image content (image/png), N bytes]` etc.) so the model receives something useful instead of crashing.

This PR bumps `github.com/mudler/cogito` from `v0.9.5-0.20260315222927-63abdec7189b` to `v0.9.5-0.20260531081147-2c13b6ac29cf` (the tip of the `fix/mcp-image-content-panic` branch in cogito, which is the revision from mudler/cogito#50).

## Test plan

- [x] `go build github.com/mudler/cogito` clean on the new pseudo-version
- [x] `go mod tidy` produces a clean go.sum
- [ ] Manual: add an MCP server that returns image content (e.g. osmmcp) to an agent and confirm the agent returns a result instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)