### PR TITLE
fix(grpc): forward word-level timestamps in AudioTranscription wrapper

### DIFF
--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -243,6 +243,14 @@ func (s *server) AudioTranscription(ctx context.Context, in *pb.TranscriptReques
 		for _, t := range s.Tokens {
 			tks = append(tks, int32(t))
 		}
+		words := make([]*pb.TranscriptWord, 0, len(s.Words))
+		for _, w := range s.Words {
+			words = append(words, &pb.TranscriptWord{
+				Start: int64(w.Start),
+				End:   int64(w.End),
+				Text:  w.Text,
+			})
+		}
 		tresult.Segments = append(tresult.Segments,
 			&pb.TranscriptSegment{
 				Text:    s.Text,
@@ -251,6 +259,7 @@ func (s *server) AudioTranscription(ctx context.Context, in *pb.TranscriptReques
 				End:     int64(s.End),
 				Tokens:  tks,
 				Speaker: s.Speaker,
+				Words:   words,
 			})
 	}
 


### PR DESCRIPTION
## Problem

The gRPC server wrapper in `pkg/grpc/server.go` reconstructs `TranscriptSegment` messages when relaying `AudioTranscription` results from backends to the HTTP layer. The `Words` field was **not being copied**, causing all word-level timestamps to be silently dropped — regardless of which backend produced them.

This explains why:
- Issue #9306 reports `words` is always `None` in `verbose_json` output
- Backends like `faster-whisper`, `crispasr`, `qwen-asr`, and `nemo` that populate word-level timestamps never actually surface them through the API

## Root Cause

PR #9621 added the `TranscriptWord` proto message and `transcriptResultFromProto` (which reads `s.Words` on the server/HTTP side), but did **not** update the gRPC server wrapper (`pkg/grpc/server.go`) to forward the `Words` field when relaying results from the backend process.

## Fix

Copy `Words` from the backend result into the gRPC response `TranscriptSegment`, converting each `schema.TranscriptionWord` to `*proto.TranscriptWord`.

## Testing

Verified on a real deployment (LocalAI v4.4.3, Docker, RTX 3090) with the `crispasr` backend (`parakeet-tdt-0.6b-v3`):

**Before** (no words):
```json
{"segments": [{"id": 0, "start": 0.16, "end": 10.48, "text": "Been playing lots of Nordic Souls recently."}]}
```

**After** (21 words):
```json
{"segments": [{"id": 0, "start": 0.16, "end": 10.48, "text": "...", "words": [
  {"start": 0.16, "end": 0.4, "text": "Been"},
  {"start": 0.4, "end": 0.72, "text": "playing"},
  ...
]}]}
```

Fixes #9306