### PR TITLE
fix(cuda): install cuda-nvrtc-dev alongside the other CUDA dev packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,7 @@ RUN <<EOT bash
         apt-get update && \
         apt-get install -y --no-install-recommends \
             cuda-nvcc-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
+            cuda-nvrtc-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
             libcufft-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
             libcurand-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
             libcublas-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \

--- a/backend/Dockerfile.python
+++ b/backend/Dockerfile.python
@@ -126,6 +126,7 @@ RUN <<EOT bash
         apt-get update && \
         apt-get install -y --no-install-recommends \
             cuda-nvcc-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
+            cuda-nvrtc-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
             libcufft-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
             libcurand-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \
             libcublas-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION} \


### PR DESCRIPTION
## Problem

Backends that JIT-compile CUDA kernels at first model load (e.g. the vllm backend via FlashInfer / torch inductor on newer architectures like Blackwell SM120/121) fail inside the cublas/l4t images:

```
fatal error: nvrtc.h: No such file or directory
/usr/bin/ld: cannot find -lnvrtc
```

The images install `cuda-nvcc` plus the cufft/curand/cublas/cusparse/cusolver dev packages, but not `cuda-nvrtc-dev`, so the NVRTC headers and the unversioned `libnvrtc.so` linker name are missing.

## Fix

Add `cuda-nvrtc-dev-${CUDA_MAJOR_VERSION}-${CUDA_MINOR_VERSION}` to the existing dev-package list, in both the runtime `Dockerfile` and `backend/Dockerfile.python`. The package comes from the same NVIDIA apt repo the Dockerfiles already configure (for CUDA 13 that's `cuda-nvrtc-dev-13-0`, currently 13.0.88-1).

## Tested

On an NVIDIA DGX Spark (GB10, ARM64) with the `nvidia-l4t-arm64-cuda-13` image: FlashInfer's JIT pass for SM121a kernels (`fp4_gemm_cutlass_sm120`, `fused_moe_120`) fails with the errors above; after providing the NVRTC dev files the kernels compile and the model loads fine.
