### PR TITLE
feat: send a LocalAI User-Agent on registry pulls

### DIFF
--- a/docs/content/getting-started/models.md
+++ b/docs/content/getting-started/models.md
@@ -131,6 +131,10 @@ local-ai run ollama://gemma:2b
 local-ai run oci://localai/phi-2:latest
 ```
 
+{{% notice note %}}
+When pulling models from Ollama or OCI registries, LocalAI identifies itself with a `LocalAI/<version>` `User-Agent` header so registry operators can attribute usage to LocalAI.
+{{% /notice %}}
+
 ### Run Models via URI
 
 To run models via URI, specify a URI to a model file or a configuration file when starting LocalAI. Valid syntax includes:

--- a/pkg/oci/blob.go
+++ b/pkg/oci/blob.go
@@ -11,6 +11,8 @@ import (
 
 	oras "oras.land/oras-go/v2"
 	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
 func FetchImageBlob(ctx context.Context, r, reference, dst string, statusReader func(ocispec.Descriptor) io.Writer) error {
@@ -27,6 +29,16 @@ func FetchImageBlob(ctx context.Context, r, reference, dst string, statusReader 
 		return fmt.Errorf("failed to create repository: %v", err)
 	}
 	repo.SkipReferrersGC = true
+
+	// Identify LocalAI to the registry. This mirrors oras' auth.DefaultClient
+	// (same retry policy) but advertises a LocalAI User-Agent instead of the
+	// library default.
+	client := &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.NewCache(),
+	}
+	client.SetUserAgent(UserAgent())
+	repo.Client = client
 
 	// https://github.com/oras-project/oras/blob/main/cmd/oras/internal/option/remote.go#L364
 	// https://github.com/oras-project/oras/blob/main/cmd/oras/root/blob/fetch.go#L136

--- a/pkg/oci/image.go
+++ b/pkg/oci/image.go
@@ -176,6 +176,7 @@ func GetImage(targetImage, targetPlatform string, auth *registrytypes.AuthConfig
 	opts := []remote.Option{
 		remote.WithTransport(tr),
 		remote.WithPlatform(*platform),
+		remote.WithUserAgent(UserAgent()),
 	}
 	if auth != nil {
 		opts = append(opts, remote.WithAuth(staticAuth{auth}))
@@ -223,6 +224,7 @@ func GetImageDigest(targetImage, targetPlatform string, auth *registrytypes.Auth
 	opts := []remote.Option{
 		remote.WithTransport(tr),
 		remote.WithPlatform(*platform),
+		remote.WithUserAgent(UserAgent()),
 	}
 	if auth != nil {
 		opts = append(opts, remote.WithAuth(staticAuth{auth}))

--- a/pkg/oci/ollama.go
+++ b/pkg/oci/ollama.go
@@ -47,6 +47,7 @@ func OllamaModelManifest(image string) (*Manifest, error) {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+	req.Header.Set("User-Agent", UserAgent())
 	client := httpclient.New(httpclient.WithFollowRedirects())
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/oci/useragent.go
+++ b/pkg/oci/useragent.go
@@ -1,0 +1,19 @@
+package oci
+
+import (
+	"fmt"
+
+	"github.com/mudler/LocalAI/internal"
+)
+
+// UserAgent returns the User-Agent string LocalAI sends on outbound registry
+// requests (OCI registries and Ollama). It identifies the client as LocalAI
+// and, when the binary was built with a version stamp, appends it so registries
+// can attribute client-side usage to LocalAI rather than to the generic
+// User-Agent of the underlying transport library.
+func UserAgent() string {
+	if internal.Version == "" {
+		return "LocalAI"
+	}
+	return fmt.Sprintf("LocalAI/%s", internal.Version)
+}

--- a/pkg/oci/useragent_test.go
+++ b/pkg/oci/useragent_test.go
@@ -1,0 +1,32 @@
+package oci_test
+
+import (
+	"github.com/mudler/LocalAI/internal"
+	. "github.com/mudler/LocalAI/pkg/oci"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("OCI", func() {
+	Context("UserAgent", func() {
+		var savedVersion string
+
+		BeforeEach(func() {
+			savedVersion = internal.Version
+		})
+
+		AfterEach(func() {
+			internal.Version = savedVersion
+		})
+
+		It("identifies as LocalAI when no version is stamped", func() {
+			internal.Version = ""
+			Expect(UserAgent()).To(Equal("LocalAI"))
+		})
+
+		It("appends the build version when one is stamped", func() {
+			internal.Version = "v3.2.1"
+			Expect(UserAgent()).To(Equal("LocalAI/v3.2.1"))
+		})
+	})
+})


### PR DESCRIPTION
**Description**

This PR implements #6258.

LocalAI pulls models from OCI registries, the Ollama registry, and OCI blob stores, but every outbound request used the underlying library's generic `User-Agent` (`go-containerregistry/…`, `oras-go`, …). As @mudler noted in the issue, *"we already support pulling images with Dockerhub in `pkg/oci/image.go` — however we don't have a specific User agent."* That makes it impossible for registry operators to attribute traffic to LocalAI (the motivation in the issue, mirroring llama.cpp's `User-Agent: "llama.cpp"`).

This adds a small `oci.UserAgent()` helper and wires it into **all three** registry-pull paths so every LocalAI request identifies itself consistently.

**What changed**

- **`pkg/oci/useragent.go`** (new): `UserAgent()` returns `LocalAI`, or `LocalAI/<version>` when the binary is built with a version stamp (`internal.Version`, set via the existing `-X …/internal.Version` ldflag).
- **`pkg/oci/image.go`**: adds `remote.WithUserAgent(UserAgent())` to the go-containerregistry image and digest pulls (`GetImage`, `GetImageDigest`).
- **`pkg/oci/ollama.go`**: sets a `User-Agent` header on the Ollama manifest request.
- **`pkg/oci/blob.go`**: sets a LocalAI `User-Agent` on the oras blob client. It mirrors oras' `auth.DefaultClient` (same `retry.DefaultClient` policy) — only the advertised `User-Agent` changes, so the HTTP/redirect behavior is unchanged.
- **Tests**: `pkg/oci/useragent_test.go` (Ginkgo/Gomega) covers both the unstamped (`LocalAI`) and stamped (`LocalAI/<version>`) cases.
- **Docs**: a short note under *Installing from OCI Registries* in `docs/content/getting-started/models.md`.

**Test output** (`go test ./pkg/oci/...`, full suite, hits the live registries):

\`\`\`
Ran 5 of 6 Specs in 66.958 seconds
SUCCESS! -- 5 Passed | 0 Failed | 0 Pending | 1 Skipped
\`\`\`

`go build`, `go vet`, `gofmt -l`, and `golangci-lint run ./pkg/oci/...` (v2.12.2) all pass with 0 issues.

**Notes for Reviewers**

`remote.WithUserAgent` appends `go-containerregistry/<ver>` to the UA, so OCI image pulls advertise e.g. `LocalAI/<version> go-containerregistry/v0.21.6`; the Ollama and oras paths advertise exactly `LocalAI/<version>`. Prepared with AI assistance (Claude Code), per the repo's AI Coding Assistants policy — see the `Assisted-by:` trailer; I have reviewed and tested every line.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.