### PR TITLE
fix(distributed): setup script

### DIFF
--- a/scripts/nats-auth-setup.sh
+++ b/scripts/nats-auth-setup.sh
@@ -1,19 +1,29 @@
 #!/usr/bin/env bash
-# Generate NATS account + service user JWTs for LocalAI distributed mode.
+# Generate NATS JWT authentication material and server configuration
+# for LocalAI distributed mode.
 #
 # Requires: nsc (https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nsc)
 #
-# Usage:
-#   ./scripts/nats-auth-setup.sh
+# Outputs:
+#   ./nats-keys/localai-nats.env
+#   ./nats-keys/localai-frontend.creds
+#   ./nats-keys/nats-auth.conf
+#   ./nats-keys/nats-server.conf
 #
-# Outputs operator/account seeds and a service user JWT suitable for:
-#   LOCALAI_NATS_ACCOUNT_SEED
-#   LOCALAI_NATS_SERVICE_JWT
+# Environment overrides:
+#   NATS_OPERATOR_NAME
+#   NATS_ACCOUNT_NAME
+#   NATS_SERVICE_USER
+#   NATS_KEYS_DIR
+
 #
-# Per-node worker JWTs are minted automatically by the frontend at registration
-# when LOCALAI_NATS_ACCOUNT_SEED is set.
+# LocalAI workers receive their own JWT and user seed when registering
+# with the frontend.
 
 set -euo pipefail
+
+# Ensure newly created secret files are private by default.
+umask 077
 
 if ! command -v nsc >/dev/null 2>&1; then
 	echo "nsc is required. Install from https://github.com/nats-io/nsc/releases" >&2
@@ -22,28 +32,189 @@ fi
 
 OPERATOR="${NATS_OPERATOR_NAME:-localai-operator}"
 ACCOUNT="${NATS_ACCOUNT_NAME:-localai}"
+SYSTEM_ACCOUNT="${NATS_SYSTEM_ACCOUNT_NAME:-SYS}"
 SERVICE_USER="${NATS_SERVICE_USER:-localai-frontend}"
+OUTPUT_DIR="${NATS_KEYS_DIR:-./nats-keys}"
 
-nsc add operator -n "$OPERATOR" --generate-signing-key
-nsc add account -n "$ACCOUNT"
-nsc add user -n "$SERVICE_USER" --account "$ACCOUNT"
+CREDS_FILE="$OUTPUT_DIR/${SERVICE_USER}.creds"
+ENV_FILE="$OUTPUT_DIR/localai-nats.env"
+AUTH_CONFIG_FILE="$OUTPUT_DIR/nats-auth.conf"
+SERVER_CONFIG_FILE="$OUTPUT_DIR/nats-server.conf"
 
-# Broad publish for frontend control plane (tighten with custom claims in production).
-nsc edit user -n "$SERVICE_USER" --account "$ACCOUNT" \
-	--allow-pub "nodes.>,gallery.>,agent.>,jobs.>,mcp.>,cache.>,prefixcache.>,finetune.>" \
-	--allow-sub "nodes.>,gallery.>,agent.>,jobs.>,mcp.>,cache.>,prefixcache.>,_INBOX.>"
+mkdir -p "$OUTPUT_DIR"
 
-KEYS_DIR="${NATS_KEYS_DIR:-./nats-keys}"
-mkdir -p "$KEYS_DIR"
-nsc generate creds -a "$ACCOUNT" -n "$SERVICE_USER" -o "$KEYS_DIR"
+echo "Configuring NATS operator: $OPERATOR"
 
-ACCOUNT_SEED=$(nsc describe account "$ACCOUNT" -o json | jq -r '.nats.private_key')
-SERVICE_JWT=$(cat "$KEYS_DIR/${ACCOUNT}/${SERVICE_USER}.jwt" 2>/dev/null || cat "$KEYS_DIR/${SERVICE_USER}.jwt")
+# Create the operator if it does not exist, otherwise select it.
+if nsc select operator "$OPERATOR" >/dev/null 2>&1; then
+	echo "[ OK ] using existing operator '$OPERATOR'"
+else
+	nsc add operator \
+		-n "$OPERATOR" \
+		--generate-signing-key
 
