### PR TITLE
fix(nemo): pin texterrors to 1.1.6 for GLIBCXX compatibility

### DIFF
--- a/backend/python/nemo/requirements-cublas13.txt
+++ b/backend/python/nemo/requirements-cublas13.txt
@@ -1,3 +1,4 @@
 --extra-index-url https://download.pytorch.org/whl/cu130
 torch
+texterrors==1.1.6
 nemo_toolkit[asr]


### PR DESCRIPTION
## Problem

The `cuda13-nemo` backend fails to load on the default LocalAI container (Ubuntu 22.04) with:

```
ImportError: /usr/lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found
(required by .../texterrors_align.cpython-310-x86_64-linux-gnu.so)
```

The `texterrors` package (a NeMo transitive dependency) contains a compiled C++ extension. When the backend OCI image is built on a system with GCC 14+ (e.g. Ubuntu 24.04), pip may build `texterrors` from source rather than using the pre-built wheel, producing a binary that requires `GLIBCXX_3.4.32` — which the Ubuntu 22.04 container does not provide (it ships up to `GLIBCXX_3.4.30`).

## Fix

Pin `texterrors==1.1.6` in `requirements-cublas13.txt` before `nemo_toolkit[asr]`.

This ensures:
- **Reproducible builds**: a known-good version is always used regardless of build environment
- **Wheel over source**: by pinning a version that has `manylinux2014` wheels on PyPI (requiring only `GLIBCXX_3.4.11`), pip is more likely to install the pre-built wheel instead of building from source with the host toolchain

## Investigation notes

I verified all available `texterrors` versions on PyPI (0.5.1 through 1.1.6) — their pre-built `manylinux2014` wheels only require `GLIBCXX` up to `3.4.11`, which is fully compatible with Ubuntu 22.04. The issue arises when the package is compiled from source (`.tar.gz`) during OCI image build on a newer platform.

Fixes #10056