### PR TITLE
fix(watchdog): guard StopWatchdog with watchdogMutex to prevent double close (#10841)

### DIFF
--- a/core/application/watchdog.go
+++ b/core/application/watchdog.go
@@ -61,7 +61,15 @@ func extractModelGroupsFromConfigs(configs []config.ModelConfig) map[string][]st
 	return out
 }
 
+// StopWatchdog signals the watchdog to stop. It takes the watchdogMutex because
+// startWatchdog/RestartWatchdog reassign and close a.watchdogStop under that same
+// lock, and POST /api/settings can reach either this or RestartWatchdog depending
+// on WatchdogShouldRun(). Without the lock, two callers can both observe a non-nil
+// channel and close it twice, which panics.
 func (a *Application) StopWatchdog() error {
+	a.watchdogMutex.Lock()
+	defer a.watchdogMutex.Unlock()
+
 	if a.watchdogStop != nil {
 		close(a.watchdogStop)
 		a.watchdogStop = nil

--- a/core/application/watchdog_test.go
+++ b/core/application/watchdog_test.go
@@ -1,6 +1,8 @@
 package application
 
 import (
+	"sync"
+
 	"github.com/mudler/LocalAI/core/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -43,5 +45,34 @@ var _ = Describe("extractModelGroupsFromConfigs", func() {
 		Expect(out).To(HaveLen(1))
 		Expect(out).To(HaveKey("b"))
 		Expect(out).ToNot(HaveKey("a"))
+	})
+})
+
+var _ = Describe("StopWatchdog", func() {
+	It("closes the stop channel exactly once under concurrent callers", func() {
+		// POST /api/settings routes to StopWatchdog whenever the new settings make
+		// WatchdogShouldRun() false, so concurrent requests land here in parallel.
+		// Before the mutex was taken, both could observe a non-nil watchdogStop and
+		// close it twice, panicking with "close of closed channel".
+		app := &Application{watchdogStop: make(chan bool, 1)}
+
+		var wg sync.WaitGroup
+		for i := 0; i < 64; i++ {
+			wg.Add(1)
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				Expect(app.StopWatchdog()).To(Succeed())
+			}()
+		}
+		wg.Wait()
+
+		Expect(app.watchdogStop).To(BeNil())
+	})
+
+	It("is a no-op when the watchdog was never started", func() {
+		app := &Application{}
+		Expect(app.StopWatchdog()).To(Succeed())
+		Expect(app.watchdogStop).To(BeNil())
 	})
 })


### PR DESCRIPTION
Fixes #10841

## Problem

`StopWatchdog()` read, closed and cleared `a.watchdogStop` without holding `a.watchdogMutex`:

```go
func (a *Application) StopWatchdog() error {
	if a.watchdogStop != nil {
		close(a.watchdogStop)
		a.watchdogStop = nil
	}
	return nil
}
```

The other two writers of that field — `startWatchdog()` (`a.watchdogStop = make(chan bool, 1)`) and `RestartWatchdog()` (close + nil) — both do so under `a.watchdogMutex`, so the unlocked reader/writer was the odd one out.

Both paths are reachable from `POST /api/settings`: the handler picks `StopWatchdog()` or `RestartWatchdog()` based on `appConfig.WatchdogShouldRun()` (`core/http/endpoints/localai/settings.go:257-266`). Two concurrent requests can therefore both observe a non-nil `watchdogStop` and both `close()` it. A double close of a Go channel is an unrecoverable panic (`close of closed channel`), so this crashes the server rather than just corrupting state — and the route is unauthenticated by default, since `adminMiddleware` resolves to `auth.NoopMiddleware()` with no `--api-keys` configured.

## Fix

Take `watchdogMutex` in `StopWatchdog()`, matching the other two writers. The check and the close become atomic with respect to `startWatchdog`/`RestartWatchdog`, so exactly one caller closes the channel and the rest see `nil`.

`sync.Mutex` is not reentrant, so I checked every call site before adding the lock: `StopWatchdog` is only called from the settings handler (which holds no lock) and from tests. `StartWatchdog`/`RestartWatchdog` inline their own close rather than calling `StopWatchdog`, so there is no path that acquires `watchdogMutex` twice.

## Tests

Added `StopWatchdog` specs to `core/application/watchdog_test.go`:

- **`closes the stop channel exactly once under concurrent callers`** — fires 64 goroutines at `StopWatchdog` on a shared `Application`. On master this panics with `close of closed channel`; with the lock it settles with `watchdogStop == nil`. Worth running under `-race` too, where the unsynchronized field access is flagged on its own.
- **`is a no-op when the watchdog was never started`** — pins the nil-channel path that the early return covers.

I kept this strictly to the locking bug in #10841. `StopWatchdog` also doesn't call `Shutdown()` on the watchdog instance the way `RestartWatchdog` does, which looks like a separate (leak-shaped) concern — happy to open a follow-up if that's a real issue rather than intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