-echo ""
-echo "=== LocalAI NATS auth material ==="
-echo "LOCALAI_NATS_ACCOUNT_SEED=${ACCOUNT_SEED}"
-echo "LOCALAI_NATS_SERVICE_JWT=${SERVICE_JWT}"
-echo ""
-echo "Configure the NATS server with the generated operator/account JWTs under $KEYS_DIR"
-echo "and set LOCALAI_NATS_REQUIRE_AUTH=true on frontends and workers in production."
+	nsc select operator "$OPERATOR" >/dev/null
+fi
+
+# Create and assign the NATS system account.
+if nsc describe account \
+	-n "$SYSTEM_ACCOUNT" >/dev/null 2>&1; then
+	echo "[ OK ] using existing system account '$SYSTEM_ACCOUNT'"
+else
+	nsc add account -n "$SYSTEM_ACCOUNT"
+fi
+
+nsc edit operator \
+	--system-account "$SYSTEM_ACCOUNT"
+
+# Create the LocalAI account if it does not exist.
+if nsc describe account -n "$ACCOUNT" >/dev/null 2>&1; then
+	echo "[ OK ] using existing account '$ACCOUNT'"
+else
+	nsc add account -n "$ACCOUNT"
+fi
+
+nsc select account "$ACCOUNT" >/dev/null
+
+# Create the frontend service user if it does not exist.
+if nsc describe user \
+	-n "$SERVICE_USER" \
+	--account "$ACCOUNT" >/dev/null 2>&1; then
+	echo "[ OK ] using existing user '$SERVICE_USER'"
+else
+	nsc add user \
+		-n "$SERVICE_USER" \
+		--account "$ACCOUNT"
+fi
+
+# Frontend control-plane permissions.
+nsc edit user \
+	-n "$SERVICE_USER" \
+	--account "$ACCOUNT" \
+	--allow-pub "nodes.>,gallery.>,agent.>,staging.>,state.>,jobs.>,mcp.>,cache.>,prefixcache.>,finetune.>" \
+	--allow-sub "nodes.>,gallery.>,agent.>,staging.>,state.>,jobs.>,mcp.>,cache.>,prefixcache.>,_INBOX.>"
+
+# Generate a credentials file containing the frontend user JWT and seed.
+rm -f "$CREDS_FILE"
+
+nsc generate creds \
+	-a "$ACCOUNT" \
+	-n "$SERVICE_USER" \
+	-o "$CREDS_FILE"
+
+# Extract the frontend JWT from the credentials file.
+SERVICE_JWT="$(
+	awk '
+		/BEGIN NATS USER JWT/ {
+			capture = 1
+			next
+		}
+		/END NATS USER JWT/ {
+			capture = 0
+		}
+		capture
+	' "$CREDS_FILE" | tr -d '\r\n'
+)"
+
+# Extract the frontend user seed from the credentials file.
+SERVICE_SEED="$(
+	awk '
+		/BEGIN USER NKEY SEED/ {
+			capture = 1
+			next
+		}
+		/END USER NKEY SEED/ {
+			capture = 0
+		}
+		capture
+	' "$CREDS_FILE" | tr -d '\r\n'
+)"
+
+# Retrieve the seed belonging to this exact account rather than taking
+# the first account key found in the keystore.
+ACCOUNT_SEED="$(
+	nsc list keys \
+		--account "$ACCOUNT" \
+		--accounts \
+		--show-seeds |
+	awk -F '|' -v expected="$ACCOUNT" '
+		function trim(value) {
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+			return value
+		}
+
+		NF >= 3 {
+			entity = trim($2)
+			seed = trim($3)
+
+			if (entity == expected && seed ~ /^SA[A-Z0-9]+$/) {
+				print seed
+				exit
+			}
+		}
+	'
+)"
+
+# Validate all extracted values before writing output files.
+if [[ ! "$ACCOUNT_SEED" =~ ^SA[A-Z0-9]+$ ]]; then
+	echo "Unable to extract the account seed for '$ACCOUNT'." >&2
+	exit 1
+fi
+
+if [[ ! "$SERVICE_JWT" =~ ^eyJ ]]; then
+	echo "Unable to extract the service JWT from '$CREDS_FILE'." >&2
+	exit 1
+fi
+
+if [[ ! "$SERVICE_SEED" =~ ^SU[A-Z0-9]+$ ]]; then
+	echo "Unable to extract the service seed from '$CREDS_FILE'." >&2
+	exit 1
+fi
+
+# Generate the trusted operator and memory resolver configuration.
+# This contains public operator/account JWT claims, not the private seeds.
+nsc generate config \
+	--mem-resolver \
+	--config-file "$AUTH_CONFIG_FILE" \
+	--force
+
+# Generate the primary NATS server configuration.
+# The include path matches the Docker Compose mounts shown below.
+cat >"$SERVER_CONFIG_FILE" <<'NATS_CONFIG'
+server_name: localai-nats
+port: 4222
+http: 8222
+
+jetstream {
+	store_dir: /data/jetstream
+}
+
+include nats-auth.conf
+NATS_CONFIG
+
+# Generate the environment file consumed by the LocalAI frontend.
+cat >"$ENV_FILE" <<EOF
+LOCALAI_NATS_ACCOUNT_SEED=$ACCOUNT_SEED
+LOCALAI_NATS_SERVICE_JWT=$SERVICE_JWT
+LOCALAI_NATS_SERVICE_SEED=$SERVICE_SEED
+EOF
+
+# The environment and credentials files contain private seeds.
+chmod 600 "$CREDS_FILE" "$ENV_FILE"
+
+# These contain server configuration and public JWT claims.
+chmod 644 "$AUTH_CONFIG_FILE" "$SERVER_CONFIG_FILE"
+
+echo
+echo "=== LocalAI NATS JWT setup complete ==="
+echo
+echo "LocalAI environment: $ENV_FILE"
+echo "Service credentials: $CREDS_FILE"
+echo "NATS server config:   $SERVER_CONFIG_FILE"
+echo "NATS auth config:     $AUTH_CONFIG_FILE"
+echo
+echo "Keep '$ENV_FILE' and '$CREDS_FILE' secret."
+echo "Do not commit them to source control."
+echo
+echo "=== LocalAI NATS environment ==="
+cat "$ENV_FILE"


