### PR TITLE
fix(vllm): structured outputs silently ignored on vLLM >= 0.23 (GuidedDecodingParams removed)

### DIFF
--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -48,8 +48,10 @@ try:
 except ImportError:
     HAS_REASONING_PARSERS = False
 
+# vLLM >= 0.23 renamed GuidedDecodingParams -> StructuredOutputsParams and the
+# SamplingParams field guided_decoding -> structured_outputs.
 try:
-    from vllm.sampling_params import GuidedDecodingParams
+    from vllm.sampling_params import StructuredOutputsParams
     HAS_GUIDED_DECODING = True
 except ImportError:
     HAS_GUIDED_DECODING = False
@@ -536,13 +538,13 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 if value not in (None, 0, [], False):
                     setattr(sampling_params, param_field, value)
 
-        # Guided decoding: use Grammar field to pass JSON schema or BNF
+        # Structured-output decoding: use Grammar field to pass JSON schema or BNF
         if HAS_GUIDED_DECODING and request.Grammar:
             try:
                 json.loads(request.Grammar)  # valid JSON = JSON schema
-                sampling_params.guided_decoding = GuidedDecodingParams(json=request.Grammar)
+                sampling_params.structured_outputs = StructuredOutputsParams(json=request.Grammar)
             except json.JSONDecodeError:
-                sampling_params.guided_decoding = GuidedDecodingParams(grammar=request.Grammar)
+                sampling_params.structured_outputs = StructuredOutputsParams(grammar=request.Grammar)
 
         # Extract image paths and process images
         prompt = request.Prompt


### PR DESCRIPTION
Supersedes #10339, which got auto-closed when I force-pushed from a shallow clone that had severed the commit's parent (the diff briefly blew up to the whole tree and GitHub closed it — sorry for the noise). This branch is now cleanly based on current `master` with a single 6-line change.

**Description**

On vLLM >= 0.23, `GuidedDecodingParams` was removed from `vllm.sampling_params` (replaced by `StructuredOutputsParams`, and the `SamplingParams` field renamed `guided_decoding` -> `structured_outputs`). The vLLM backend's import therefore fails:

```python
try:
    from vllm.sampling_params import GuidedDecodingParams
    HAS_GUIDED_DECODING = True
except ImportError:
    HAS_GUIDED_DECODING = False
```

`HAS_GUIDED_DECODING` becomes `False`, so the entire guided-decoding block is skipped and **`response_format` / grammar constraints are silently ignored** — the model returns unconstrained text.

**Reproduce** (vLLM 0.23.0, request with `"response_format": {"type": "json_schema", ...}`):
- Before: plain text (e.g. `Innsbruck`), schema not enforced.
- After: schema-conforming JSON (e.g. `{"country":"Österreich","name":"Innsbruck","population":132493}`).

Verified on NVIDIA GB10 / arm64 / CUDA 13, vLLM 0.23.0.

**Fix**

Adapt the existing `request.Grammar` path to the new class/field (`StructuredOutputsParams` / `structured_outputs`). Per @richiejp's review on #10339, no backwards-compat branch — the backend tracks the latest vLLM, so there's no supported version below 0.23 to fall back to.