### PR TITLE
fix(functions): avoid quadratic-time debug logging in CleanupLLMResult / ParseFunctionCall

### DIFF
--- a/pkg/functions/parse.go
+++ b/pkg/functions/parse.go
@@ -252,8 +252,25 @@ func (g FunctionsConfig) GrammarOptions() []func(o *grammars.GrammarOption) {
 	return opts
 }
 
+// truncForLog returns a length+head-truncated view of s for debug logging.
+//
+// CleanupLLMResult / ParseFunctionCall are invoked once per streaming chunk
+// with the *full accumulated* LLM result so far (see
+// core/http/endpoints/openai/chat_stream_workers.go). Logging the full
+// argument on every call gives O(N^2) total log volume across a single
+// generation, which under LOG_LEVEL=debug has been observed to fill disks
+// and stall the host during long streaming sessions. Logging only the
+// length plus a fixed-size head bounds per-call output to a constant.
+func truncForLog(s string) string {
+	const maxHead = 200
+	if len(s) <= maxHead {
+		return s
+	}
+	return s[:maxHead] + "...(truncated)"
+}
+
 func CleanupLLMResult(llmresult string, functionConfig FunctionsConfig) string {
-	xlog.Debug("LLM result", "result", llmresult)
+	xlog.Debug("LLM result", "len", len(llmresult), "head", truncForLog(llmresult))
 
 	for _, item := range functionConfig.ReplaceLLMResult {
 		k, v := item.Key, item.Value
@@ -261,7 +278,7 @@ func CleanupLLMResult(llmresult string, functionConfig FunctionsConfig) string {
 		re := regexp.MustCompile(k)
 		llmresult = re.ReplaceAllString(llmresult, v)
 	}
-	xlog.Debug("LLM result(processed)", "result", llmresult)
+	xlog.Debug("LLM result(processed)", "len", len(llmresult), "head", truncForLog(llmresult))
 
 	return llmresult
 }
@@ -913,7 +930,7 @@ func parseParameterValue(paramValue string, format *XMLToolCallFormat) any {
 
 func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncCallResults {
 
-	xlog.Debug("LLM result", "result", llmresult)
+	xlog.Debug("LLM result", "len", len(llmresult), "head", truncForLog(llmresult))
 
 	for _, item := range functionConfig.ReplaceFunctionResults {
 		k, v := item.Key, item.Value
@@ -921,7 +938,7 @@ func ParseFunctionCall(llmresult string, functionConfig FunctionsConfig) []FuncC
 		re := regexp.MustCompile(k)
 		llmresult = re.ReplaceAllString(llmresult, v)
 	}
-	xlog.Debug("LLM result(function cleanup)", "result", llmresult)
+	xlog.Debug("LLM result(function cleanup)", "len", len(llmresult), "head", truncForLog(llmresult))
 
 	functionNameKey := defaultFunctionNameKey
 	functionArgumentsKey := defaultFunctionArgumentsKey


### PR DESCRIPTION
## What

`pkg/functions/parse.go::CleanupLLMResult` and `ParseFunctionCall` both `xlog.Debug` the full `llmresult` string twice per call (on entry and after the regex replace loop). The streaming chat path (`core/http/endpoints/openai/chat_stream_workers.go:359`) calls `CleanupLLMResult` once per streaming delta chunk with the **full accumulated** result so far. For an N-chunk generation this means roughly `chunk_size * N^2` bytes of debug output total — quadratic in the number of chunks.

## Why this matters

Under `LOG_LEVEL=debug` I observed this drive a LocalAI container's log volume to about **96 GiB during a single ~50K-token streaming session** (SGLang-via-LocalAI backend on a DGX Spark / GB10, sm_121). The resulting disk pressure interacted with the streaming hot loop on the same filesystem and contributed to a host-wide hard hang. Workaround was setting `LOG_LEVEL=info`, but the quadratic shape is a foot-gun for anyone enabling debug intentionally for field diagnostics — it's not obvious from the code that a single Debug-level field grows superlinearly with response length.

## The fix

Replace the four result-content debug arguments with `len(...)` plus a fixed-size head (200 bytes via a new local `truncForLog` helper), bounding per-call output to a constant. The debug signal stays useful in practice:

- the **length** field lets you observe growth/saturation
- the **first 200 chars** are usually enough to identify *which* generation is in flight (system prompt prefix or tool-call XML opener)

The `Replacing` debug entries inside the replacement loop are unchanged — they are linear in the number of configured `ReplaceLLMResult` entries, not in the result length, so they don't accumulate.

Same fix applied to `ParseFunctionCall` (mirrors the same pattern, called from the same hot streaming path).

## Compatibility

No API change. No behaviour change for `LOG_LEVEL != debug` (the default). Only the *form* of two log records changes when debug is enabled.

## Verification

I don't have a Go toolchain on the host where I wrote this, so I haven't run `go test ./pkg/functions/...` locally — the change is intentionally small (4 logger arg-tuples + one helper, all in one file) and CI here will catch anything I missed. Happy to add a regression test that asserts the per-call log payload is bounded if a maintainer thinks that's worth it.