### PR TITLE
feat(vllm): progressive streaming via parser.extract_tool_calls_streaming (follow-up to #10346)

### DIFF
--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -596,29 +596,124 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
 
         # Stream the results
         generated_text = ""
+        generated_token_ids: list[int] = []
         last_output = None
-        # When a tool parser is active for a tool-enabled request, the model's
-        # raw tool-call markup (e.g. <tool_call>...) must not be streamed as
-        # delta.content — clients would otherwise see the unparsed syntax. Buffer
-        # the text; the final chat_delta below carries the parsed tool_calls (or
-        # the cleaned content), which the Go side converts to SSE deltas.
+
+        # Tool-parsing strategy decision (made once, before the loop):
+        #
+        # When a tool parser is active, the model's raw tool-call markup
+        # (e.g. <tool_call>...) must not be streamed verbatim as delta.content
+        # — clients would see the unparsed syntax. Two paths:
+        #
+        # (A) native streaming via parser.extract_tool_calls_streaming. All
+        #     concrete tool parsers shipped with vLLM 0.23+ implement this
+        #     (Granite4, Qwen3Coder, DeepSeekV31, Jamba, Ernie45, Hermes,
+        #     llama3_json, mistral, …). The parser decides per-delta whether
+        #     to emit content or suppress tool-call markup, and emits a
+        #     structured DeltaMessage(tool_calls=[...]) when a call is ready.
+        # (B) buffer fallback — used only when the parser surprisingly lacks
+        #     the streaming method or it raises mid-stream. The post-loop
+        #     extract_tool_calls assembles the final chat_delta. Same correctness
+        #     guarantee as a non-streaming response, at the cost of a delayed
+        #     final chunk.
         has_tool_parser = bool(self.tool_parser_cls and request.Tools)
+        tp_instance = None
+        tp_request = None
+        native_streaming = False
+        native_streaming_error = False
+        if has_tool_parser:
+            try:
+                tools_for_parser = json.loads(request.Tools)
+            except json.JSONDecodeError:
+                tools_for_parser = []
+            try:
+                tp_instance = self.tool_parser_cls(self.tokenizer, tools=tools_for_parser)
+            except TypeError:
+                tp_instance = self.tool_parser_cls(self.tokenizer)
+            # Build a minimal ChatCompletionRequest so the streaming method
+            # sees the tools list. We do not need any other request fields —
+            # parsers only read .tools (and sometimes .tool_choice, which we
+            # leave at default).
+            try:
+                from vllm.entrypoints.openai.chat_completion.protocol import (
+                    ChatCompletionRequest as _CCR,
+                )
+                tp_request = _CCR(
+                    model="local",
+                    messages=[{"role": "user", "content": ""}],
+                    tools=tools_for_parser or None,
+                )
+            except Exception as e:
+                print(f"Could not build ChatCompletionRequest for streaming parser: {e}",
+                      file=sys.stderr)
+                tp_request = None
+            native_streaming = (
+                tp_request is not None
+                and hasattr(tp_instance, "extract_tool_calls_streaming")
+            )
+
         try:
             async for request_output in outputs:
                 iteration_text = request_output.outputs[0].text
                 last_output = request_output
 
-                if streaming and not has_tool_parser:
-                    # Remove text already sent as vllm concatenates the text from previous yields
+                if streaming:
                     delta_iteration_text = iteration_text.removeprefix(generated_text)
-                    # Send the partial result
-                    yield backend_pb2.Reply(
-                        message=bytes(delta_iteration_text, encoding='utf-8'),
-                        chat_deltas=[backend_pb2.ChatDelta(content=delta_iteration_text)],
-                    )
+                    new_token_ids = list(request_output.outputs[0].token_ids)
+                    delta_token_ids = new_token_ids[len(generated_token_ids):]
 
-                # Keep track of text generated
+                    if not has_tool_parser:
+                        # Plain streaming — unchanged from pre-tool-parser path.
+                        yield backend_pb2.Reply(
+                            message=bytes(delta_iteration_text, encoding='utf-8'),
+                            chat_deltas=[backend_pb2.ChatDelta(content=delta_iteration_text)],
+                        )
+                    elif native_streaming and not native_streaming_error:
+                        # (A) Native vLLM extract_tool_calls_streaming.
+                        try:
+                            msg = tp_instance.extract_tool_calls_streaming(
+                                previous_text=generated_text,
+                                current_text=iteration_text,
+                                delta_text=delta_iteration_text,
+                                previous_token_ids=generated_token_ids,
+                                current_token_ids=new_token_ids,
+                                delta_token_ids=delta_token_ids,
+                                request=tp_request,
+                            )
+                        except Exception as e:
+                            print(f"Streaming tool parser error (falling back to "
+                                  f"buffer for the rest of the stream): {e}",
+                                  file=sys.stderr)
+                            native_streaming_error = True
+                            msg = None
+                        if msg is not None:
+                            tc_protos = []
+                            for tc in (msg.tool_calls or []):
+                                fn = tc.function or None
+                                tc_protos.append(backend_pb2.ToolCallDelta(
+                                    index=tc.index,
+                                    id=tc.id or "",
+                                    name=(fn.name if fn and fn.name else "") or "",
+                                    arguments=(fn.arguments if fn and fn.arguments else "") or "",
+                                ))
+                            cd_kwargs = {}
+                            if msg.content:
+                                cd_kwargs["content"] = msg.content
+                            if msg.reasoning:
+                                cd_kwargs["reasoning_content"] = msg.reasoning
+                            if tc_protos:
+                                cd_kwargs["tool_calls"] = tc_protos
+                            if cd_kwargs:
+                                yield backend_pb2.Reply(
+                                    message=bytes(msg.content or "", encoding='utf-8'),
+                                    chat_deltas=[backend_pb2.ChatDelta(**cd_kwargs)],
+                                )
+                    # (B) buffer fallback — emit nothing during the stream.
+                    # The post-loop extract_tool_calls block builds the final chunk.
+
+                # Keep track of text + token_ids generated
                 generated_text = iteration_text
+                generated_token_ids = list(request_output.outputs[0].token_ids)
         finally:
             await outputs.aclose()
 
@@ -643,16 +738,19 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             except Exception as e:
                 print(f"Reasoning parser error: {e}", file=sys.stderr)
 
-        if self.tool_parser_cls and request.Tools:
+        # When (A) native streaming ran cleanly, per-delta yields above already
+        # delivered everything — do NOT extract again on the full text or we'd
+        # duplicate content/tool_calls into the final chunk.
+        if has_tool_parser and not (native_streaming and not native_streaming_error):
             try:
-                tools = json.loads(request.Tools)
-                # Some concrete parsers only accept the tokenizer; only the
-                # abstract base declares the tools kwarg. Try with tools first,
-                # fall back to tokenizer-only.
-                try:
-                    tp = self.tool_parser_cls(self.tokenizer, tools=tools)
-                except TypeError:
-                    tp = self.tool_parser_cls(self.tokenizer)
+                tp = tp_instance
+                if tp is None:
+                    # Defensive: tp_instance build failed earlier; reconstruct.
+                    tools = json.loads(request.Tools)
+                    try:
+                        tp = self.tool_parser_cls(self.tokenizer, tools=tools)
+                    except TypeError:
+                        tp = self.tool_parser_cls(self.tokenizer)
                 info = tp.extract_tool_calls(content, request=None)
                 if info.tools_called:
                     content = info.content or ""
@@ -665,6 +763,10 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                         ))
             except Exception as e:
                 print(f"Tool parser error: {e}", file=sys.stderr)
+        elif native_streaming and not native_streaming_error:
+            # Per-delta path already emitted content + tool_calls; the final
+            # chat_delta should carry only metadata (token counts, logprobs).
+            content = ""
 
         # Extract token counts
         prompt_tokens = 0
