### PR TITLE
fix(config): register parakeet-cpp as a transcript backend (#9718)

### DIFF
--- a/core/config/backend_capabilities.go
+++ b/core/config/backend_capabilities.go
@@ -291,6 +291,12 @@ var BackendCapabilities = map[string]BackendCapability{
 		DefaultUsecases:  []string{UsecaseTranscript},
 		Description:      "NVIDIA NeMo speech recognition",
 	},
+	"parakeet-cpp": {
+		GRPCMethods:      []GRPCMethod{MethodAudioTranscription},
+		PossibleUsecases: []string{UsecaseTranscript},
+		DefaultUsecases:  []string{UsecaseTranscript},
+		Description:      "NVIDIA NeMo Parakeet ASR (parakeet.cpp)",
+	},
 	"qwen-asr": {
 		GRPCMethods:      []GRPCMethod{MethodAudioTranscription},
 		PossibleUsecases: []string{UsecaseTranscript},


### PR DESCRIPTION
## Summary

Fixes #9718 — after installing a parakeet model, the speech-to-speech pipeline UI only offers it in the LLM selector, not the speech-to-text selector.

**Root cause**: `parakeet-cpp` was added in #10084 but never registered in `BackendCapabilities`. `GuessUsecases` (`model_config.go:798`) only allows `"whisper"` for `FLAG_TRANSCRIPT`, so any backend not in the capabilities map is gated out of the transcript usecase by the heuristic fallback. All other STT backends (`faster-whisper`, `whisperx`, `moonshine`, `nemo`, `qwen-asr`, `voxtral`) are registered in the map and bypass that guard.

**Fix**: Add a `"parakeet-cpp"` entry to `BackendCapabilities` with `MethodAudioTranscription` / `UsecaseTranscript`, matching the pattern of every other STT backend in the same block.

## Test plan

- [x] `gofmt -e` on the edited file: clean
- [ ] Install a parakeet GGUF model, open the speech-to-speech pipeline — parakeet should now appear in the STT dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)