### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/pkg/functions/peg/parser.go
+++ b/pkg/functions/peg/parser.go
@@ -461,10 +461,7 @@ func (p *RuleParser) parse(arena *Arena, ctx *ParseContext, start int) ParseResu
 	if result.Type != Fail {
 		text := ""
 		if result.Start < len(ctx.Input) {
-			end := result.End
-			if end > len(ctx.Input) {
-				end = len(ctx.Input)
-			}
+			end := min(result.End, len(ctx.Input))
 			text = ctx.Input[result.Start:end]
 		}
 
@@ -514,10 +511,7 @@ func (p *TagParser) parse(arena *Arena, ctx *ParseContext, start int) ParseResul
 	if result.Type != Fail {
 		text := ""
 		if result.Start < len(ctx.Input) {
-			end := result.End
-			if end > len(ctx.Input) {
-				end = len(ctx.Input)
-			}
+			end := min(result.End, len(ctx.Input))
 			text = ctx.Input[result.Start:end]
 		}
 


### PR DESCRIPTION
**Description**


In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.



**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->