### PR TITLE
fix(vllm): restore compatibility with vLLM >= 0.22 (get_tokenizer moved to vllm.tokenizers)

### DIFF
--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -26,7 +26,10 @@ from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.async_llm_engine import AsyncLLMEngine
 from vllm.sampling_params import SamplingParams
 from vllm.utils import random_uuid
-from vllm.transformers_utils.tokenizer import get_tokenizer
+try:
+    from vllm.tokenizers import get_tokenizer  # vLLM >= 0.22
+except ImportError:
+    from vllm.transformers_utils.tokenizer import get_tokenizer  # vLLM < 0.22
 from vllm.multimodal.utils import fetch_image
 from vllm.assets.video import VideoAsset
 import base64


### PR DESCRIPTION
## Problem

vLLM 0.22 moved `get_tokenizer` from `vllm.transformers_utils.tokenizer` to `vllm.tokenizers`. Since the backend's requirements install vllm **unpinned**, every freshly built/installed vllm backend currently crashes on startup:

```
ModuleNotFoundError: No module named 'vllm.transformers_utils.tokenizer'
```

which surfaces to the user as `grpc service not ready` when loading any model through the vllm backend.

## Fix

Wrap the import in a try/except — the same version-compat pattern this file already uses for other imports: try the new `vllm.tokenizers` location first, fall back to the pre-0.22 path.

## Tested

On an NVIDIA DGX Spark (GB10, ARM64) with the `cuda13-nvidia-l4t-arm64-vllm` backend and vllm 0.22.0:
- without the patch: backend process dies on import → "grpc service not ready"
- with the patch: model load, chat completions and tool calls (`finish_reason: tool_calls` with correct JSON arguments) all work
