### PR TITLE
fix(launcher): keep data/config under ~/.localai (#10610)

### DIFF
--- a/cmd/launcher/internal/launcher.go
+++ b/cmd/launcher/internal/launcher.go
@@ -207,12 +207,20 @@ func (l *Launcher) StartLocalAI() error {
 	}
 
 	// Build command arguments
+	dataPath := l.GetDataPath()
 	args := []string{
 		"run",
 		"--models-path", l.config.ModelsPath,
 		"--backends-path", l.config.BackendsPath,
 		"--address", l.config.Address,
 		"--log-level", l.config.LogLevel,
+		// Keep persistent data and dynamic config under the launcher's data
+		// directory (~/.localai) rather than letting the server resolve them
+		// to ${basepath}/{data,configuration}. ${basepath} expands to the
+		// launcher process's CWD (often the user's home root), which puts
+		// ~/data and ~/configuration outside ~/.localai. See #10610.
+		"--data-path", filepath.Join(dataPath, "data"),
+		"--localai-config-dir", filepath.Join(dataPath, "configuration"),
 	}
 
 	l.localaiCmd = exec.CommandContext(l.ctx, binaryPath, args...)


### PR DESCRIPTION
## What

When the desktop **Launcher** starts the server, it only passes `--models-path`, `--backends-path`, `--address`, and `--log-level`. It never sets `--data-path` or the dynamic config dir, so the server falls back to its defaults:

```go
// core/cli/run.go
DataPath         ... default:"${basepath}/data"
LocalaiConfigDir ... default:"${basepath}/configuration"
```

`${basepath}` is `kong.ExpandPath(".")` (`cmd/local-ai/main.go`), i.e. the **launcher process's current working directory**. The launcher never sets `.Dir` on the `exec.Command`, so the child inherits the launcher GUI's CWD — commonly the user's home root. The result is `~/data` and `~/configuration` created outside `~/.localai`, and the agent pool's `stateDir` (`core/services/agentpool/agent_pool.go`, `cmp.Or(cfg.StateDir, appConfig.DataPath, ...)`) resolves to `~/data`:

```
INFO  Agent pool started ... stateDir="/home/<user>/data"
```

This is inconsistent with `--models-path`/`--backends-path`, which the launcher already roots under `~/.localai`, and with the launcher's own `GetDataPath()` (which returns `~/.localai`).

Fixes #10610.

## Fix

Pass `--data-path` and `--localai-config-dir` explicitly from `StartLocalAI()`, rooted at the launcher's own data directory (`GetDataPath()` → `~/.localai`):

```go
dataPath := l.GetDataPath()
args := []string{
    "run",
    "--models-path", l.config.ModelsPath,
    "--backends-path", l.config.BackendsPath,
    "--address", l.config.Address,
    "--log-level", l.config.LogLevel,
    "--data-path", filepath.Join(dataPath, "data"),
    "--localai-config-dir", filepath.Join(dataPath, "configuration"),
}
```

Now data and dynamic config land under `~/.localai/data` and `~/.localai/configuration` regardless of the launcher's CWD, matching the existing models/backends paths. The flag names match the kong-derived CLI flags for `DataPath` and `LocalaiConfigDir` (same kebab-case convention as the existing `--models-path`/`--backends-path`).

Scoped to the launcher only — no change to server defaults or CLI behavior for non-launcher users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
