### PR TITLE
fix(backend): don't crash the whole process on an invalid cutstrings/extract_regex

### DIFF
--- a/core/backend/llm.go
+++ b/core/backend/llm.go
@@ -463,7 +463,9 @@ func Finetune(config config.ModelConfig, input, prediction string) string {
 		if !ok {
 			r, err := regexp.Compile(c)
 			if err != nil {
-				xlog.Fatal("failed to compile regex", "error", err)
+				mu.Unlock()
+				xlog.Error("failed to compile cutstrings regex, skipping", "error", err, "regex", c)
+				continue
 			}
 			cutstrings[c] = r
 			reg = cutstrings[c]
@@ -480,7 +482,9 @@ func Finetune(config config.ModelConfig, input, prediction string) string {
 		if !ok {
 			regex, err := regexp.Compile(r)
 			if err != nil {
-				xlog.Fatal("failed to compile regex", "error", err)
+				mu.Unlock()
+				xlog.Error("failed to compile extract_regex regex, skipping", "error", err, "regex", r)
+				continue
 			}
 			cutstrings[r] = regex
 			reg = regex


### PR DESCRIPTION
## What
`Finetune()` in `core/backend/llm.go` compiles every model `cutstrings` and `extract_regex` entry with `regexp.Compile` and calls `xlog.Fatal` when compilation fails. `xlog.Fatal` terminates the **entire** `local-ai` process, so a single model whose config contains an invalid regex (e.g. `cutstrings: ["("]`) turns one normal `/v1/chat/completions` request into a process-level denial of service.

## Fix
Log the compile error via `xlog.Error` and skip the offending pattern instead of aborting. Two details that make this correct rather than just non-fatal:

- The mutex is unlocked **before** `continue`, so the skip does not leave `mu` held for the next iteration.
- Skipping (rather than merely dropping the `Fatal`) avoids dereferencing the `nil` `*regexp.Regexp` that would otherwise reach `reg.ReplaceAllString` / `reg.FindString`.

A malformed pattern now degrades gracefully (that one cut/extract is skipped, response still returned) instead of killing the server for every client.

## Test plan
```yaml
# models/model.yaml
name: mock-model
backend: mock-backend
cutstrings:
  - "("
```
Before: a chat-completion request against this model crashes the whole `local-ai` process.
After: the request completes; the log shows `failed to compile cutstrings regex, skipping` and the invalid pattern is ignored.

Fixes #10843

🤖 Generated with [Claude Code](https://claude.com/claude-code)