@@ -704,7 +806,26 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         )
 
         if streaming:
-            # Final chunk with structured data
+            # Final chunk with structured data.
+            #
+            # If we used the buffer fallback (has_tool_parser=True AND native
+            # streaming did NOT run cleanly) and the parser found no tool call,
+            # flush the buffered content as ONE content delta — and clear the
+            # final chat_delta's content so the metadata chunk does not repeat
+            # what we just sent. This is the plain-text-with-tool-parser path.
+            buffered_fallback = (
+                has_tool_parser
+                and not (native_streaming and not native_streaming_error)
+            )
+            if buffered_fallback and not tool_calls_proto and content:
+                yield backend_pb2.Reply(
+                    message=bytes(content, encoding='utf-8'),
+                    chat_deltas=[backend_pb2.ChatDelta(content=content)],
+                )
+                chat_delta = backend_pb2.ChatDelta(
+                    reasoning_content=reasoning_content,
+                    tool_calls=tool_calls_proto,
+                )
             yield backend_pb2.Reply(
                 message=b"",
                 prompt_tokens=prompt_tokens,

--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -597,12 +597,18 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         # Stream the results
         generated_text = ""
         last_output = None
+        # When a tool parser is active for a tool-enabled request, the model's
+        # raw tool-call markup (e.g. <tool_call>...) must not be streamed as
+        # delta.content — clients would otherwise see the unparsed syntax. Buffer
+        # the text; the final chat_delta below carries the parsed tool_calls (or
+        # the cleaned content), which the Go side converts to SSE deltas.
+        has_tool_parser = bool(self.tool_parser_cls and request.Tools)
         try:
             async for request_output in outputs:
                 iteration_text = request_output.outputs[0].text
                 last_output = request_output
 
-                if streaming:
+                if streaming and not has_tool_parser:
                     # Remove text already sent as vllm concatenates the text from previous yields
                     delta_iteration_text = iteration_text.removeprefix(generated_text)
                     # Send the partial result

--- a/backend/python/vllm/test.py
+++ b/backend/python/vllm/test.py
@@ -353,3 +353,87 @@ class TestBackendServicer(unittest.TestCase):
             joined.count("The capital of France is Paris."), 1,
             f"buffered content was duplicated: {joined!r}",
         )
+    @unittest.expectedFailure
+    def test_streaming_tool_parser_progressive_plain_text(self):
+        """
+        Case 3 (TDD — currently fails, defines acceptance criterion for follow-up, see #582):
+
+        When a tool parser is active but the model returns plain text (no tool call),
+        and the parser implements extract_tool_calls_streaming, tokens should be emitted
+        progressively — not held until the final chunk.
+
+        Proposed interface:
+            extract_tool_calls_streaming(delta: str, request=None)
+            -> SimpleNamespace(is_tool_call_token=bool, content=str)
+
+        Fails on current code because has_tool_parser=True suppresses all intermediate
+        deltas. Will pass after Option A or B from the follow-up (Issue #582).
+        """
+        import sys, os, asyncio
+        from types import SimpleNamespace
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from backend import BackendServicer
+
+        def make_generate(chunks):
+            async def gen(*a, **k):
+                for t in chunks:
+                    yield SimpleNamespace(
+                        outputs=[SimpleNamespace(text=t, token_ids=[1], logprobs=None)],
+                        prompt_token_ids=[0],
+                    )
+            return lambda *a, **k: gen()
+
+        class StreamingAwareParser:
+            def __init__(self, tokenizer, tools=None):
+                pass
+
+            def extract_tool_calls(self, c, request=None):
+                return SimpleNamespace(tools_called=False, content=c, tool_calls=[])
+
+            def extract_tool_calls_streaming(self, delta, request=None):
+                # Plain-text delta — not tool-call markup, pass through as content.
+                return SimpleNamespace(is_tool_call_token=False, content=delta)
+
+        def collect(servicer, req):
+            async def run():
+                return [r async for r in servicer._predict(req, None, streaming=True)]
+            return asyncio.run(run())
+
+        # vLLM yields cumulative text per iteration
+        s = BackendServicer()
+        s.reasoning_parser_cls = None
+        s.tokenizer = None
+        s.llm = SimpleNamespace(generate=make_generate([
+            "Paris ",
+            "Paris is ",
+            "Paris is the capital of France.",
+        ]))
+        s.tool_parser_cls = StreamingAwareParser
+
+        tools_json = '[{"type":"function","function":{"name":"calc"}}]'
+        req = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
+        replies = collect(s, req)
+
+        # Key assertion: intermediate replies (before the final chunk) must carry content.
+        # Currently fails because has_tool_parser=True suppresses all intermediate deltas.
+        intermediate_content = [
+            cd.content
+            for r in replies[:-1]
+            for cd in r.chat_deltas
+            if cd.content
+        ]
+        self.assertTrue(
+            len(intermediate_content) > 0,
+            "Plain-text response not streamed progressively — "
+            "all content arrived in the final chunk. "
+            "Fix: use extract_tool_calls_streaming when available (Option A).",
+        )
+
+        # No duplication: assembled content equals the full text exactly once.
+        assembled = "".join(
+            cd.content for r in replies for cd in r.chat_deltas if cd.content
+        )
+        self.assertEqual(
+            assembled, "Paris is the capital of France.",
+            f"Content wrong or duplicated: {assembled!r}",
+        )

--- a/backend/python/vllm/test.py
+++ b/backend/python/vllm/test.py
@@ -280,316 +280,259 @@ class TestBackendServicer(unittest.TestCase):
         finally:
             self.tearDown()
 
-    def test_streaming_tool_parser_buffering(self):
-        """
-        When a tool parser is active and the request carries tools, streaming
-        must NOT emit the model's raw tool-call markup as content, and must NOT
-        duplicate the buffered content. Exercises _predict(streaming=True) with a
-        mocked engine + tool parser (no server / GPU).
-        """
-        import sys, os, asyncio
+
+class TestStreamingToolParser(unittest.TestCase):
+    """
+    Server-less unit tests for the streaming + tool-parser machinery in
+    BackendServicer._predict. These tests instantiate BackendServicer
+    directly and mock the vLLM engine + tool parser, so they do not need
+    a GPU, a model, or a running gRPC server. Kept in a separate class to
+    avoid the parent setUp() which spawns a subprocess.
+
+    Covers #582 (follow-up to #10346):
+      1. Markup-leak prevention with a non-streaming parser (buffer fallback)
+      2. No content duplication on the plain-text path with the buffer fallback
+      3. Native streaming progressive plain-text emission
+      4. Native streaming structured tool_call, no markup leak
+      5. Parser exception → graceful fallback to buffer, still no markup
+      6. No-tool-parser regression: unchanged per-delta content stream
+    """
+
+    @staticmethod
+    def _make_generate(chunks):
+        """Build a fake vLLM engine.generate that yields cumulative chunks."""
         from types import SimpleNamespace
+        async def gen(*a, **k):
+            for i, t in enumerate(chunks):
+                yield SimpleNamespace(
+                    outputs=[SimpleNamespace(
+                        text=t,
+                        token_ids=list(range(i + 1)),
+                        logprobs=None,
+                    )],
+                    prompt_token_ids=[0],
+                )
+        return lambda *a, **k: gen()
+
+    @staticmethod
+    def _collect(servicer, req):
+        import asyncio
+        async def run():
+            return [r async for r in servicer._predict(req, None, streaming=True)]
+        return asyncio.run(run())
+
+    def _new_servicer(self):
+        import sys, os
         sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
         from backend import BackendServicer
+        s = BackendServicer()
+        s.reasoning_parser_cls = None
+        s.tool_parser_cls = None
+        s.tokenizer = None
+        return s
 
