### PR TITLE
fix(agent-ui): reset streamed text at generation boundaries in agent chat

### DIFF
--- a/core/http/react-ui/src/pages/AgentChat.jsx
+++ b/core/http/react-ui/src/pages/AgentChat.jsx
@@ -221,7 +221,14 @@ export default function AgentChat() {
             return updated
           })
         } else if (data.type === 'done') {
-          // Content will be finalized by json_message event
+          // One agent turn runs several internal LLM generations (tool
+          // selection, reasoning, final answer) over the same SSE channel;
+          // 'done' marks the boundary between them. Reset the accumulated
+          // text so an internal generation's output doesn't merge into the
+          // next one's bubble — the final json_message carries the
+          // authoritative full answer anyway.
+          setStreamContent('')
+          setStreamReasoning('')
         }
       } catch (_err) {
         // ignore


### PR DESCRIPTION
## What

One agent turn runs several internal LLM generations (tool selection, reasoning, final answer) that all emit `stream_event` deltas over the same per-agent SSE channel. The agent chat page accumulates every `content` delta into a single live bubble and ignores the `done` boundary events — so the internal generations' text (e.g. the English tool-selection rationale) merges with, and visually corrupts, the streamed final answer.

## Fix

Reset the accumulated content/reasoning when a `done` stream event arrives: each generation gets a clean live bubble. The authoritative full answer still arrives via the final `json_message` event exactly as before, so no information is lost.

Related server-side ordering fix: mudler/LocalAGI#483 (SSE broadcast worker pool scrambles delta order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KYp5FnAfsdGb6yjLmv8Mge