### PR TITLE
fix(vllm): parse tool_call function arguments before applying the chat template

### DIFF
--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -150,9 +150,24 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 d["reasoning_content"] = msg.reasoning_content
             if msg.tool_calls:
                 try:
-                    d["tool_calls"] = json.loads(msg.tool_calls)
+                    tool_calls = json.loads(msg.tool_calls)
                 except json.JSONDecodeError:
                     pass
+                else:
+                    # OpenAI wire format carries function.arguments as a
+                    # JSON-encoded string, but chat templates (e.g. Qwen3)
+                    # iterate over it as a mapping. vLLM's own OpenAI server
+                    # parses arguments before applying the template, so do
+                    # the same here.
+                    if isinstance(tool_calls, list):
+                        for tc in tool_calls:
+                            func = tc.get("function") if isinstance(tc, dict) else None
+                            if isinstance(func, dict) and isinstance(func.get("arguments"), str):
+                                try:
+                                    func["arguments"] = json.loads(func["arguments"])
+                                except json.JSONDecodeError:
+                                    pass
+                    d["tool_calls"] = tool_calls
             result.append(d)
         return result
 


### PR DESCRIPTION
## Problem

Multi-turn tool calling fails with a 500 once the client sends back an assistant message containing `tool_calls`:

```
TypeError: Can only get item pairs from a mapping.
```

`_messages_to_dicts()` parses the outer `tool_calls` JSON array but leaves `function.arguments` as a JSON-encoded string (that's the OpenAI wire format). Chat templates like Qwen3's iterate over `arguments` as a mapping, so `apply_chat_template()` blows up. vLLM's own OpenAI-compatible server parses `arguments` into a dict before rendering the template.

## Fix

After decoding the outer array, decode each `function.arguments` string into a dict. Strings that aren't valid JSON are left untouched.

## Tested

On an NVIDIA DGX Spark (GB10, ARM64), `cuda13-nvidia-l4t-arm64-vllm` backend, Qwen3-Coder with `use_tokenizer_template: true`: without the patch every second-turn tool call 500s; with the patch multi-turn tool calling works (`finish_reason: tool_calls`, correct arguments round-trip).