-        def make_generate(chunks):
-            async def gen(*a, **k):
-                for t in chunks:
-                    yield SimpleNamespace(
-                        outputs=[SimpleNamespace(text=t, token_ids=[1], logprobs=None)],
-                        prompt_token_ids=[0],
-                    )
-            return lambda *a, **k: gen()
+    # ── Case 1+2: parser without streaming method → buffer fallback ──
+    def test_buffer_path_no_markup_no_duplication(self):
+        from types import SimpleNamespace
 
-        def parser_cls(called, content, calls):
+        def parser_cls(called, content_text, calls):
             class _P:
                 def __init__(self, tokenizer, tools=None):
                     pass
+                # NOTE: NO extract_tool_calls_streaming → takes the buffer path
                 def extract_tool_calls(self, c, request=None):
-                    return SimpleNamespace(tools_called=called, content=content, tool_calls=calls)
+                    return SimpleNamespace(
+                        tools_called=called, content=content_text, tool_calls=calls,
+                    )
             return _P
 
-        def collect(servicer, req):
-            async def run():
-                return [r async for r in servicer._predict(req, None, streaming=True)]
-            return asyncio.run(run())
+        tools_json = '[{"type":"function","function":{"name":"calc","parameters":{}}}]'
 
-        def contents(replies):
-            return [cd.content for r in replies for cd in r.chat_deltas if cd.content]
-
-        tools_json = '[{"type":"function","function":{"name":"calc"}}]'
-
-        # Case 1: model emits a tool call -> no raw markup as content, tool_call present.
-        s = BackendServicer()
-        s.reasoning_parser_cls = None
-        s.tokenizer = None
-        s.llm = SimpleNamespace(generate=make_generate([
+        # Tool-call case: no raw markup in any delta.content
+        s = self._new_servicer()
+        s.llm = SimpleNamespace(generate=self._make_generate([
             '<tool_call>\n{"name": "calc"',
             '<tool_call>\n{"name": "calc", "arguments": {"x": 1}}\n</tool_call>',
         ]))
-        call = SimpleNamespace(id="call_1", function=SimpleNamespace(name="calc", arguments='{"x": 1}'))
+        call = SimpleNamespace(id="call_1",
+                               function=SimpleNamespace(name="calc", arguments='{"x": 1}'))
         s.tool_parser_cls = parser_cls(True, "", [call])
         req = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
-        replies = collect(s, req)
+        replies = self._collect(s, req)
+        contents = [cd.content for r in replies for cd in r.chat_deltas if cd.content]
         self.assertFalse(
-            any("<tool_call" in c or "<function" in c for c in contents(replies)),
-            "raw tool-call markup leaked as streamed content",
+            any("<tool_call" in c for c in contents),
+            f"markup leaked: {contents!r}",
         )
         names = [tc.name for r in replies for cd in r.chat_deltas for tc in cd.tool_calls]
-        self.assertIn("calc", names, "structured tool_call was not emitted")
+        self.assertIn("calc", names, "tool_call missing from final chunk")
 
-        # Case 2: tools offered but model answers in plain text -> content once.
-        s2 = BackendServicer()
-        s2.reasoning_parser_cls = None
-        s2.tokenizer = None
-        s2.llm = SimpleNamespace(generate=make_generate([
+        # Plain-text-with-tools case: full content delivered exactly once
+        s2 = self._new_servicer()
+        s2.llm = SimpleNamespace(generate=self._make_generate([
             "The capital ",
             "The capital of France is Paris.",
         ]))
         s2.tool_parser_cls = parser_cls(False, "", [])
         req2 = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
-        joined = "".join(contents(collect(s2, req2)))
+        joined = "".join(
+            cd.content for r in self._collect(s2, req2)
+            for cd in r.chat_deltas if cd.content
+        )
         self.assertEqual(
             joined.count("The capital of France is Paris."), 1,
-            f"buffered content was duplicated: {joined!r}",
+            f"buffered content duplicated: {joined!r}",
         )
-    @unittest.expectedFailure
-    def test_streaming_tool_parser_progressive_plain_text(self):
-        """
-        Case 3 (TDD — currently fails, defines acceptance criterion for follow-up, see #582):
 
-        When a tool parser is active but the model returns plain text (no tool call),
-        and the parser implements extract_tool_calls_streaming, tokens should be emitted
-        progressively — not held until the final chunk.
-
-        Proposed interface:
-            extract_tool_calls_streaming(delta: str, request=None)
-            -> SimpleNamespace(is_tool_call_token=bool, content=str)
-
-        Fails on current code because has_tool_parser=True suppresses all intermediate
-        deltas. Will pass after Option A or B from the follow-up (Issue #582).
-        """
-        import sys, os, asyncio
+    # ── Case 3: native streaming, progressive plain text ──
+    def test_native_streaming_progressive_plain_text(self):
         from types import SimpleNamespace
-        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-        from backend import BackendServicer
 
-        def make_generate(chunks):
-            async def gen(*a, **k):
-                for t in chunks:
-                    yield SimpleNamespace(
-                        outputs=[SimpleNamespace(text=t, token_ids=[1], logprobs=None)],
-                        prompt_token_ids=[0],
-                    )
-            return lambda *a, **k: gen()
+        class _DeltaMsg:
+            def __init__(self, content=None, reasoning=None, tool_calls=None):
+                self.content = content
+                self.reasoning = reasoning
+                self.tool_calls = tool_calls or []
 
-        class StreamingAwareParser:
+        class StreamingParser:
             def __init__(self, tokenizer, tools=None):
                 pass
-
             def extract_tool_calls(self, c, request=None):
-                return SimpleNamespace(tools_called=False, content=c, tool_calls=[])
+                # Should NOT be called when native streaming runs successfully.
+                raise AssertionError("extract_tool_calls invoked on native-streaming path")
+            def extract_tool_calls_streaming(
+                self, previous_text, current_text, delta_text,
+                previous_token_ids, current_token_ids, delta_token_ids, request,
+            ):
+                if not delta_text:
+                    return None
+                return _DeltaMsg(content=delta_text)
 
-            def extract_tool_calls_streaming(self, delta, request=None):
-                # Plain-text delta — not tool-call markup, pass through as content.
-                return SimpleNamespace(is_tool_call_token=False, content=delta)
-
-        def collect(servicer, req):
-            async def run():
-                return [r async for r in servicer._predict(req, None, streaming=True)]
-            return asyncio.run(run())
-
-        # vLLM yields cumulative text per iteration
-        s = BackendServicer()
-        s.reasoning_parser_cls = None
-        s.tokenizer = None
-        s.llm = SimpleNamespace(generate=make_generate([
+        s = self._new_servicer()
+        s.llm = SimpleNamespace(generate=self._make_generate([
             "Paris ",
             "Paris is ",
             "Paris is the capital of France.",
         ]))
-        s.tool_parser_cls = StreamingAwareParser
+        s.tool_parser_cls = StreamingParser
+        req = backend_pb2.PredictOptions(
+            Prompt="x",
+            Tools='[{"type":"function","function":{"name":"calc","parameters":{}}}]',
+        )
+        replies = self._collect(s, req)
 
-        tools_json = '[{"type":"function","function":{"name":"calc"}}]'
-        req = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
-        replies = collect(s, req)
-
-        # Key assertion: intermediate replies (before the final chunk) must carry content.
-        # Currently fails because has_tool_parser=True suppresses all intermediate deltas.
         intermediate_content = [
-            cd.content
-            for r in replies[:-1]
-            for cd in r.chat_deltas
-            if cd.content
+            cd.content for r in replies[:-1] for cd in r.chat_deltas if cd.content
         ]
         self.assertTrue(
             len(intermediate_content) > 0,
-            "Plain-text response not streamed progressively — "
-            "all content arrived in the final chunk. "
-            "Fix: use extract_tool_calls_streaming when available (Option A).",
+            "Plain-text response not streamed progressively (native streaming inactive?)",
         )
-
-        # No duplication: assembled content equals the full text exactly once.
         assembled = "".join(
             cd.content for r in replies for cd in r.chat_deltas if cd.content
         )
         self.assertEqual(
             assembled, "Paris is the capital of France.",
-            f"Content wrong or duplicated: {assembled!r}",
+            f"Assembled content wrong: {assembled!r}",
         )
-    @unittest.expectedFailure
-    def test_streaming_tool_parser_marker_split_across_chunks(self):
-        """
-        Case 4 (TDD — Option B state machine, marker spans chunk boundary):
 
-        vLLM may yield "Some text <tool_" in one iteration and
-        "call>\\n{...}\\n</tool_call>" in the next. The state machine must hold
-        the incomplete prefix ("<tool_") in an uncertainty buffer rather than
-        streaming it, since it could be the start of a marker. Once the full
-        marker is confirmed in the next chunk, buffering activates.
-
-        Expected:
-        - "Some text " streams through as intermediate content.
-        - "<tool_" does NOT appear in any streamed intermediate content.
-        - Final chunk carries the parsed tool_call (name "calc").
-        """
-        import sys, os, asyncio
+    # ── Case 4: native streaming, structured tool_call, no markup ──
+    def test_native_streaming_tool_call_no_markup_leak(self):
         from types import SimpleNamespace
-        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-        from backend import BackendServicer
 
-        def make_generate(chunks):
-            async def gen(*a, **k):
-                for t in chunks:
-                    yield SimpleNamespace(
-                        outputs=[SimpleNamespace(text=t, token_ids=[1], logprobs=None)],
-                        prompt_token_ids=[0],
-                    )
-            return lambda *a, **k: gen()
+        class _DeltaMsg:
+            def __init__(self, content=None, reasoning=None, tool_calls=None):
+                self.content = content
+                self.reasoning = reasoning
+                self.tool_calls = tool_calls or []
 
-        call = SimpleNamespace(
-            id="call_1",
-            function=SimpleNamespace(name="calc", arguments='{"x": 1}'),
+        class _ToolCallStreamer:
+            def __init__(self, tokenizer, tools=None):
+                self._emitted = False
+            def extract_tool_calls(self, c, request=None):
+                raise AssertionError("extract_tool_calls invoked on native-streaming path")
+            def extract_tool_calls_streaming(
+                self, previous_text, current_text, delta_text,
+                previous_token_ids, current_token_ids, delta_token_ids, request,
+            ):
+                if "</tool_call>" in current_text and not self._emitted:
+                    self._emitted = True
+                    fn = SimpleNamespace(name="calc", arguments='{"x": 1}')
+                    tc = SimpleNamespace(id="call_1", type="function", index=0, function=fn)
+                    return _DeltaMsg(tool_calls=[tc])
+                return None
+
+        s = self._new_servicer()
+        s.llm = SimpleNamespace(generate=self._make_generate([
+            '<tool_call>\n',
+            '<tool_call>\n{"name": "calc"',
+            '<tool_call>\n{"name": "calc", "arguments": {"x": 1}}\n</tool_call>',
+        ]))
+        s.tool_parser_cls = _ToolCallStreamer
+        req = backend_pb2.PredictOptions(
+            Prompt="x",
+            Tools='[{"type":"function","function":{"name":"calc","parameters":{}}}]',
         )
+        replies = self._collect(s, req)
 
-        class StateMachineParser:
+        contents = [cd.content for r in replies for cd in r.chat_deltas if cd.content]
+        self.assertFalse(
+            any("<tool_call" in c or "</tool_call>" in c for c in contents),
+            f"markup leaked as content: {contents!r}",
+        )
+        names = [tc.name for r in replies for cd in r.chat_deltas for tc in cd.tool_calls if tc.name]
+        args  = [tc.arguments for r in replies for cd in r.chat_deltas for tc in cd.tool_calls if tc.arguments]
+        self.assertIn("calc", names, f"tool_call name missing; got {names!r}")
+        self.assertIn('{"x": 1}', args, f"tool_call args missing; got {args!r}")
+
+    # ── Case 5: parser exception → fallback to buffer, no leak ──
+    def test_native_streaming_parser_exception_falls_back_to_buffer(self):
+        from types import SimpleNamespace
+        call = SimpleNamespace(id="call_1",
+                               function=SimpleNamespace(name="calc", arguments='{"x": 1}'))
+
+        class _BrokenStreamer:
             def __init__(self, tokenizer, tools=None):
                 pass
-
             def extract_tool_calls(self, c, request=None):
                 return SimpleNamespace(tools_called=True, content="", tool_calls=[call])
+            def extract_tool_calls_streaming(self, *a, **kw):
+                raise RuntimeError("simulated parser bug")
 
-        def collect(servicer, req):
-            async def run():
-                return [r async for r in servicer._predict(req, None, streaming=True)]
-            return asyncio.run(run())
-
-        # Marker "<tool_call>" is split: first chunk ends with "<tool_",
-        # second chunk starts with "call>..."
-        full_tool = '<tool_call>\n{"name": "calc", "arguments": {"x": 1}}\n</tool_call>'
-        s = BackendServicer()
-        s.reasoning_parser_cls = None
-        s.tokenizer = None
-        s.llm = SimpleNamespace(generate=make_generate([
-            "Some text <tool_",
-            "Some text " + full_tool,
+        s = self._new_servicer()
+        s.llm = SimpleNamespace(generate=self._make_generate([
+            '<tool_call>\n{"name": "calc"',
+            '<tool_call>\n{"name": "calc", "arguments": {"x": 1}}\n</tool_call>',
         ]))
-        s.tool_parser_cls = StateMachineParser
-
-        tools_json = '[{"type":"function","function":{"name":"calc"}}]'
-        req = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
-        replies = collect(s, req)
-
-        intermediate_content = [
-            cd.content
-            for r in replies[:-1]
-            for cd in r.chat_deltas
-            if cd.content
-        ]
-
-        # "Some text " must have streamed through before the marker was seen
-        self.assertTrue(
-            any("Some text" in c for c in intermediate_content),
-            "Content before the marker was not streamed progressively.",
+        s.tool_parser_cls = _BrokenStreamer
+        req = backend_pb2.PredictOptions(
+            Prompt="x",
+            Tools='[{"type":"function","function":{"name":"calc","parameters":{}}}]',
         )
+        replies = self._collect(s, req)
 
-        # The marker prefix "<tool_" must never appear as streamed content
+        contents = [cd.content for r in replies for cd in r.chat_deltas if cd.content]
         self.assertFalse(
-            any("<tool_" in c for c in intermediate_content),
-            "Incomplete marker prefix was streamed before it was confirmed.",
+            any("<tool_call" in c for c in contents),
+            f"markup leaked after parser exception: {contents!r}",
         )
-
-        # Final chunk must carry the parsed tool_call
         names = [tc.name for r in replies for cd in r.chat_deltas for tc in cd.tool_calls]
-        self.assertIn("calc", names, "Structured tool_call not present in final chunk.")
+        self.assertIn("calc", names, "tool_call missing from final chunk after fallback")
 
-    @unittest.expectedFailure
-    def test_streaming_tool_parser_false_positive_marker(self):
-        """
-        Case 5 (TDD — Option B state machine, false-positive marker prefix):
-
-        The model writes text that starts like a tool-call marker but is not one,
-        e.g. "Let me use a <tool" followed by "box> to help." The state machine
-        must flush the uncertainty buffer as content once the prefix is disconfirmed.
-
-        Expected:
-        - All text streams through as content (no tool call).
-        - Assembled content equals the full sentence exactly once (no duplication).
-        - No tool_calls in the final reply.
-        """
-        import sys, os, asyncio
+    # ── Case 6: no tool parser → unchanged per-delta content stream ──
+    def test_no_tool_parser_unchanged_per_delta_stream(self):
         from types import SimpleNamespace
-        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-        from backend import BackendServicer
-
-        def make_generate(chunks):
-            async def gen(*a, **k):
-                for t in chunks:
-                    yield SimpleNamespace(
-                        outputs=[SimpleNamespace(text=t, token_ids=[1], logprobs=None)],
-                        prompt_token_ids=[0],
-                    )
-            return lambda *a, **k: gen()
-
-        class StateMachineParser:
-            def __init__(self, tokenizer, tools=None):
-                pass
-
-            def extract_tool_calls(self, c, request=None):
-                return SimpleNamespace(tools_called=False, content=c, tool_calls=[])
-
-        def collect(servicer, req):
-            async def run():
-                return [r async for r in servicer._predict(req, None, streaming=True)]
-            return asyncio.run(run())
-
-        # "<tool" looks like the start of "<tool_call>" but completes as "<toolbox>"
-        full_text = "Let me use a <toolbox> to help."
-        s = BackendServicer()
-        s.reasoning_parser_cls = None
-        s.tokenizer = None
-        s.llm = SimpleNamespace(generate=make_generate([
-            "Let me use a <tool",
-            full_text,
+        s = self._new_servicer()  # tool_parser_cls already None
+        s.llm = SimpleNamespace(generate=self._make_generate([
+            "Hello ", "Hello world", "Hello world!",
         ]))
-        s.tool_parser_cls = StateMachineParser
+        req = backend_pb2.PredictOptions(Prompt="x", Tools="")
+        replies = self._collect(s, req)
 
-        tools_json = '[{"type":"function","function":{"name":"calc"}}]'
-        req = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
-        replies = collect(s, req)
-
-        # Full text must be assembled exactly once (uncertainty buffer flushed correctly)
-        assembled = "".join(
-            cd.content for r in replies for cd in r.chat_deltas if cd.content
-        )
+        intermediate = [
+            cd.content for r in replies[:-1] for cd in r.chat_deltas if cd.content
+        ]
         self.assertEqual(
-            assembled, full_text,
-            f"False-positive marker mangled or duplicated the content: {assembled!r}",
-        )
-
-        # No tool_calls must be present
-        tool_calls = [tc for r in replies for cd in r.chat_deltas for tc in cd.tool_calls]
-        self.assertEqual(
-            len(tool_calls), 0,
-            "Tool call emitted for plain-text response with false-positive marker.",
+            intermediate, ["Hello ", "world", "!"],
+            f"plain streaming changed; got {intermediate!r}",
         )

--- a/backend/python/vllm/test.py
+++ b/backend/python/vllm/test.py
@@ -437,3 +437,159 @@ class TestBackendServicer(unittest.TestCase):
             assembled, "Paris is the capital of France.",
             f"Content wrong or duplicated: {assembled!r}",
         )
+    @unittest.expectedFailure
+    def test_streaming_tool_parser_marker_split_across_chunks(self):
+        """
+        Case 4 (TDD — Option B state machine, marker spans chunk boundary):
+
+        vLLM may yield "Some text <tool_" in one iteration and
+        "call>\\n{...}\\n</tool_call>" in the next. The state machine must hold
+        the incomplete prefix ("<tool_") in an uncertainty buffer rather than
+        streaming it, since it could be the start of a marker. Once the full
+        marker is confirmed in the next chunk, buffering activates.
+
+        Expected:
+        - "Some text " streams through as intermediate content.
+        - "<tool_" does NOT appear in any streamed intermediate content.
+        - Final chunk carries the parsed tool_call (name "calc").
+        """
+        import sys, os, asyncio
+        from types import SimpleNamespace
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from backend import BackendServicer
+
+        def make_generate(chunks):
+            async def gen(*a, **k):
+                for t in chunks:
+                    yield SimpleNamespace(
+                        outputs=[SimpleNamespace(text=t, token_ids=[1], logprobs=None)],
+                        prompt_token_ids=[0],
+                    )
+            return lambda *a, **k: gen()
+
+        call = SimpleNamespace(
+            id="call_1",
+            function=SimpleNamespace(name="calc", arguments='{"x": 1}'),
+        )
+
+        class StateMachineParser:
+            def __init__(self, tokenizer, tools=None):
+                pass
+
+            def extract_tool_calls(self, c, request=None):
+                return SimpleNamespace(tools_called=True, content="", tool_calls=[call])
+
+        def collect(servicer, req):
+            async def run():
+                return [r async for r in servicer._predict(req, None, streaming=True)]
+            return asyncio.run(run())
+
+        # Marker "<tool_call>" is split: first chunk ends with "<tool_",
+        # second chunk starts with "call>..."
+        full_tool = '<tool_call>\n{"name": "calc", "arguments": {"x": 1}}\n</tool_call>'
+        s = BackendServicer()
+        s.reasoning_parser_cls = None
+        s.tokenizer = None
+        s.llm = SimpleNamespace(generate=make_generate([
+            "Some text <tool_",
+            "Some text " + full_tool,
+        ]))
+        s.tool_parser_cls = StateMachineParser
+
+        tools_json = '[{"type":"function","function":{"name":"calc"}}]'
+        req = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
+        replies = collect(s, req)
+
+        intermediate_content = [
+            cd.content
+            for r in replies[:-1]
+            for cd in r.chat_deltas
+            if cd.content
+        ]
+
+        # "Some text " must have streamed through before the marker was seen
+        self.assertTrue(
+            any("Some text" in c for c in intermediate_content),
+            "Content before the marker was not streamed progressively.",
+        )
+
+        # The marker prefix "<tool_" must never appear as streamed content
+        self.assertFalse(
+            any("<tool_" in c for c in intermediate_content),
+            "Incomplete marker prefix was streamed before it was confirmed.",
+        )
+
+        # Final chunk must carry the parsed tool_call
+        names = [tc.name for r in replies for cd in r.chat_deltas for tc in cd.tool_calls]
+        self.assertIn("calc", names, "Structured tool_call not present in final chunk.")
+
+    @unittest.expectedFailure
+    def test_streaming_tool_parser_false_positive_marker(self):
+        """
+        Case 5 (TDD — Option B state machine, false-positive marker prefix):
+
+        The model writes text that starts like a tool-call marker but is not one,
+        e.g. "Let me use a <tool" followed by "box> to help." The state machine
+        must flush the uncertainty buffer as content once the prefix is disconfirmed.
+
+        Expected:
+        - All text streams through as content (no tool call).
+        - Assembled content equals the full sentence exactly once (no duplication).
+        - No tool_calls in the final reply.
+        """
+        import sys, os, asyncio
+        from types import SimpleNamespace
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from backend import BackendServicer
+
+        def make_generate(chunks):
+            async def gen(*a, **k):
+                for t in chunks:
+                    yield SimpleNamespace(
+                        outputs=[SimpleNamespace(text=t, token_ids=[1], logprobs=None)],
+                        prompt_token_ids=[0],
+                    )
+            return lambda *a, **k: gen()
+
+        class StateMachineParser:
+            def __init__(self, tokenizer, tools=None):
+                pass
+
+            def extract_tool_calls(self, c, request=None):
+                return SimpleNamespace(tools_called=False, content=c, tool_calls=[])
+
+        def collect(servicer, req):
+            async def run():
+                return [r async for r in servicer._predict(req, None, streaming=True)]
+            return asyncio.run(run())
+
+        # "<tool" looks like the start of "<tool_call>" but completes as "<toolbox>"
+        full_text = "Let me use a <toolbox> to help."
+        s = BackendServicer()
+        s.reasoning_parser_cls = None
+        s.tokenizer = None
+        s.llm = SimpleNamespace(generate=make_generate([
+            "Let me use a <tool",
+            full_text,
+        ]))
+        s.tool_parser_cls = StateMachineParser
+
+        tools_json = '[{"type":"function","function":{"name":"calc"}}]'
+        req = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
+        replies = collect(s, req)
+
+        # Full text must be assembled exactly once (uncertainty buffer flushed correctly)
+        assembled = "".join(
+            cd.content for r in replies for cd in r.chat_deltas if cd.content
+        )
+        self.assertEqual(
+            assembled, full_text,
+            f"False-positive marker mangled or duplicated the content: {assembled!r}",
+        )
+
+        # No tool_calls must be present
+        tool_calls = [tc for r in replies for cd in r.chat_deltas for tc in cd.tool_calls]
+        self.assertEqual(
+            len(tool_calls), 0,
+            "Tool call emitted for plain-text response with false-positive marker.",
+        )

--- a/backend/python/vllm/test.py
+++ b/backend/python/vllm/test.py
@@ -279,3 +279,77 @@ class TestBackendServicer(unittest.TestCase):
             self.fail("Embedding service failed")
         finally:
             self.tearDown()
+
+    def test_streaming_tool_parser_buffering(self):
+        """
+        When a tool parser is active and the request carries tools, streaming
+        must NOT emit the model's raw tool-call markup as content, and must NOT
+        duplicate the buffered content. Exercises _predict(streaming=True) with a
+        mocked engine + tool parser (no server / GPU).
+        """
+        import sys, os, asyncio
+        from types import SimpleNamespace
+        sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+        from backend import BackendServicer
+
+        def make_generate(chunks):
+            async def gen(*a, **k):
+                for t in chunks:
+                    yield SimpleNamespace(
+                        outputs=[SimpleNamespace(text=t, token_ids=[1], logprobs=None)],
+                        prompt_token_ids=[0],
+                    )
+            return lambda *a, **k: gen()
+
+        def parser_cls(called, content, calls):
+            class _P:
+                def __init__(self, tokenizer, tools=None):
+                    pass
+                def extract_tool_calls(self, c, request=None):
+                    return SimpleNamespace(tools_called=called, content=content, tool_calls=calls)
+            return _P
+
+        def collect(servicer, req):
+            async def run():
+                return [r async for r in servicer._predict(req, None, streaming=True)]
+            return asyncio.run(run())
+
+        def contents(replies):
+            return [cd.content for r in replies for cd in r.chat_deltas if cd.content]
+
+        tools_json = '[{"type":"function","function":{"name":"calc"}}]'
+
+        # Case 1: model emits a tool call -> no raw markup as content, tool_call present.
+        s = BackendServicer()
+        s.reasoning_parser_cls = None
+        s.tokenizer = None
+        s.llm = SimpleNamespace(generate=make_generate([
+            '<tool_call>\n{"name": "calc"',
+            '<tool_call>\n{"name": "calc", "arguments": {"x": 1}}\n</tool_call>',
+        ]))
+        call = SimpleNamespace(id="call_1", function=SimpleNamespace(name="calc", arguments='{"x": 1}'))
+        s.tool_parser_cls = parser_cls(True, "", [call])
+        req = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
+        replies = collect(s, req)
+        self.assertFalse(
+            any("<tool_call" in c or "<function" in c for c in contents(replies)),
+            "raw tool-call markup leaked as streamed content",
+        )
+        names = [tc.name for r in replies for cd in r.chat_deltas for tc in cd.tool_calls]
+        self.assertIn("calc", names, "structured tool_call was not emitted")
+
+        # Case 2: tools offered but model answers in plain text -> content once.
+        s2 = BackendServicer()
+        s2.reasoning_parser_cls = None
+        s2.tokenizer = None
+        s2.llm = SimpleNamespace(generate=make_generate([
+            "The capital ",
+            "The capital of France is Paris.",
+        ]))
+        s2.tool_parser_cls = parser_cls(False, "", [])
+        req2 = backend_pb2.PredictOptions(Prompt="x", Tools=tools_json)
+        joined = "".join(contents(collect(s2, req2)))
+        self.assertEqual(
+            joined.count("The capital of France is Paris."), 1,
+            f"buffered content was duplicated: {joined!r}",
+        )

--- a/examples/vllm-bench/README.md
+++ b/examples/vllm-bench/README.md
@@ -1,0 +1,44 @@
+# vLLM streaming + tool-parser benchmark
+
+A small, self-contained Python script (stdlib only) that measures
+time-to-first-token (TTFT) for the vLLM backend's streaming path with
+a tool parser configured.
+
+## Why this exists
+
+When a vLLM tool parser is active and a streaming chat completion is requested,
+LocalAI used to buffer the full generation to prevent raw tool-call markup
+(e.g. `<tool_call>...`) from leaking as `delta.content`. That was correct
+for tool-call responses, but it turned plain-text responses into effectively
+non-streaming — the client received nothing until the model finished.
+
+With native parser-side streaming (`parser.extract_tool_calls_streaming`,
+implemented by every concrete vLLM 0.23+ tool parser), each delta can be
+classified per-token: emit as content, emit as a structured tool_call, or
+suppress. This benchmark shows the difference.
+
+## Two scenarios
+
+| Scenario | Request | Expected outcome |
+|---|---|---|
+| `tool_call` | "What is the weather in Paris? Please use the tool." | Model calls `get_weather`. `delta.tool_calls` chunks; no content leak. |
+| `plain_text` | "Explain in 3 short sentences what a hash table is. Do NOT call any tool." | Model writes prose. With the streaming parser, content streams progressively; without it, the entire response arrives in one chunk. |
+
+## What the script reports
+
+For each scenario, across N runs:
+
+- `ttf_content_s` — time until the first `delta.content` chunk
+- `ttf_tool_s` — time until the first `delta.tool_calls` chunk
+- `n_content_chunks` — total number of distinct content deltas (1 = bundled, >1 = streamed)
+- `n_tool_chunks` — total tool_call deltas
+- `total_s` — total wall-clock until `[DONE]`
+- `finish_reason` — `tool_calls` / `stop` / `length`
+
+## Usage
+
+```bash
+python ttft_streaming_tool_parser.py --url http://localhost:8080 --model my-coder --runs 3
+```
+
+JSON results are written to `ttft_bench_<label>.json` (default label: `run`).

--- a/examples/vllm-bench/README.md
+++ b/examples/vllm-bench/README.md
@@ -15,14 +15,20 @@ non-streaming — the client received nothing until the model finished.
 With native parser-side streaming (`parser.extract_tool_calls_streaming`,
 implemented by every concrete vLLM 0.23+ tool parser), each delta can be
 classified per-token: emit as content, emit as a structured tool_call, or
-suppress. This benchmark shows the difference.
+suppress.
 
-## Two scenarios
+## Three scenarios
 
 | Scenario | Request | Expected outcome |
 |---|---|---|
-| `tool_call` | "What is the weather in Paris? Please use the tool." | Model calls `get_weather`. `delta.tool_calls` chunks; no content leak. |
-| `plain_text` | "Explain in 3 short sentences what a hash table is. Do NOT call any tool." | Model writes prose. With the streaming parser, content streams progressively; without it, the entire response arrives in one chunk. |
+| `tool_call`         | "What is the weather in Paris? Please use the tool." | Model calls `get_weather`. `delta.tool_calls` chunks; no content leak. |
+| `plain_text_short`  | "Explain in 3 short sentences what a hash table is. Do NOT call any tool." | Model writes ~3 sentences. |
+| `plain_text_long`   | "Write a thorough 8-paragraph explanation of how Python's GIL works…" | Model writes ~1500 tokens of prose. |
+
+The **long scenario** is where the streaming/buffering difference is most
+dramatic: with the buffer-all path, the client sees nothing for 20+ seconds
+and then everything at once; with native streaming, the first token arrives
+in <100ms and the response flows progressively.
 
 ## What the script reports
 
@@ -30,10 +36,14 @@ For each scenario, across N runs:
 
 - `ttf_content_s` — time until the first `delta.content` chunk
 - `ttf_tool_s` — time until the first `delta.tool_calls` chunk
-- `n_content_chunks` — total number of distinct content deltas (1 = bundled, >1 = streamed)
+- `n_content_chunks` — total content deltas (1 = bundled, >>1 = streamed)
 - `n_tool_chunks` — total tool_call deltas
 - `total_s` — total wall-clock until `[DONE]`
 - `finish_reason` — `tool_calls` / `stop` / `length`
+
+The big tell is **`n_content_chunks` vs `total_s` ratio**:
+- Buffer-all: `n_content_chunks` ≈ 1, `ttf_content_s` ≈ `total_s` (one chunk at end)
+- Streaming: `n_content_chunks` ≈ token count, `ttf_content_s` ≈ first-token latency
 
 ## Usage
 

--- a/examples/vllm-bench/ttft_streaming_tool_parser.py
+++ b/examples/vllm-bench/ttft_streaming_tool_parser.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""
+TTFT benchmark for the vLLM backend's streaming + tool-parser path.
+
+Measures time-to-first-token (TTFT) for two scenarios against a running
+LocalAI instance with a vLLM-backed chat model:
+
+  1. tool_call  — request mentions a tool; model is expected to call it
+  2. plain_text — request offers a tool but explicitly asks for prose
+
+Useful to validate the difference between:
+  - the buffer-all path  (#10346):       plain_text TTFT ≈ total response time
+  - the native-streaming path (this PR): plain_text TTFT ≈ true first-token time
+
+Usage:
+  python ttft_streaming_tool_parser.py \\
+      --url http://localhost:8080 --model my-coder --runs 3
+
+The script is self-contained (stdlib only — urllib, json, time, argparse).
+"""
+import argparse
+import json
+import sys
+import time
+import urllib.request
+
+DEFAULT_TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "description": "Get current weather for a city",
+        "parameters": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    },
+}]
+
+SCENARIOS = [
+    {
+        "label": "tool_call",
+        "messages": [{"role": "user",
+                      "content": "What is the weather in Paris? Please use the tool."}],
+        "max_tokens": 80,
+    },
+    {
+        "label": "plain_text",
+        "messages": [{"role": "user",
+                      "content": "Explain in 3 short sentences what a hash table is. "
+                                 "Do NOT call any tool."}],
+        "max_tokens": 200,
+    },
+]
+
+
+def bench_one(url, model, messages, tools, max_tokens, timeout):
+    body = json.dumps({
+        "model": model,
+        "stream": True,
+        "tools": tools,
+        "messages": messages,
+        "max_tokens": max_tokens,
+    }).encode()
+    req = urllib.request.Request(
+        f"{url.rstrip('/')}/v1/chat/completions",
+        data=body, headers={"Content-Type": "application/json"},
+    )
+
+    t0 = time.perf_counter()
+    first_content = None
+    first_tool = None
+    n_content = 0
+    n_tool = 0
+    last = None
+    finish = None
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        for line in resp:
+            line = line.decode("utf-8", "replace").strip()
+            if not line.startswith("data: "):
+                continue
+            payload = line[6:]
+            if payload == "[DONE]":
+                break
+            try:
+                chunk = json.loads(payload)
+            except Exception:
+                continue
+            if not chunk.get("choices"):
+                continue
+            ch = chunk["choices"][0]
+            delta = ch.get("delta") or {}
+            now = time.perf_counter() - t0
+            if delta.get("content"):
+                if first_content is None:
+                    first_content = now
+                n_content += 1
+            if delta.get("tool_calls"):
+                if first_tool is None:
+                    first_tool = now
+                n_tool += 1
+            if ch.get("finish_reason"):
+                finish = ch["finish_reason"]
+            last = now
+    return {
+        "ttf_content_s": first_content,
+        "ttf_tool_s": first_tool,
+        "n_content_chunks": n_content,
+        "n_tool_chunks": n_tool,
+        "total_s": last,
+        "finish_reason": finish,
+    }
+
+
+def stats(values):
+    values = [v for v in values if v is not None]
+    if not values:
+        return "n/a"
+    return f"min={min(values):.3f}  avg={sum(values)/len(values):.3f}  max={max(values):.3f}"
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--url", default="http://localhost:8080",
+                   help="LocalAI base URL (default: %(default)s)")
+    p.add_argument("--model", default="coder", help="Model name (default: %(default)s)")
+    p.add_argument("--runs", type=int, default=3, help="Repetitions per scenario (default: %(default)s)")
+    p.add_argument("--timeout", type=int, default=120, help="Per-request timeout in seconds")
+    p.add_argument("--label", default="run",
+                   help="Tag for the JSON output file (default: %(default)s)")
+    args = p.parse_args()
+
+    print(f"=== TTFT Bench — {args.url}  model={args.model}  runs={args.runs} ===")
+    summary = {}
+    for sc in SCENARIOS:
+        print(f"\nScenario: {sc['label']}")
+        rows = []
+        for run in range(args.runs):
+            r = bench_one(args.url, args.model,
+                          sc["messages"], DEFAULT_TOOLS, sc["max_tokens"], args.timeout)
+            rows.append(r)
+            ttf_c = f"{r['ttf_content_s']:.3f}" if r["ttf_content_s"] is not None else "—"
+            ttf_t = f"{r['ttf_tool_s']:.3f}" if r["ttf_tool_s"] is not None else "—"
+            print(f"  run {run+1}/{args.runs}: "
+                  f"ttf_content={ttf_c}s  ttf_tool={ttf_t}s  "
+                  f"n_content={r['n_content_chunks']}  n_tool={r['n_tool_chunks']}  "
+                  f"total={r['total_s']:.2f}s  finish={r['finish_reason']}")
+        summary[sc["label"]] = rows
+
+    print("\n=== Summary (per scenario) ===")
+    for label, rows in summary.items():
+        print(f"[{label}]")
+        print(f"  ttf_content_s:    {stats(r['ttf_content_s'] for r in rows)}")
+        print(f"  ttf_tool_s:       {stats(r['ttf_tool_s']    for r in rows)}")
+        print(f"  n_content_chunks: {stats(r['n_content_chunks'] for r in rows)}")
+        print(f"  n_tool_chunks:    {stats(r['n_tool_chunks']    for r in rows)}")
+        print(f"  total_s:          {stats(r['total_s']        for r in rows)}")
+
+    out = f"ttft_bench_{args.label}.json"
+    with open(out, "w") as f:
+        json.dump(summary, f, indent=2)
+    print(f"\nSaved to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/vllm-bench/ttft_streaming_tool_parser.py
+++ b/examples/vllm-bench/ttft_streaming_tool_parser.py
@@ -2,15 +2,14 @@
 """
 TTFT benchmark for the vLLM backend's streaming + tool-parser path.
 
-Measures time-to-first-token (TTFT) for two scenarios against a running
-LocalAI instance with a vLLM-backed chat model:
+Three scenarios:
+  1. tool_call        — request mentions a tool; model is expected to call it
+  2. plain_text_short — request offers a tool but explicitly asks for ~3 sentences
+  3. plain_text_long  — same as above but asks for ~8 paragraphs (1500 tokens)
 
-  1. tool_call  — request mentions a tool; model is expected to call it
-  2. plain_text — request offers a tool but explicitly asks for prose
-
-Useful to validate the difference between:
-  - the buffer-all path  (#10346):       plain_text TTFT ≈ total response time
-  - the native-streaming path (this PR): plain_text TTFT ≈ true first-token time
+The long scenario shows the dramatic difference between buffering and
+streaming most clearly: with buffer-all, the client sees nothing for
+20+ seconds; with native streaming, the first token arrives in <100 ms.
 
 Usage:
   python ttft_streaming_tool_parser.py \\
@@ -45,11 +44,20 @@ SCENARIOS = [
         "max_tokens": 80,
     },
     {
-        "label": "plain_text",
+        "label": "plain_text_short",
         "messages": [{"role": "user",
                       "content": "Explain in 3 short sentences what a hash table is. "
                                  "Do NOT call any tool."}],
         "max_tokens": 200,
+    },
+    {
+        "label": "plain_text_long",
+        "messages": [{"role": "user",
+                      "content": "Write a thorough 8-paragraph explanation of how "
+                                 "Python's GIL works, including history, current "
+                                 "state, no-GIL build, and alternatives. Be "
+                                 "detailed. Do NOT call any tool."}],
+        "max_tokens": 1500,
     },
 ]
 
@@ -125,7 +133,7 @@ def main():
                    help="LocalAI base URL (default: %(default)s)")
     p.add_argument("--model", default="coder", help="Model name (default: %(default)s)")
     p.add_argument("--runs", type=int, default=3, help="Repetitions per scenario (default: %(default)s)")
-    p.add_argument("--timeout", type=int, default=120, help="Per-request timeout in seconds")
+    p.add_argument("--timeout", type=int, default=180, help="Per-request timeout in seconds")
     p.add_argument("--label", default="run",
                    help="Tag for the JSON output file (default: %(default)s)")
     args = p.parse_args()


### PR DESCRIPTION
**Description**

Follow-up to #10346: replace the buffer-all path with native progressive streaming.

When the vLLM backend has a `tool_parser` configured and a streaming chat
completion request includes `tools`, PR #10346 stops streaming any deltas
and surfaces parsed `tool_calls` (or the cleaned content) on the final chunk
only. This is correct for tool-call responses, but it turns the
plain-text-with-tools case into effectively non-streaming: the client
receives nothing until the model finishes.

Every concrete tool parser shipped with vLLM 0.23+ already implements
`extract_tool_calls_streaming` — including `qwen3coder`, `granite4`,
`deepseekv31`, `jamba`, `ernie45`, `hermes2pro`, `llama3_json`, `mistral`,
and ~30 more (verified by walking `vllm.tool_parsers.*` and checking each
class against `ToolParser.extract_tool_calls_streaming`). This PR delegates
to that interface for the streaming branch.

**E2E numbers** (qwen3_coder · NVIDIA GB10 / arm64 / vLLM 0.23.0, 3 runs avg)

| Scenario | Buffer-all (#10346) | This PR | Delta |
|---|---|---|---|
| Plain text (~70 tokens), TTFT content | 1.32 s | **0.226 s** | **5.8× faster** |
| Plain text (~70 tokens), content chunks | 2 | **71** | per-token stream |
| Plain text (~1100 tokens), TTFT content | ~18 s¹ | **0.221 s** | **~80× faster** |
| Plain text (~1100 tokens), content chunks | 1¹ | **~1135** | per-token stream |
| Tool call, TTFT tool | 0.51 s | 0.54 s² | unchanged |
| Tool call, raw markup leak | none ✓ | none ✓ | — |

¹ Buffer-all sends everything in the final chunk → `ttf_content ≈ total_time`.  
² First run includes cold-start (0.98 s); stabilises at ~0.54 s by run 3.

The long-text scenario is where the difference is dramatic: with buffer-all
the client sees nothing for ~18 seconds and then a 1100-token wall of text;
with native streaming the first token arrives in 0.22 s and the response
flows progressively. Total wall-clock is unchanged — only the perceived
reactivity changes.

**Bonus**: tool_call is now emitted as a proper OpenAI-style incremental
stream — `tool_calls[0].function.name` first, then `arguments` as a separate
delta — instead of one bundled chunk at the end:

```
chunk 1: tool_calls=[{id, type:function, function:{name:"get_weather", arguments:""}}]
chunk 2: tool_calls=[{function:{arguments:'{"city": "Paris"}'}}]
chunk 3: finish_reason="tool_calls"
```

**Fix shape**

- **Instantiate the tool parser before the streaming loop**, build a minimal
  `ChatCompletionRequest` (only `tools` is read by parsers), set
  `native_streaming` if `hasattr(tp_instance, "extract_tool_calls_streaming")`.
- **Inside the loop**, when `native_streaming` is on, call the parser's
  streaming method per delta with the full 7-parameter signature
  (`previous_text`, `current_text`, `delta_text`, `previous_token_ids`,
  `current_token_ids`, `delta_token_ids`, `request`). Map the returned
  `DeltaMessage` to `ChatDelta(content / reasoning_content / tool_calls)`.
  `None` → suppress this delta.
- **Fallback to buffer** when the streaming method raises (logged with the
  request id) or is absent (future Python backends, custom parsers). The
  existing post-loop `extract_tool_calls` block builds the final chunk —
  same correctness as a non-streaming response.
- **Buffer-fallback content flush**: when has_tool_parser is set and the
  parser found no tool call (plain text response), flush the buffered
  content as one content delta before the final metadata chunk, and clear
  `chat_delta.content` so the metadata chunk does not repeat it. This also
  fixes the trade-off in #10346 where plain-text-with-tools responses
  arrived empty.
- **No change** to the no-tool-parser path — per-delta content stream is
  byte-identical to the pre-#10346 baseline.

**Trade-offs / things to know**

| Concern | Status |
|---|---|
| New code surface (~80 lines vs ~4 in #10346) | 6 mock tests cover all paths; E2E verified |
| Per-delta `extract_tool_calls_streaming` CPU cost | Negligible vs. token generation; vLLM's own OpenAI frontend does the same |
| New import path `vllm.entrypoints.openai.chat_completion.protocol` | Wrapped in try/except; falls back to buffer if absent (no crash) |
| Parser exceptions mid-stream | Logged with request id; rest of stream uses buffer fallback; final chunk still correct |
| Tokens-list tracking per delta | O(N); trivial |
| **Reasoning + Tool parser composition** | Currently the reasoning parser runs post-stream. When *both* parsers are active and a model emits e.g. `<think>...</think><tool_call>...`, the streaming tool parser sees the reasoning markup as content. This is unchanged from #10346 (which had the same composition issue, just hidden by buffer-all). Treating reasoning-during-streaming properly is **out of scope** for this PR — see [#10000](https://github.com/mudler/LocalAI/pull/10000) for the post-stream reasoning side. |
| Backwards compatibility | Parser without streaming method → buffer fallback = #10346 behaviour. Non-tool-parser path → byte-identical to pre-#10346. |

**Tests** (`backend/python/vllm/test.py`, new class `TestStreamingToolParser`)

Six server-less mock tests that exercise `_predict(streaming=True)` directly:

1. Buffer fallback: tool call → no markup as content; tool_call name present
2. Buffer fallback: plain text → content delivered exactly once (no dupe)
3. Native streaming: plain text → content streams progressively
4. Native streaming: tool call → structured `tool_calls` emitted, no markup leak
5. Native streaming exception → graceful fallback, no leak, no crash
6. No tool parser → unchanged per-delta content stream (regression guard)

All six green on vLLM 0.23.0 (NVIDIA GB10 / arm64 / CUDA 13).

**Bench script — `examples/vllm-bench/`**

Self-contained stdlib-only TTFT benchmark with three scenarios (`tool_call`,
`plain_text_short`, `plain_text_long`). Reviewers can verify the
improvement on their own model:

```bash
python examples/vllm-bench/ttft_streaming_tool_parser.py \
    --url http://localhost:8080 --model my-coder --runs 3
```

The `plain_text_long` scenario (1500-token GIL explanation) shows the
buffering vs streaming difference most dramatically — see numbers above.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