### PR DESCRIPTION
**Description**

This PR fixes #10550 

**Notes for Reviewers**
In this PR I updated the scripts to fix the 3 issues I ran into with the original, you can now also rerun it multiple times, it will also output the nats files so you can mount it into docker e.g

```
  nats:
    image: nats:2-alpine
    ports:
      - "4222:4222"
      - "8222:8222"
    command:
      - "-c"
      - "/etc/nats/nats-server.conf"
    volumes:
      - /mnt/user/appdata/local_ai/nats/nats-server.conf:/etc/nats/nats-server.conf:ro
      - /mnt/user/appdata/local_ai/nats/nats-auth.conf:/etc/nats/nats-auth.conf:ro
```

First time run
```
Configuring NATS operator: localai-operator
[ OK ] generated and stored operator key "OAETPG75FKOOGSV5IZVRZGM4PLPCZ7CP6KHDXMSY6L6WLKPZGXCZQMXW"
[ OK ] added operator "localai-operator"
[ OK ] When running your own nats-server, make sure they run at least version 2.2.0
[ OK ] generated and stored account key "AALMNQPSVL5T5ABYLODE75KFFF5CWBNVY44Z4OCX5THZ2J6IDMD4NXRN"
[ OK ] added account "SYS"
[ OK ] set system account "AALMNQPSVL5T5ABYLODE75KFFF5CWBNVY44Z4OCX5THZ2J6IDMD4NXRN"
[ OK ] edited operator "localai-operator"
[ OK ] generated and stored account key "AAFV7F2MB3D4ZMQKU7XATWUG7KJQWAYGF5CKTT5BBZMSAT7CG2KQ2TVV"
[ OK ] added account "localai"
[ OK ] generated and stored user key "UDQ43KCDNCRWPRUKRIFJ65IZA7H75FNYQRU5ZNRMWSFHOZSJIROJ4NDD"
[ OK ] generated user creds file `~/.local/share/nats/nsc/keys/creds/localai-operator/localai/localai-frontend.creds`
[ OK ] added user "localai-frontend" to account "localai"
[ OK ] added pub "nodes.>"
[ OK ] added pub "gallery.>"
[ OK ] added pub "agent.>"
[ OK ] added pub "jobs.>"
[ OK ] added pub "mcp.>"
[ OK ] added pub "cache.>"
[ OK ] added pub "prefixcache.>"
[ OK ] added pub "finetune.>"
[ OK ] added sub "nodes.>"
[ OK ] added sub "gallery.>"
[ OK ] added sub "agent.>"
[ OK ] added sub "jobs.>"
[ OK ] added sub "mcp.>"
[ OK ] added sub "cache.>"
[ OK ] added sub "prefixcache.>"
[ OK ] added sub "_INBOX.>"
[ OK ] generated user creds file `~/.local/share/nats/nsc/keys/creds/localai-operator/localai/localai-frontend.creds`
[ OK ] edited user "localai-frontend"
[ OK ] wrote credentials to `./nats-keys/localai-frontend.creds`
Success!! - generated `./nats-keys/localai-frontend.creds`
[ OK ] wrote server configuration to `/work/nats-keys/nats-auth.conf`
Success!! - generated `/work/nats-keys/nats-auth.conf`

=== LocalAI NATS JWT setup complete ===

LocalAI environment: ./nats-keys/localai-nats.env
Service credentials: ./nats-keys/localai-frontend.creds
NATS server config:   ./nats-keys/nats-server.conf
NATS auth config:     ./nats-keys/nats-auth.conf

Keep './nats-keys/localai-nats.env' and './nats-keys/localai-frontend.creds' secret.
Do not commit them to source control.

=== LocalAI NATS environment ===
LOCALAI_NATS_ACCOUNT_SEED=SAAMFB5PDFLI3M5GLUIV23DYPEVCGEBTWHO3LQEPM36F2PIR5NJMFHCTIU
LOCALAI_NATS_SERVICE_JWT=eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiJSRzNPNFBESEFMSFlWRFVXRlNZS080Mk5SWUZVNjVIQk1QWk82RzVDR1VLMjNTTllQUzJBIiwiaWF0IjoxNzgyNTUwMjYyLCJpc3MiOiJBQUZWN0YyTUIzRDRaTVFLVTdYQVRXVUc3S0pRV0FZR0Y1Q0tUVDVCQlpNU0FUN0NHMktRMlRWViIsIm5hbWUiOiJsb2NhbGFpLWZyb250ZW5kIiwic3ViIjoiVURRNDNLQ0ROQ1JXUFJVS1JJRko2NUlaQTdINzVGTllRUlU1Wk5STVdTRkhPWlNKSVJPSjROREQiLCJuYXRzIjp7InB1YiI6eyJhbGxvdyI6WyJhZ2VudC5cdTAwM2UiLCJjYWNoZS5cdTAwM2UiLCJmaW5ldHVuZS5cdTAwM2UiLCJnYWxsZXJ5Llx1MDAzZSIsImpvYnMuXHUwMDNlIiwibWNwLlx1MDAzZSIsIm5vZGVzLlx1MDAzZSIsInByZWZpeGNhY2hlLlx1MDAzZSJdfSwic3ViIjp7ImFsbG93IjpbIl9JTkJPWC5cdTAwM2UiLCJhZ2VudC5cdTAwM2UiLCJjYWNoZS5cdTAwM2UiLCJnYWxsZXJ5Llx1MDAzZSIsImpvYnMuXHUwMDNlIiwibWNwLlx1MDAzZSIsIm5vZGVzLlx1MDAzZSIsInByZWZpeGNhY2hlLlx1MDAzZSJdfSwic3VicyI6LTEsImRhdGEiOi0xLCJwYXlsb2FkIjotMSwidHlwZSI6InVzZXIiLCJ2ZXJzaW9uIjoyfX0.d89x-UT_RHtLBXeE9U0sOWrSwV6Cj9N_e0SY2p1PHKkHdFp4YPAQ4BOKTFVxA1BQ4zdJ1aC1nPL1aZglKTyHAA
LOCALAI_NATS_SERVICE_SEED=SUAOUPHM2DOYIPWO3LOGIR35I7TKX7YRPDS6NXCIDUTO5LKOKNFM5HV5ZQ
```

