### PR TITLE
fix(whisperx): use whisperx.diarize.DiarizationPipeline with token kwarg

### DIFF
--- a/backend/python/whisperx/backend.py
+++ b/backend/python/whisperx/backend.py
@@ -79,6 +79,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
 
     def AudioTranscription(self, request, context):
         import whisperx
+        from whisperx.diarize import DiarizationPipeline
 
         resultSegments = []
         text = ""
@@ -106,8 +107,8 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             # Diarize if requested and HF token is available
             if request.diarize and self.hf_token:
                 if self.diarize_pipeline is None:
-                    self.diarize_pipeline = whisperx.DiarizationPipeline(
-                        use_auth_token=self.hf_token,
+                    self.diarize_pipeline = DiarizationPipeline(
+                        token=self.hf_token,
                         device=self.device,
                     )
                 diarize_segments = self.diarize_pipeline(audio)


### PR DESCRIPTION
## What

Fixes the WhisperX diarization path, which currently fails with:

```
AttributeError: module 'whisperx' has no attribute 'DiarizationPipeline'
```

returning HTTP 200 with an empty `text` whenever a transcription is requested with `diarize=true`.

## Why

The backend pins `whisperx @ git+https://github.com/m-bain/whisperX.git` (latest). Since WhisperX 3.6.0 the diarization API changed:

- `DiarizationPipeline` is no longer re-exported at the top level (`whisperx/__init__.py` only lazily exposes `load_model`, `load_audio`, `align`, `load_align_model`, `assign_word_speakers`, ...). It now lives in `whisperx.diarize`.
- Its constructor kwarg was renamed `use_auth_token` -> `token` (`DiarizationPipeline(model_name=None, token=None, device="cpu", cache_dir=None)`).

## Change

- Import `DiarizationPipeline` from `whisperx.diarize`.
- Pass the HF token via `token=` instead of `use_auth_token=`.

`whisperx.assign_word_speakers(...)` is still exported, so it is left unchanged. Two-line change, no behavior change beyond making diarization work again.

Fixes #10388

AI-assisted, human reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
