### PR TITLE
fix(watchdog): force-kill stuck-busy backends instead of deadlocking the loader

### DIFF
--- a/pkg/model/loader.go
+++ b/pkg/model/loader.go
@@ -535,7 +535,19 @@ func (ml *ModelLoader) ShutdownModel(modelName string) error {
 	ml.mu.Lock()
 	defer ml.mu.Unlock()
 
-	return ml.deleteProcess(modelName)
+	return ml.deleteProcess(modelName, false)
+}
+
+// ShutdownModelForce stops a backend without waiting for an in-flight gRPC
+// call to finish first. It is used by the watchdog's busy-killer, which only
+// fires once a backend has been stuck on a call past the busy timeout — the
+// graceful ShutdownModel would block forever on that stuck call (while
+// holding ml.mu), preventing every other model load. See deleteProcess.
+func (ml *ModelLoader) ShutdownModelForce(modelName string) error {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+
+	return ml.deleteProcess(modelName, true)
 }
 
 func (ml *ModelLoader) CheckIsLoaded(s string) *Model {
@@ -577,7 +589,7 @@ func (ml *ModelLoader) checkIsLoaded(s string) *Model {
 			// Timeouts may mean the node is busy, so keep the model cached.
 			if isConnectionError(err) {
 				xlog.Warn("Remote model unreachable (connection error), removing from cache", "model", s, "error", err)
-				if delErr := ml.deleteProcess(s); delErr != nil {
+				if delErr := ml.deleteProcess(s, false); delErr != nil {
 					xlog.Error("error cleaning up remote model", "error", delErr, "model", s)
 				}
 				return nil
@@ -588,7 +600,7 @@ func (ml *ModelLoader) checkIsLoaded(s string) *Model {
 		if !process.IsAlive() {
 			xlog.Debug("GRPC Process is not responding", "model", s)
 			// stop and delete the process, this forces to re-load the model and re-create again the service
-			err := ml.deleteProcess(s)
+			err := ml.deleteProcess(s, false)
 			if err != nil {
 				xlog.Error("error stopping process", "error", err, "process", s)
 			}

--- a/pkg/model/process.go
+++ b/pkg/model/process.go
@@ -23,50 +23,67 @@ var (
 	modelNotFoundErr = errors.New("model not found")
 )
 
-func (ml *ModelLoader) deleteProcess(s string) error {
+// deleteProcess stops and removes a backend. The force flag trades a graceful
+// shutdown for a prompt one and is meant for the watchdog's busy-killer: a
+// backend that has been busy past the watchdog timeout is, by definition,
+// stuck in an in-flight gRPC call. Waiting for that call to finish before
+// stopping the process (the graceful path) would block forever — and since
+// deleteProcess runs under ml.mu, it would stall every other model load,
+// including the shared opus backend load at the start of every realtime
+// (WebRTC) session, hanging new connections at "Connected, waiting for
+// session...". The force path stops the process first, which drops the
+// in-flight call's gRPC connection and unblocks it, then cleans up.
+func (ml *ModelLoader) deleteProcess(s string, force bool) error {
 	model, ok := ml.store.Get(s)
 	if !ok {
 		xlog.Debug("Model not found", "model", s)
 		return modelNotFoundErr
 	}
 
-	retries := 1
-	for model.GRPC(false, ml.wd).IsBusy() {
-		xlog.Debug("Model busy. Waiting.", "model", s)
-		dur := time.Duration(retries*2) * time.Second
-		if dur > retryTimeout {
-			dur = retryTimeout
-		}
-		time.Sleep(dur)
-		retries++
+	if !force {
+		retries := 1
+		for model.GRPC(false, ml.wd).IsBusy() {
+			xlog.Debug("Model busy. Waiting.", "model", s)
+			dur := time.Duration(retries*2) * time.Second
+			if dur > retryTimeout {
+				dur = retryTimeout
+			}
+			time.Sleep(dur)
+			retries++
 
-		if retries > 10 && forceBackendShutdown {
-			xlog.Warn("Model is still busy after retries. Forcing shutdown.", "model", s, "retries", retries)
-			break
+			if retries > 10 && forceBackendShutdown {
+				xlog.Warn("Model is still busy after retries. Forcing shutdown.", "model", s, "retries", retries)
+				break
+			}
 		}
 	}
 
-	xlog.Debug("Deleting process", "model", s)
+	xlog.Debug("Deleting process", "model", s, "force", force)
 
 	// Run unload hooks (e.g. close MCP sessions)
 	for _, hook := range ml.onUnloadHooks {
 		hook(s)
 	}
 
-	// Free GPU resources before stopping the process to ensure VRAM is released.
-	// Free is optional: backends that don't override it (the generated stub, many
-	// Python/external backends, or a federation proxy in distributed mode) return
-	// gRPC Unimplemented. That is expected, not a failure — VRAM is reclaimed when
-	// the process is stopped below, or by the remote unloader for remote backends —
-	// so don't surface it as an error.
-	xlog.Debug("Calling Free() to release GPU resources", "model", s)
-	if err := model.GRPC(false, ml.wd).Free(context.Background()); err != nil {
-		if grpcerrors.IsUnimplemented(err) {
-			xlog.Debug("Backend does not implement Free(); GPU release handled on process stop", "model", s)
-		} else {
-			// Now that the expected Unimplemented case is filtered out above, a
-			// remaining error is a genuine failure to release VRAM — surface it.
-			xlog.Error("Error freeing GPU resources", "error", err, "model", s)
+	// Free GPU resources before stopping the process to ensure VRAM is
+	// released. Skipped on force-shutdown: a stuck-busy backend won't answer
+	// a Free RPC (it's hung on the same stuck call), and stopping the
+	// process releases its VRAM anyway. Free is optional: backends that
+	// don't override it (the generated stub, many Python/external backends,
+	// or a federation proxy in distributed mode) return gRPC Unimplemented.
+	// That is expected, not a failure — VRAM is reclaimed when the process
+	// is stopped below, or by the remote unloader for remote backends — so
+	// don't surface it as an error.
+	if !force {
+		xlog.Debug("Calling Free() to release GPU resources", "model", s)
+		if err := model.GRPC(false, ml.wd).Free(context.Background()); err != nil {
+			if grpcerrors.IsUnimplemented(err) {
+				xlog.Debug("Backend does not implement Free(); GPU release handled on process stop", "model", s)
+			} else {
+				// Now that the expected Unimplemented case is filtered out above, a
+				// remaining error is a genuine failure to release VRAM — surface it.
+				xlog.Error("Error freeing GPU resources", "error", err, "model", s)
+			}
 		}
 	}
 
@@ -115,7 +132,7 @@ func (ml *ModelLoader) StopGRPC(filter GRPCProcessFilter) error {
 		return true
 	})
 	for _, k := range toDelete {
-		e := ml.deleteProcess(k)
+		e := ml.deleteProcess(k, false)
 		err = errors.Join(err, e)
 	}
 	return err

--- a/pkg/model/watchdog.go
+++ b/pkg/model/watchdog.go
@@ -62,6 +62,11 @@ type WatchDog struct {
 
 type ProcessManager interface {
 	ShutdownModel(modelName string) error
+	// ShutdownModelForce stops the backend without waiting for an in-flight
+	// gRPC call to finish. Used when the watchdog evicts a backend that is
+	// stuck busy: the graceful ShutdownModel would block on that stuck call
+	// (while holding the loader's mutex), stalling every other model load.
+	ShutdownModelForce(modelName string) error
 }
 
 // NewWatchDog creates a new WatchDog with the provided options.
@@ -342,6 +347,17 @@ type modelUsageInfo struct {
 	sizeBytes int64 // on-disk file size; 0 if unknown
 }
 
+// evictionTarget is a model selected for eviction, retaining whether it was busy
+// at selection time. A busy target must be shut down via ShutdownModelForce:
+// the graceful path waits for its in-flight gRPC call to finish, but a busy
+// eviction only happens when that call is stuck (busy-killer) or the operator
+// opted into forceEvictionWhenBusy — either way, waiting would deadlock while
+// holding the loader mutex.
+type evictionTarget struct {
+	model   string
+	wasBusy bool
+}
+
 // EnforceLRULimitResult contains the result of LRU enforcement
 type EnforceLRULimitResult struct {
 	EvictedCount int  // Number of models successfully evicted
@@ -410,13 +426,10 @@ func (wd *WatchDog) EnforceLRULimit(pendingLoads int) EnforceLRULimitResult {
 	needMore := len(modelsToShutdown) < modelsToEvict && skippedBusyCount > 0
 	wd.Unlock()
 
-	// Now shutdown models without holding the watchdog lock to prevent deadlock
-	for _, model := range modelsToShutdown {
-		if err := wd.pm.ShutdownModel(model); err != nil {
-			xlog.Error("[WatchDog] error shutting down model during LRU eviction", "error", err, "model", model)
-		}
-		xlog.Debug("[WatchDog] LRU eviction complete", "model", model)
-	}
+	// Now shutdown models without holding the watchdog lock to prevent
+	// deadlock. Busy targets go through the force path so the loader doesn't
+	// wait on their stuck in-flight call (which would re-deadlock here).
+	wd.shutdownEvicted(modelsToShutdown, "LRU eviction")
 
 	if needMore {
 		xlog.Warn("[WatchDog] LRU eviction incomplete", "evicted", len(modelsToShutdown), "needed", modelsToEvict, "skippedBusy", skippedBusyCount, "reason", "some models are busy with active API calls")
@@ -431,9 +444,10 @@ func (wd *WatchDog) EnforceLRULimit(pendingLoads int) EnforceLRULimitResult {
 // collectEvictionsLocked walks `candidates` (already in eviction order) and
 // untracks up to `maxToEvict` models that are eligible for eviction. Pinned
 // models are always skipped; busy models are skipped unless `force` is true.
-// Returns the names of evicted models and the number skipped because they
-// were busy. Must be called with wd.Lock() held.
-func (wd *WatchDog) collectEvictionsLocked(candidates []modelUsageInfo, maxToEvict int, force bool) (evicted []string, skippedBusy int) {
+// Returns the evicted models (with their busy state at selection time) and
+// the number skipped because they were busy. Must be called with wd.Lock()
+// held.
+func (wd *WatchDog) collectEvictionsLocked(candidates []modelUsageInfo, maxToEvict int, force bool) (evicted []evictionTarget, skippedBusy int) {
 	for i := 0; len(evicted) < maxToEvict && i < len(candidates); i++ {
 		m := candidates[i]
 		if wd.pinnedModels[m.model] {
@@ -447,10 +461,29 @@ func (wd *WatchDog) collectEvictionsLocked(candidates []modelUsageInfo, maxToEvi
 			continue
 		}
 		xlog.Info("[WatchDog] evicting model", "model", m.model, "busy", isBusy)
-		evicted = append(evicted, m.model)
+		evicted = append(evicted, evictionTarget{model: m.model, wasBusy: isBusy})
 		wd.untrack(m.address)
 	}
 	return evicted, skippedBusy
+}
+
+// shutdownEvicted shuts down each evicted model, using the force path for any
+// that were busy at selection time so a stuck in-flight call doesn't deadlock
+// the graceful ShutdownModel (which waits for that call while holding the
+// loader's mutex).
+func (wd *WatchDog) shutdownEvicted(targets []evictionTarget, label string) {
+	for _, t := range targets {
+		var err error
+		if t.wasBusy {
+			err = wd.pm.ShutdownModelForce(t.model)
+		} else {
+			err = wd.pm.ShutdownModel(t.model)
+		}
+		if err != nil {
+			xlog.Error("[WatchDog] error shutting down model during "+label, "error", err, "model", t.model, "busy", t.wasBusy)
+		}
+		xlog.Debug("[WatchDog] "+label+" complete", "model", t.model, "busy", t.wasBusy)
+	}
 }
 
 // EnforceGroupExclusivity evicts every loaded model that shares at least one
@@ -502,12 +535,7 @@ func (wd *WatchDog) EnforceGroupExclusivity(requestedModel string) EnforceLRULim
 	needMore := len(modelsToShutdown) < len(conflicts)
 	wd.Unlock()
 
-	for _, m := range modelsToShutdown {
-		if err := wd.pm.ShutdownModel(m); err != nil {
-			xlog.Error("[WatchDog] error shutting down model during group eviction", "error", err, "model", m)
-		}
-		xlog.Debug("[WatchDog] Group eviction complete", "model", m)
-	}
+	wd.shutdownEvicted(modelsToShutdown, "group eviction")
 
 	if needMore {
 		xlog.Warn("[WatchDog] Group eviction incomplete", "requested", requestedModel, "evicted", len(modelsToShutdown), "needed", len(conflicts), "skippedBusy", skippedBusyCount, "reason", "some conflicts are busy or pinned")
@@ -623,12 +651,19 @@ func (wd *WatchDog) checkBusy() {
 	}
 	wd.Unlock()
 
-	// Now shutdown models without holding the watchdog lock to prevent deadlock
+	// The busy-killer targets backends whose in-flight gRPC call has been
+	// stuck past the busy timeout. Use the force path so the loader stops
+	// the process FIRST (dropping the stuck call's gRPC connection) instead
+	// of waiting for that call to finish — the graceful path would block on
+	// that stuck call while holding the loader mutex and stall every other
+	// model load (notably the opus backend load at the start of every
+	// realtime WebRTC session, which hangs new sessions at "Connected,
+	// waiting for session...").
 	for _, model := range modelsToShutdown {
-		if err := wd.pm.ShutdownModel(model); err != nil {
+		if err := wd.pm.ShutdownModelForce(model); err != nil {
 			xlog.Error("[watchdog] error shutting down model", "error", err, "model", model)
 		}
-		xlog.Debug("[WatchDog] model shut down", "model", model)
+		xlog.Debug("[WatchDog] busy model shut down", "model", model)
 	}
 }
 
@@ -743,10 +778,20 @@ func (wd *WatchDog) evictLRUModel() {
 
 	xlog.Info("[WatchDog] Memory reclaimer evicting LRU model", "model", lruModel.model, "lastUsed", lruModel.lastUsed)
 
+	// A busy target only gets here when forceEvictionWhenBusy is true, i.e.
+	// the operator accepted evicting models with active calls. Route it
+	// through the force path so the loader stops the process first instead
+	// of blocking on the stuck in-flight call while holding its mutex.
+	_, wasBusy := wd.busyTime[lruModel.address]
+
 	wd.Unlock()
 
 	// Shutdown the model
-	if err := wd.pm.ShutdownModel(lruModel.model); err != nil && err != modelNotFoundErr {
+	shutdown := wd.pm.ShutdownModel
+	if wasBusy {
+		shutdown = wd.pm.ShutdownModelForce
+	}
+	if err := shutdown(lruModel.model); err != nil && err != modelNotFoundErr {
 		xlog.Error("[WatchDog] error shutting down model during memory reclamation", "error", err, "model", lruModel.model)
 	} else {
 		// Untrack the model

--- a/pkg/model/watchdog_test.go
+++ b/pkg/model/watchdog_test.go
@@ -13,6 +13,8 @@ import (
 type mockProcessManager struct {
 	mu             sync.Mutex
 	shutdownCalls  []string
+	forceCalls     []string
+	gracefulCalls  []string
 	shutdownErrors map[string]error
 }
 
@@ -27,6 +29,18 @@ func (m *mockProcessManager) ShutdownModel(modelName string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.shutdownCalls = append(m.shutdownCalls, modelName)
+	m.gracefulCalls = append(m.gracefulCalls, modelName)
+	if err, ok := m.shutdownErrors[modelName]; ok {
+		return err
+	}
+	return nil
+}
+
+func (m *mockProcessManager) ShutdownModelForce(modelName string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.shutdownCalls = append(m.shutdownCalls, modelName)
+	m.forceCalls = append(m.forceCalls, modelName)
 	if err, ok := m.shutdownErrors[modelName]; ok {
 		return err
 	}
@@ -38,6 +52,14 @@ func (m *mockProcessManager) getShutdownCalls() []string {
 	defer m.mu.Unlock()
 	result := make([]string, len(m.shutdownCalls))
 	copy(result, m.shutdownCalls)
+	return result
+}
+
+func (m *mockProcessManager) getForceShutdownCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]string, len(m.forceCalls))
+	copy(result, m.forceCalls)
 	return result
 }
 
@@ -663,6 +685,35 @@ var _ = Describe("WatchDog", func() {
 			shutdowns := pm.getShutdownCalls()
 			Expect(shutdowns).To(ContainElement("model2"))
 			Expect(shutdowns).ToNot(ContainElement("model1"))
+		})
+	})
+
+	Context("Busy Killer", func() {
+		It("force-shuts down a model that is stuck busy past the busy timeout", func() {
+			// Regression: a backend stuck on an in-flight gRPC call must be
+			// killed via the force path (stop the process first), not the
+			// graceful one (wait for the stuck call to finish, which would
+			// deadlock while holding the loader mutex and stall every other
+			// model load — e.g. the opus backend load at the start of every
+			// realtime WebRTC session, hanging new "Connected, waiting for
+			// session..." connections).
+			wd = model.NewWatchDog(
+				model.WithProcessManager(pm),
+				model.WithBusyTimeout(10*time.Millisecond),
+				model.WithBusyCheck(true),
+				model.WithWatchdogInterval(20*time.Millisecond),
+			)
+
+			wd.AddAddressModelMap("addr1", "stuckModel")
+			wd.Mark("addr1") // busy — simulates an in-flight gRPC call
+
+			go wd.Run()
+			defer wd.Shutdown()
+
+			Eventually(func() []string {
+				return pm.getForceShutdownCalls()
+			}, "300ms", "10ms").Should(ContainElement("stuckModel"))
+			Expect(pm.getShutdownCalls()).To(ContainElement("stuckModel"))
 		})
 	})
 


### PR DESCRIPTION
## Problem

With the watchdog enabled, the **first** realtime (Talk) WebRTC session works, but the **second** connection hangs at *"Connected, waiting for session..."*. The logs keep printing the watchdog's busy / *"active connection"* line (and a VAD-already-loaded message) forever, and no further realtime session starts.

Fixes #10391

## Root cause

When the watchdog's busy-killer decides a backend has been busy past the busy timeout, it shuts it down via `ModelLoader.ShutdownModel` → `deleteProcess`. That path grabs `ml.mu` and then **waits for `IsBusy()` to clear BEFORE stopping the process**:

```go
func (ml *ModelLoader) deleteProcess(s string) error {
	...
	for model.GRPC(false, ml.wd).IsBusy() {   // blocks while ml.mu is held
		time.Sleep(...)
	}
	...
	process.Stop()
}
```

But a backend that exceeds the busy timeout is, by definition, **stuck on an in-flight gRPC call**, so the graceful wait never returns. `ml.mu` is held forever, and every subsequent `ml.Load` blocks — including the shared **opus** backend load that runs at the start of every realtime (WebRTC) session (`RealtimeCalls` → `application.ModelLoader().Load(...)`). New realtime connections therefore hang at *"Connected, waiting for session..."* until the server is restarted. The repeated "vad already loaded" log line is the watchdog re-logging the busy model that nothing can touch while `ml.mu` is wedged.

## Fix

Add a **force** shutdown path (`ShutdownModelForce` / `deleteProcess(force=true)`) that stops the process **FIRST** — dropping the stuck call's gRPC connection and unblocking it — instead of waiting on it, and skips the `Free()` RPC (a stuck-busy backend won't answer it; stopping the process releases its VRAM anyway).

Route the watchdog's in-place evictions through the force path, since those only run on backends that are busy:
- `checkBusy` (busy-killer) → `ShutdownModelForce`
- `EnforceLRULimit` / `EnforceGroupExclusivity` → force for busy targets, graceful for idle ones
- `evictLRUModel` (memory reclaimer) → force for busy targets

Graceful behaviour for idle timeouts and user/initiated unloads is unchanged.

## Verification

- `go build ./core/... ./pkg/... ./cmd/... ./internal/...` ✅
- `go test ./pkg/model/` ✅ (114 specs, incl. new regression test)
- new regression test: the watchdog busy-killer uses `ShutdownModelForce` (not the graceful `ShutdownModel`)
- `gofmt` clean

## Files

- `pkg/model/process.go` — `deleteProcess(s, force bool)`; skip the `IsBusy()` wait and `Free()` on force; stop the process first.
- `pkg/model/loader.go` — add `ShutdownModelForce`; thread `force=false` through existing `deleteProcess` callers.
- `pkg/model/watchdog.go` — `ProcessManager` gains `ShutdownModelForce`; `evictionTarget` carries busy state; `checkBusy`/LRU/group/memory busy evictions use the force path.
- `pkg/model/watchdog_test.go` — mock PM implements `ShutdownModelForce` + regression spec.