### PR TITLE
fix(p2p): serialize access to p2pCtx/p2pCancel (#10839)

### DIFF
--- a/core/application/p2p.go
+++ b/core/application/p2p.go
@@ -18,14 +18,24 @@ import (
 )
 
 func (a *Application) StopP2P() error {
-	if a.p2pCancel != nil {
-		a.p2pCancel()
-		a.p2pCancel = nil
-		a.p2pCtx = nil
-		// Wait a bit for shutdown to complete
-		time.Sleep(200 * time.Millisecond)
-	}
+	a.p2pMutex.Lock()
+	defer a.p2pMutex.Unlock()
+
+	a.stopP2PLocked()
 	return nil
+}
+
+// stopP2PLocked cancels the running P2P stack, if any, and clears the
+// context fields. Callers must hold a.p2pMutex.
+func (a *Application) stopP2PLocked() {
+	if a.p2pCancel == nil {
+		return
+	}
+	a.p2pCancel()
+	a.p2pCancel = nil
+	a.p2pCtx = nil
+	// Wait a bit for shutdown to complete
+	time.Sleep(200 * time.Millisecond)
 }
 
 func (a *Application) StartP2P() error {
@@ -37,8 +47,13 @@ func (a *Application) StartP2P() error {
 	networkID := a.applicationConfig.P2PNetworkID
 
 	ctx, cancel := context.WithCancel(a.ApplicationConfig().Context)
+	// Publishing the context is the only shared-state write here; the node
+	// and discoverer setup below works off the local ctx/cancel, so the lock
+	// is not held across the network calls.
+	a.p2pMutex.Lock()
 	a.p2pCtx = ctx
 	a.p2pCancel = cancel
+	a.p2pMutex.Unlock()
 
 	var n *node.Node
 	// Here we are avoiding creating multiple nodes:
@@ -131,13 +146,7 @@ func (a *Application) RestartP2P() error {
 	defer a.p2pMutex.Unlock()
 
 	// Stop existing P2P if running
-	if a.p2pCancel != nil {
-		a.p2pCancel()
-		a.p2pCancel = nil
-		a.p2pCtx = nil
-		// Wait a bit for shutdown to complete
-		time.Sleep(200 * time.Millisecond)
-	}
+	a.stopP2PLocked()
 
 	appConfig := a.ApplicationConfig()
 
@@ -151,8 +160,8 @@ func (a *Application) RestartP2P() error {
 	go func() {
 		if err := a.StartP2P(); err != nil {
 			xlog.Error("Failed to start P2P stack", "error", err)
-			if a.p2pCancel != nil {
-				a.p2pCancel()
+			if stopErr := a.StopP2P(); stopErr != nil {
+				xlog.Error("Failed to stop partially started P2P stack", "error", stopErr)
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #10839.

### The race

`Application.p2pCtx` / `p2pCancel` are mutated from three places with inconsistent locking:

- `StopP2P()` read and wrote both fields without ever taking `a.p2pMutex`.
- `StartP2P()` reassigned both fields with no lock at all (`p2p.go:40-41`), and `RestartP2P()` invokes it from a background goroutine — so the write happens *after* `RestartP2P` has released the mutex.
- The goroutine's error path read `a.p2pCancel` unlocked as well.

Both entry points are reachable from `POST /api/settings` (empty `p2p_token` → `StopP2P`, non-empty → `RestartP2P`), so two concurrent requests race on the same struct fields (CWE-362), as the reporter's `-race` build shows.

### The fix

- `StopP2P()` now takes `a.p2pMutex`.
- The teardown body is factored into `stopP2PLocked()` (documented as caller-holds-the-lock) so `RestartP2P()` reuses it instead of duplicating the cancel/clear/sleep block.
- `StartP2P()` takes the mutex around the *publication* of `ctx`/`cancel` only. The node and discoverer setup below works off the local `ctx` variable, so the lock is deliberately not held across those network calls — this keeps `StopP2P` from blocking for the duration of a P2P bring-up.
- The `RestartP2P` goroutine's error path now goes through `StopP2P()` rather than touching `a.p2pCancel` directly.

No deadlock is introduced: `RestartP2P` holds the mutex only until it returns, and it does not wait on the goroutine it spawns, so the goroutine's `StartP2P` lock acquisition just waits for that unlock.

This mirrors the `mitmMutex` convention already used in `Application` ("serializes Stop+Start").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