repeated runs
```
Configuring NATS operator: localai-operator
[ OK ] using existing operator 'localai-operator'
[ OK ] using existing system account 'SYS'
[ OK ] edited operator "localai-operator"
[ OK ] using existing account 'localai'
[ OK ] using existing user 'localai-frontend'
[ OK ] added pub "nodes.>"
[ OK ] added pub "gallery.>"
[ OK ] added pub "agent.>"
[ OK ] added pub "jobs.>"
[ OK ] added pub "mcp.>"
[ OK ] added pub "cache.>"
[ OK ] added pub "prefixcache.>"
[ OK ] added pub "finetune.>"
[ OK ] added sub "nodes.>"
[ OK ] added sub "gallery.>"
[ OK ] added sub "agent.>"
[ OK ] added sub "jobs.>"
[ OK ] added sub "mcp.>"
[ OK ] added sub "cache.>"
[ OK ] added sub "prefixcache.>"
[ OK ] added sub "_INBOX.>"
[ OK ] generated user creds file `~/.local/share/nats/nsc/keys/creds/localai-operator/localai/localai-frontend.creds`
[ OK ] edited user "localai-frontend"
[ OK ] wrote credentials to `./nats-keys/localai-frontend.creds`
Success!! - generated `./nats-keys/localai-frontend.creds`
[ OK ] wrote server configuration to `/work/nats-keys/nats-auth.conf`
Success!! - generated `/work/nats-keys/nats-auth.conf`

=== LocalAI NATS JWT setup complete ===

LocalAI environment: ./nats-keys/localai-nats.env
Service credentials: ./nats-keys/localai-frontend.creds
NATS server config:   ./nats-keys/nats-server.conf
NATS auth config:     ./nats-keys/nats-auth.conf

Keep './nats-keys/localai-nats.env' and './nats-keys/localai-frontend.creds' secret.
Do not commit them to source control.

=== LocalAI NATS environment ===
LOCALAI_NATS_ACCOUNT_SEED=SAAJUFUTLAIQ2PLDAR5MN5EIOZZRQQ6LQU6L3L3HG255NP3DM2XJOGG62A
LOCALAI_NATS_SERVICE_JWT=eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiI3U0lZMlM0VUFTWkZZT0UyTzIzTDY1RktDQUk3VUJHMlNKSEdNNVEySk1DT0YzMk8zU0tRIiwiaWF0IjoxNzgyNTUwMDg4LCJpc3MiOiJBQ05VSExES0ZZRTU1NEw1R1I3VFNQVTNHTVVKVVdPUEtPRkVXNkVFV0hOSVhGMlFCWkI2MllPRSIsIm5hbWUiOiJsb2NhbGFpLWZyb250ZW5kIiwic3ViIjoiVUI0RVdHSFZCRk1NTzIzVzNUTDNSNlRYNTdHRzI3VFlQNDdJTkVVVVJGU0NNUU4yRllLSzVXSkIiLCJuYXRzIjp7InB1YiI6eyJhbGxvdyI6WyJhZ2VudC5cdTAwM2UiLCJjYWNoZS5cdTAwM2UiLCJmaW5ldHVuZS5cdTAwM2UiLCJnYWxsZXJ5Llx1MDAzZSIsImpvYnMuXHUwMDNlIiwibWNwLlx1MDAzZSIsIm5vZGVzLlx1MDAzZSIsInByZWZpeGNhY2hlLlx1MDAzZSJdfSwic3ViIjp7ImFsbG93IjpbIl9JTkJPWC5cdTAwM2UiLCJhZ2VudC5cdTAwM2UiLCJjYWNoZS5cdTAwM2UiLCJnYWxsZXJ5Llx1MDAzZSIsImpvYnMuXHUwMDNlIiwibWNwLlx1MDAzZSIsIm5vZGVzLlx1MDAzZSIsInByZWZpeGNhY2hlLlx1MDAzZSJdfSwic3VicyI6LTEsImRhdGEiOi0xLCJwYXlsb2FkIjotMSwidHlwZSI6InVzZXIiLCJ2ZXJzaW9uIjoyfX0.8jE6F2nW86aMcKVl1FGs-pmfYdLHrZCaS_TuA3ib1EXwfQQO8sXfDBgwWzfdhDp4lFOcAX1rhMmmU_eEB-MACw
LOCALAI_NATS_SERVICE_SEED=SUAJ36D4MAVCHCZCIQ2ZRCL5NYU62WOF3INDFG234CH5JG2WWSMK7GMBJY
```


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.