### PR TITLE
model: fix case-insensitive suffix matching and skip .bak files in ListFilesInModelPath

### DIFF
--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -193,8 +193,7 @@ var knownModelsNameSuffixToSkip []string = []string{
 	".pt",
 	".onnx",
 	".md",
-	".MD",
-	".DS_Store",
+	".ds_store",
 	".",
 	".safetensors",
 	".bin",
@@ -203,6 +202,7 @@ var knownModelsNameSuffixToSkip []string = []string{
 	".ckpt",
 	".zip",
 	".tag",
+	".bak",
 	".partial",
 	".tar.gz",
 }
@@ -225,11 +225,17 @@ FILE:
 			}
 		}
 
-		// Skip templates, YAML, .keep, .json, and .DS_Store files
+		// Skip templates, YAML, .keep, .json, .DS_Store, and other non-model files.
+		// Use case-insensitive matching so e.g. CACHEDIR.TAG is caught by ".tag".
+		lowerName := strings.ToLower(file.Name())
 		for _, skip := range knownModelsNameSuffixToSkip {
-			if strings.HasSuffix(file.Name(), skip) {
+			if strings.HasSuffix(lowerName, skip) {
 				continue FILE
 			}
+		}
+		// Skip backup files created by LocalAI or huggingface_hub (e.g. model.yaml.bak-pre-gpumem072).
+		if strings.Contains(lowerName, ".bak") {
+			continue FILE
 		}
 
 		// Skip directories


### PR DESCRIPTION
## Problem

When `huggingface_hub` downloads models into LocalAIs models directory, it creates a `CACHEDIR.TAG` file. This file shows up in `/v1/models` because the suffix skip list contains `.tag` (lowercase), but `strings.HasSuffix` is case-sensitive — `CACHEDIR.TAG` (uppercase) is therefore not matched.

Additionally, backup files like `model.yaml.bak-pre-gpumem072` appear in `/v1/models`. These are created e.g. when LocalAI backs up YAML configs before modifying them.

## Fix

1. **Case-insensitive suffix matching**: The filename is lowercased once with `strings.ToLower` before comparing against entries in `knownModelsNameSuffixToSkip`. This makes `.tag` match `CACHEDIR.TAG` and similar variants.
2. **`.bak` detection via contains-check**: Backup files with suffixes like `.bak-pre-gpumem072` do not end exactly in `.bak`, so an additional `strings.Contains(lowerName, ".bak")` check is added.
3. **Cleanup**: The duplicate `.MD` entry is removed (now redundant via case-insensitive `.md` matching). `.DS_Store` is replaced by lowercased `.ds_store`.

## Reproduction

```
$ curl http://localhost:8080/v1/models | jq '.data[].id'
"CACHEDIR.TAG"
"coder.yaml.bak-pre-gpumem072"
"gemma4-12b.yaml.bak-pre-gpulayers"
...
```

Affects any installation that uses `huggingface_hub` for model downloads or has YAML backup files in the models directory.
