### PR TITLE
fix(vllm): non-streaming tool-call regression after #10351

### DIFF
--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -748,7 +748,12 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
         # When (A) native streaming ran cleanly, per-delta yields above already
         # delivered everything — do NOT extract again on the full text or we'd
         # duplicate content/tool_calls into the final chunk.
-        if has_tool_parser and not (native_streaming and not native_streaming_error):
+        # NOTE: `native_streaming` is a capability flag ("streaming parser is
+        # available"), not a state flag ("streaming actually ran"). For
+        # non-streaming requests it is still True but the per-delta loop was
+        # never entered, so we MUST still run extract_tool_calls here. Hence
+        # the explicit `streaming and …` guard on both branches.
+        if has_tool_parser and not (streaming and native_streaming and not native_streaming_error):
             try:
                 tp = tp_instance
                 if tp is None:
@@ -770,7 +775,7 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                         ))
             except Exception as e:
                 print(f"Tool parser error: {e}", file=sys.stderr)
-        elif native_streaming and not native_streaming_error:
+        elif streaming and native_streaming and not native_streaming_error:
             # Per-delta path already emitted content + tool_calls; the final
             # chat_delta should carry only metadata (token counts, logprobs).
             content = ""


### PR DESCRIPTION
## Summary

Non-streaming `chat.completions` with `tools=[...]` silently drops the tool
call (`finish_reason: "stop"`, empty content, no `tool_calls[]`) when a
`tool_parser` is configured. Streaming requests are unaffected.

## Root cause

#10351 introduced native streaming via `parser.extract_tool_calls_streaming`
and gated the post-loop `extract_tool_calls` block on
`native_streaming and not native_streaming_error`.

`native_streaming` is a **capability** flag — it becomes `True` as soon as
`tp_request` builds and the parser exposes `extract_tool_calls_streaming`.
It is **not** a state flag telling us the per-delta loop actually ran.

For non-streaming requests it is still `True`, so:

- the `if` branch (`extract_tool_calls` on the full text) was skipped
- the `elif` branch (`content = ""`, "the stream already emitted everything")
  fired

The result: the tool call is neither extracted nor streamed — it's lost.

## Fix

Add an explicit `streaming and …` guard on both branches so
`extract_tool_calls` runs for the non-streaming path (and for streaming
paths that fell back to the buffered mode). No change to streaming
requests where native streaming ran cleanly.

## Reproduction

Model: `saricles/Qwen3-Coder-Next-NVFP4-GB10`, vLLM 0.24.0, LocalAI
v4.5.6, `coder.yaml` with `options: - tool_parser:qwen3_coder`.

```bash
curl -s -X POST http://localhost:8080/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model":"coder","stream":false,
       "messages":[{"role":"user","content":"7*8 with the calc tool"}],
       "tools":[{"type":"function","function":{"name":"calc",
         "parameters":{"type":"object",
           "properties":{"expression":{"type":"string"}}}}}]}'
```

Before this patch: `finish_reason: "stop"`, `content: ""`, `tool_calls: []`.

After this patch: `finish_reason: "tool_calls"`,
`tool_calls[0].function.name: "calc"`,
`arguments: '{"expression":"7*8"}'`.

Streaming (`stream: true`) re-verified after the change: `delta.tool_calls`
arrives token-by-token, `finish_reason: "tool_calls"`, no raw XML in
content (behaviour from #10351 unchanged).

## Scope

Two lines of behaviour change plus a comment explaining the capability-vs-state
distinction so the guard isn't accidentally removed again.