### PR TITLE
docs: fix documentation typos

### DIFF
--- a/docs/content/advanced/advanced-usage.md
+++ b/docs/content/advanced/advanced-usage.md
@@ -273,7 +273,7 @@ A list of the environment variable that tweaks parallelism is the following:
 ```
 ### Python backends GRPC max workers
 ### Default number of workers for GRPC Python backends.
-### This actually controls wether a backend can process multiple requests or not.
+### This actually controls whether a backend can process multiple requests or not.
 
 ### Define the number of parallel LLAMA.cpp workers (Defaults to 1)
 

--- a/docs/content/features/image-generation.md
+++ b/docs/content/features/image-generation.md
@@ -199,7 +199,7 @@ Pipelines types available:
 
 ##### Advanced: Additional parameters
 
-Additional arbitrarly parameters can be specified in the option field in key/value separated by `:`:
+Additional arbitrary parameters can be specified in the option field in key/value separated by `:`:
 
 ```yaml
 name: animagine-xl
@@ -207,7 +207,7 @@ options:
 - "cfg_scale:6"
 ```
 
-**Note**: There is no complete parameter list. Any parameter can be passed arbitrarly and is passed to the model directly as argument to the pipeline. Different pipelines/implementations support different parameters.
+**Note**: There is no complete parameter list. Any parameter can be passed arbitrarily and is passed to the model directly as argument to the pipeline. Different pipelines/implementations support different parameters.
 
 The example above, will result in the following python code when generating images:
 

--- a/docs/content/features/text-generation.md
+++ b/docs/content/features/text-generation.md
@@ -897,7 +897,7 @@ The backend will automatically download the required files in order to run the m
 - `OVModelForCausalLM` requires OpenVINO IR [Text Generation](https://huggingface.co/models?library=openvino&pipeline_tag=text-generation) models from Hugging face
 - `OVModelForFeatureExtraction` works with any Safetensors Transformer [Feature Extraction](https://huggingface.co/models?pipeline_tag=feature-extraction&library=transformers,safetensors) model from Huggingface (Embedding Model)
 
-Please note that streaming is currently not implemente in `AutoModelForCausalLM` for Intel GPU.
+Please note that streaming is currently not implemented in `AutoModelForCausalLM` for Intel GPU.
 AMD GPU support is not implemented.
 Although AMD CPU is not officially supported by OpenVINO there are reports that it works: YMMV.
 

--- a/docs/content/whats-new.md
+++ b/docs/content/whats-new.md
@@ -105,7 +105,7 @@ It is now possible for single-devices with one GPU to specify `--single-active-b
 
 #### Resources management
 
-Thanks to the continous community efforts (another cool contribution from {{< github "dave-gray101" >}} ) now it's possible to shutdown a backend programmatically via the API.
+Thanks to the continuous community efforts (another cool contribution from {{< github "dave-gray101" >}} ) now it's possible to shutdown a backend programmatically via the API.
 There is an ongoing effort in the community to better handling of resources. See also the [🔥Roadmap](https://localai.io/#-hot-topics--roadmap).
 
 #### New how-to section


### PR DESCRIPTION
Summary:
Fixes several clear spelling mistakes in the documentation. The changes are limited to docs text and do not alter behavior.

Testing:
- `git diff --check`
- `uvx codespell` on the changed files

AI assistance disclosure:
Prepared with Codex assistance and reviewed before submission.