### PR TITLE
fix(sglang): implement Status RPC to unblock backend-monitor polling

### DIFF
--- a/backend/python/sglang/backend.py
+++ b/backend/python/sglang/backend.py
@@ -173,6 +173,14 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
     def Health(self, request, context):
         return backend_pb2.Reply(message=bytes("OK", 'utf-8'))
 
+
+    def Status(self, request, context):
+        # Minimal shim: LocalAI polls /backend.Backend/Status on registered
+        # backends; without this method the default NotImplementedError from
+        # backend_pb2_grpc bubbles up as HTTP 500 on /backend/monitor and blocks
+        # inference requests to a healthy loaded model. Returning READY
+        # unconditionally mirrors the existing Health method's behavior.
+        return backend_pb2.StatusResponse(state=backend_pb2.StatusResponse.State.READY)
     async def LoadModel(self, request, context):
         model_ref, local_only = resolve_model_reference(request)
         engine_kwargs = {"model_path": model_ref}


### PR DESCRIPTION
## Problem

The sglang Python backend inherits the default `Status` RPC from `backend_pb2_grpc.BackendServicer`, which raises `NotImplementedError`. LocalAI's backend-monitor polls `/backend.Backend/Status` periodically on every registered backend; when the call fails, `/backend/monitor` returns HTTP 500 and downstream inference requests to the sglang backend get blocked — even though the model is loaded and answering fine on its direct gRPC endpoint.

## Fix

Add a minimal `Status` shim that mirrors the existing `Health` method and returns `StatusResponse{state=READY}` unconditionally. This unblocks the monitor path immediately. A state-aware follow-up (`UNINITIALIZED` during load, `BUSY` under active inference) would be an improvement but is intentionally out of scope for this MVP — the current change matches what `Health` does today, which is what registered backends have effectively been telling the monitor loop anyway.

## Reproducer / verification

Hardware: DGX Spark (GB10, arm64-l4t-cuda-13 image). Backend: `cuda13-nvidia-l4t-arm64-sglang` at sglang v0.5.15, model `ucbye/Qwen3-Coder-Next-NVFP4-GB10` (80B NVFP4). Before the shim, `/backend/monitor` returns 500 and inference requests routed via LocalAI hang; direct gRPC-level calls to the sglang server work. Patching the shim in place on the running container instantly restores both `/backend/monitor` and inference to the sglang slot. Same pattern has been carrying prod for the sglang coder there since 2026-07-15 (~24 h uptime).

## Notes for reviewers

- The change is 8 lines in `backend/python/sglang/backend.py`; nothing else is touched.
- Other Python backends (e.g. `vllm`, `llama-cpp-python`) also don't implement `Status` today — if the monitor polls them too, the same shim would apply. I've only reproduced the failure end-to-end with sglang so this PR is intentionally sglang-only; happy to file follow-ups if useful.
- Cross-ref: same pattern of "sglang wrapper missing a method that vllm has" as #10558 (`function.arguments` string→dict parse).
