### PR TITLE
fix(runtime-settings): apply persisted threads/context_size/f16 at startup

### DIFF
--- a/core/application/startup.go
+++ b/core/application/startup.go
@@ -675,6 +675,36 @@ func loadRuntimeSettingsFromFile(options *config.ApplicationConfig) {
 			options.AgentJobRetentionDays = *settings.AgentJobRetentionDays
 		}
 	}
+
+	// Performance settings (threads / context size / f16). ApplyRuntimeSettings
+	// already persists these on the live /api/settings path, but the startup
+	// loader dropped them, so a value saved via the Middleware UI was silently
+	// ignored on restart (the model booted with the CLI/physical-core default).
+	//
+	// Threads is special: unlike ContextSize/F16, WithThreads eagerly resolves
+	// an unset (0) value to xsysinfo.CPUPhysicalCores() at option-apply time
+	// (see application_config.go), so options.Threads is never 0 here and the
+	// usual "== default" heuristic can't distinguish an env/CLI value from the
+	// physical-core fallback. Detect the env/CLI explicitly so
+	// LOCALAI_THREADS/THREADS still win over the persisted file value.
+	if settings.Threads != nil {
+		if os.Getenv("LOCALAI_THREADS") == "" && os.Getenv("THREADS") == "" {
+			options.Threads = *settings.Threads
+		}
+	}
+	if settings.ContextSize != nil {
+		// Only apply if current value is default (0), suggesting it wasn't set from env var
+		if options.ContextSize == 0 {
+			options.ContextSize = *settings.ContextSize
+		}
+	}
+	if settings.F16 != nil {
+		// Only apply if current value is default (false), suggesting it wasn't set from env var
+		if !options.F16 {
+			options.F16 = *settings.F16
+		}
+	}
+
 	if !options.WatchDogIdle && !options.WatchDogBusy {
 		if settings.WatchdogEnabled != nil && *settings.WatchdogEnabled {
 			options.WatchDog = true


### PR DESCRIPTION
### What / why

Closes #10845.

Setting **threads** (and, by the same defect, **context_size** / **f16**) via the Middleware UI persists the value to `runtime_settings.json`, but it was silently ignored after a restart: the model booted with the CLI/physical-core default and `GET /api/settings` echoed that default instead of the saved value. The only working workaround was `LOCALAI_THREADS`.

### Root cause

`ApplicationConfig.ApplyRuntimeSettings` (the live `POST /api/settings` path) already persists the three performance fields:

```go
if settings.Threads != nil { o.Threads = *settings.Threads }
if settings.ContextSize != nil { o.ContextSize = *settings.ContextSize }
if settings.F16 != nil { o.F16 = *settings.F16 }
```

…but the **startup** loader `loadRuntimeSettingsFromFile` (in `core/application/startup.go`) applies watchdog / backend / eviction / tracing / branding settings and never reads the performance group back, so a persisted value never reaches `options` on boot.

`threads` needs special handling: unlike `context_size`/`f16`, `WithThreads` eagerly resolves an unset (`0`) value to `xsysinfo.CPUPhysicalCores()` at option-apply time, so `options.Threads` is never `0` when the loader runs and the usual `== default` heuristic used by the other fields cannot distinguish an env/CLI value from the physical-core fallback. This change detects `LOCALAI_THREADS`/`THREADS` explicitly so the env still wins over the persisted file value, preserving the existing **env > file** precedence. `context_size`/`f16` use the same `== default` guard as their sibling fields in this loader.

### Change

Adds a performance-settings block to `loadRuntimeSettingsFromFile`, mirroring `ApplyRuntimeSettings`. Additive only (30 lines, single file); no behavior change when `runtime_settings.json` has no performance fields, and env/CLI values keep priority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
