### PR TITLE
docs(config): document grpc.attempts timing + tuning guidance

### DIFF
--- a/docs/content/advanced/model-configuration.md
+++ b/docs/content/advanced/model-configuration.md
@@ -914,12 +914,40 @@ Define pipelines for audio-to-audio processing and the [Realtime API]({{%relref 
 
 ## gRPC Configuration
 
-Backend gRPC communication settings:
+Backend gRPC communication settings. These control the readiness handshake
+between LocalAI and a freshly spawned backend process — LocalAI polls the
+backend's `Health` gRPC method up to `grpc.attempts` times, sleeping
+`grpc.attempts_sleep_time` seconds between polls, before giving up and
+terminating the backend as unresponsive.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `grpc.attempts` | int | Number of retry attempts |
-| `grpc.attempts_sleep_time` | int | Sleep time between retries (seconds) |
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `grpc.attempts` | int | 20 | Number of health-check attempts before the backend is killed as unresponsive |
+| `grpc.attempts_sleep_time` | int | 2 | Sleep time between health-check attempts (seconds) |
+
+**Total load window ≈ `grpc.attempts × (grpc.attempts_sleep_time + per-call gRPC dial timeout)`.**
+The default of `20 × 2 s ≈ 40 s` is fine for typical backends but is too
+short for large models that need substantial time to become gRPC-ready
+after the process starts — for example NVFP4 / FP8 models whose shard
+loading and CUDA-graph capture can take several minutes, or slow storage
+backends. If the backend keeps getting killed while still legitimately
+loading (visible as `exitCode=120` + `rpc error: code = Canceled desc =
+context canceled` in the LocalAI log, while the backend's own stderr
+shows continued forward progress), raise these values.
+
+Example configuration for a model that needs up to ~10 minutes to become
+gRPC-ready (large NVFP4 model, cold shard load + CUDA-graph capture):
+
+```yaml
+grpc:
+  attempts: 140
+  attempts_sleep_time: 5
+```
+
+This gives a ~700 s window while keeping health-check polling frequent
+enough to detect real backend crashes quickly. The values only affect
+the initial readiness handshake — inference-request timeouts and the
+watchdog are unchanged.
 
 ## Overrides
 


### PR DESCRIPTION
## What

Extends the (very minimal) gRPC Configuration section in `docs/content/advanced/model-configuration.md` with defaults, a total-load-window formula, a failure-signature hint, and a concrete example for models that need a longer readiness window.

## Why

The current table lists `grpc.attempts` and `grpc.attempts_sleep_time` with a one-line description each. It doesn't say what the defaults are (they're `20` and `2` in `pkg/model/loader_options.go`), what timing behavior they produce end-to-end, or when a user should touch them.

In practice the default `20 × 2 s ≈ 40 s` window is too tight for large NVFP4 / FP8 models on slow storage or first-run CUDA-graph capture. The resulting kill shows up in the LocalAI log as `exitCode=120` plus `rpc error: code = Canceled desc = context canceled` — which reads like a backend crash even though the backend's own stderr shows continued forward progress (e.g. `Multi-thread loading shards: 3/10 [01:22<03:43]`). Without knowing the timing math, users spend time chasing the wrong root cause (I did, before I traced it back to `pkg/model/initializers.go:145-160`).

## What the doc adds

- A **Default** column in the config table (`20` and `2`)
- Prose framing: these govern the *readiness handshake* between LocalAI and a freshly spawned backend (Health-polling loop), not runtime request timeouts
- The total-load-window approximation: `grpc.attempts × (grpc.attempts_sleep_time + per-call gRPC dial timeout)`
- The concrete failure signature so users can recognize a timeout-kill vs. a real backend crash
- Example values for a ~10 min cold-load window (`attempts: 140`, `attempts_sleep_time: 5`), with a note that inference-request timeouts and the watchdog are unaffected

## Verification

Docs-only change; no code paths touched. Verified locally on DGX Spark (GB10, sglang v0.5.15, `ucbye/Qwen3-Coder-Next-NVFP4-GB10`) that the example values do produce a stable ~9 min cold-load; without them the load consistently died at ~90 s.

## Cross-refs

- Companion to the stderr-capture discussion on #10720
- Related PR: #10867 (sglang backend Status shim — separate root cause, same debugging trip)
