### PR TITLE
fix(nix flake): ensure nix flake builds successfully

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,5 @@
 {
   "nodes": {
-    "inference-defaults": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-ygWIkY2xiUEWqAZQM4/0vBz8vWd/RKX5VBj7EHovU14=",
-        "type": "file",
-        "url": "https://raw.githubusercontent.com/unslothai/unsloth/main/studio/backend/assets/configs/inference_defaults.json"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://raw.githubusercontent.com/unslothai/unsloth/main/studio/backend/assets/configs/inference_defaults.json"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1777578337,
@@ -30,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "inference-defaults": "inference-defaults",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,13 +4,9 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    inference-defaults = {
-      url = "https://raw.githubusercontent.com/unslothai/unsloth/main/studio/backend/assets/configs/inference_defaults.json";
-      flake = false;
-    };
   };
 
-  outputs = { self, nixpkgs, inference-defaults }:
+  outputs = { self, nixpkgs }:
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
@@ -44,8 +40,6 @@
 
           go mod edit -replace github.com/mudler/LocalAI/pkg/grpc/proto=./pkg/grpc/proto
 
-          mkdir -p core/config/gen_inference_defaults
-          cp ${inference-defaults} core/config/gen_inference_defaults/inference_defaults.json
           sed -i '/go:generate/d' core/config/inference_defaults.go || true
 
 	'';

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
 
  	src = ./.;
         proxyVendor = true;
-        vendorHash = "sha256-6f3adjGsoFXlUtXjBDHP4Mv9jKCOK3aeUXprm0EAVO8=";
+        vendorHash = "sha256-z3lxQS8mXFuJzvYamejwapwVEmLpeAoiO3ksUKb4I3Q=";
 
         nativeBuildInputs = with pkgs; [
           pkg-config cmake gcc protobuf go-protobuf protoc-gen-go protoc-gen-go-grpc

--- a/flake.nix
+++ b/flake.nix
@@ -24,8 +24,7 @@
           runHook postInstall
         '';
       };
-    in {
-      packages.${system}.default = pkgs.buildGoModule {
+      localai-unwrapped = pkgs.buildGoModule {
         pname = "localai";
         version = "custom";
 
@@ -67,6 +66,21 @@
         postInstall = ''
           [ -f $out/bin/local-ai ] && mv $out/bin/local-ai $out/bin/localai
         '';
+      };
+    in {
+      packages.${system} = {
+        localai-unwrapped = localai-unwrapped;
+
+        default = pkgs.buildFHSEnv {
+          name = "localai";
+          targetPkgs = pkgs: with pkgs; [
+            localai-unwrapped
+            bash
+            coreutils
+            gnugrep
+          ];
+          runScript = "${localai-unwrapped}/bin/localai";
+        };
       };
 
       devShells.${system}.default = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,20 @@
     let
       system = "x86_64-linux";
       pkgs = nixpkgs.legacyPackages.${system};
+      reactUi = pkgs.buildNpmPackage {
+        pname = "localai-react-ui";
+        version = "custom";
+        src = ./core/http/react-ui;
+        npmDepsHash = "sha256-G+bc1SajltRt4ZfkKNN1h6kFSmD0pCOR8MqRE6cKDLM=";
+        npmBuildScript = "build";
+
+        installPhase = ''
+          runHook preInstall
+          mkdir -p $out
+          cp -r dist $out/
+          runHook postInstall
+        '';
+      };
     in {
       packages.${system}.default = pkgs.buildGoModule {
         pname = "localai";
@@ -39,6 +53,9 @@
             $PROTO_SOURCE_DIR/*.proto
 
           go mod edit -replace github.com/mudler/LocalAI/pkg/grpc/proto=./pkg/grpc/proto
+
+          mkdir -p core/http/react-ui
+          cp -r ${reactUi}/dist core/http/react-ui/dist
 
           sed -i '/go:generate/d' core/config/inference_defaults.go || true
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,10 @@
         pname = "localai-react-ui";
         version = "custom";
         src = ./core/http/react-ui;
-        npmDepsHash = "sha256-G+bc1SajltRt4ZfkKNN1h6kFSmD0pCOR8MqRE6cKDLM=";
+        npmDeps = pkgs.importNpmLock {
+          npmRoot = ./core/http/react-ui;
+        };
+        npmConfigHook = pkgs.importNpmLock.npmConfigHook;
         npmBuildScript = "build";
 
         installPhase = ''


### PR DESCRIPTION
**Description**

This PR fixes the issue of nix flake not  building, and additionally also fixes a NixOS specific bug where in the backends folder when running scripts like run.sh (which is present in the cuda12-llama-cpp backend)



**Notes for Reviewers**
There were many reasons the flake was not building.

First inference_defaults.json was being fetched from unsloth by the flake and this caused a hash mismatch. I noticed that inference_defaults.json was already present in the repository and was regularly updated via github actions so I thought it was unecessary to fetch it via the flake and instead the inference_defaults.json that already exists in the repo can be used.

There was a hash mismatch for the Go vendorHash so I updated that with the correct hash.

The Go makefile required "core/http/react-ui/dist" to exist so I added a nix derivation for the react UI.

After this it was able to build successfully but some backends such as the "cuda12-llama-cpp" backend weren't working and there was an error running run.sh in this backend as they used the "#!/bin/bash" shebang and /bin/bash isn't present on NixOS due to it not following the Filesystem Hierarchy Standard (FHS). I fixed this by adding an FHS environment wrapper with bash, grep and coreutils to ensure that the script is able to run correctly.

To avoid hash mismatches in the future, I think it might be a good idea to have GitHub actions automatically update the vendorHash for the flake whenever go.mod or go.sum is updated


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.