### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/core/services/agents/citations.go
+++ b/core/services/agents/citations.go
@@ -100,7 +100,7 @@ func kbCitationRawFileURL(collection, entryKey, userID string) string {
 	}
 
 	var escapedEntrySegments []string
-	for _, segment := range strings.Split(entryKey, "/") {
+	for segment := range strings.SplitSeq(entryKey, "/") {
 		if segment == "" {
 			continue
 		}

--- a/pkg/huggingface-api/snapshot.go
+++ b/pkg/huggingface-api/snapshot.go
@@ -218,7 +218,7 @@ func (c *Client) decodeTreePage(req *http.Request) ([]snapshotTreeItem, string, 
 }
 
 func nextPage(link string, current *url.URL) (string, error) {
-	for _, entry := range strings.Split(link, ",") {
+	for entry := range strings.SplitSeq(link, ",") {
 		parts := strings.Split(entry, ";")
 		if len(parts) >= 2 && strings.TrimSpace(parts[1]) == `rel="next"` {
 			raw := strings.Trim(strings.TrimSpace(parts[0]), "<>")

--- a/pkg/modelartifacts/path.go
+++ b/pkg/modelartifacts/path.go
@@ -76,8 +76,8 @@ func ValidateRelativeHubPath(candidate string) error {
 	if candidate == "" || filepath.IsAbs(candidate) || strings.ContainsAny(candidate, "\\\x00") {
 		return fmt.Errorf("unsafe Hub path %q", candidate)
 	}
-	parts := strings.Split(candidate, "/")
-	for _, part := range parts {
+	parts := strings.SplitSeq(candidate, "/")
+	for part := range parts {
 		if part == "" || part == "." || part == ".." {
 			return fmt.Errorf("unsafe Hub path %q", candidate)
 		}

--- a/pkg/modelartifacts/types.go
+++ b/pkg/modelartifacts/types.go
@@ -142,7 +142,7 @@ func validatePattern(pattern string) error {
 	if pattern == "" || path.IsAbs(pattern) || strings.ContainsAny(pattern, "\\\x00") {
 		return fmt.Errorf("invalid artifact pattern %q", pattern)
 	}
-	for _, part := range strings.Split(pattern, "/") {
+	for part := range strings.SplitSeq(pattern, "/") {
 		if part == ".." {
 			return fmt.Errorf("invalid artifact pattern %q", pattern)
 		}

--- a/pkg/xsysinfo/gpu.go
+++ b/pkg/xsysinfo/gpu.go
@@ -438,7 +438,7 @@ func detectNVIDIAComputeCapability() string {
 
 	best := ""
 	bestMajor, bestMinor := -1, -1
-	for _, line := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(stdout.String()), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -500,9 +500,9 @@ func getNVIDIAGPUMemory() []GPUMemoryInfo {
 	}
 
 	var gpus []GPUMemoryInfo
-	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	lines := strings.SplitSeq(strings.TrimSpace(stdout.String()), "\n")
 
-	for _, line := range lines {
+	for line := range lines {
 		if line == "" {
 			continue
 		}

--- a/pkg/xsysinfo/memory_total.go
+++ b/pkg/xsysinfo/memory_total.go
@@ -56,7 +56,7 @@ func parseCgroupV1Limit(raw string) uint64 {
 // /proc/meminfo contents. MemTotal is reported in kibibytes, so the parsed
 // value is multiplied by 1024. Returns 0 when the field is missing.
 func parseMemTotal(raw string) uint64 {
-	for _, line := range strings.Split(raw, "\n") {
+	for line := range strings.SplitSeq(raw, "\n") {
 		if !strings.HasPrefix(line, "MemTotal:") {
 			continue
 		}


### PR DESCRIPTION
**Description**

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901


**Notes for Reviewers**


**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->