### PR TITLE
fix(completions): reject empty PromptStrings in streaming to avoid index-out-of-range panic

### DIFF
--- a/core/http/endpoints/openai/completion.go
+++ b/core/http/endpoints/openai/completion.go
@@ -2,8 +2,8 @@ package openai
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/labstack/echo/v4"
@@ -18,6 +18,18 @@ import (
 	"github.com/mudler/LocalAI/pkg/model"
 	"github.com/mudler/xlog"
 )
+
+// validateStreamingPromptStrings enforces that a streaming completion request
+// resolves to exactly one prompt string. Malformed inputs — an omitted prompt,
+// an empty array, or an array whose elements do not reduce to a single string —
+// return a 400 error instead of panicking on PromptStrings[0] or opening a
+// half-written event stream (which Echo surfaces as a 500). See issue #11021.
+func validateStreamingPromptStrings(cfg *config.ModelConfig) error {
+	if len(cfg.PromptStrings) != 1 {
+		return echo.NewHTTPError(http.StatusBadRequest, "streaming completions require exactly one prompt string")
+	}
+	return nil
+}
 
 // CompletionEndpoint is the OpenAI Completion API endpoint https://platform.openai.com/docs/api-reference/completions
 // @Summary Generate completions for a given prompt and model.
@@ -102,13 +114,17 @@ func CompletionEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, eva
 
 		if input.Stream {
 			xlog.Debug("Stream request received")
+
+			// Validate before writing any SSE headers so a malformed request
+			// yields a 400 JSON error instead of a half-opened event stream
+			// (which Echo would otherwise surface as a 500). See issue #11021.
+			if err := validateStreamingPromptStrings(config); err != nil {
+				return err
+			}
+
 			c.Response().Header().Set("Content-Type", "text/event-stream")
 			c.Response().Header().Set("Cache-Control", "no-cache")
 			c.Response().Header().Set("Connection", "keep-alive")
-
-			if len(config.PromptStrings) != 1 {
-				return errors.New("streaming completions require exactly 1 `PromptStrings`")
-			}
 
 			// Response/output PII redaction is out of scope for now —
 			// redaction runs request-side via the NER middleware only.

--- a/core/http/endpoints/openai/completion.go
+++ b/core/http/endpoints/openai/completion.go
@@ -106,8 +106,8 @@ func CompletionEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, eva
 			c.Response().Header().Set("Cache-Control", "no-cache")
 			c.Response().Header().Set("Connection", "keep-alive")
 
-			if len(config.PromptStrings) > 1 {
-				return errors.New("cannot handle more than 1 `PromptStrings` when Streaming")
+			if len(config.PromptStrings) != 1 {
+				return errors.New("streaming completions require exactly 1 `PromptStrings`")
 			}
 
 			// Response/output PII redaction is out of scope for now —

--- a/core/http/endpoints/openai/completion_stream_validation_test.go
+++ b/core/http/endpoints/openai/completion_stream_validation_test.go
@@ -1,0 +1,40 @@
+package openai
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/mudler/LocalAI/core/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// These tests pin the streaming completion request validation added for issue
+// #11021: a streaming request whose prompt does not resolve to exactly one
+// string must be rejected with an HTTP 400 before any SSE headers are written,
+// rather than panicking on PromptStrings[0] or returning a 500 on a
+// half-opened event stream.
+var _ = Describe("streaming completion prompt validation (issue #11021)", func() {
+	DescribeTable("rejects malformed prompts with HTTP 400",
+		func(prompts []string) {
+			cfg := &config.ModelConfig{}
+			cfg.PromptStrings = prompts
+
+			err := validateStreamingPromptStrings(cfg)
+			Expect(err).To(HaveOccurred())
+
+			he, ok := err.(*echo.HTTPError)
+			Expect(ok).To(BeTrue(), "expected an *echo.HTTPError, got %T", err)
+			Expect(he.Code).To(Equal(http.StatusBadRequest))
+		},
+		Entry("omitted prompt (nil slice)", []string(nil)),
+		Entry("empty array", []string{}),
+		Entry("multiple prompt strings", []string{"a", "b", "c"}),
+	)
+
+	It("accepts exactly one prompt string", func() {
+		cfg := &config.ModelConfig{}
+		cfg.PromptStrings = []string{"hello"}
+		Expect(validateStreamingPromptStrings(cfg)).To(Succeed())
+	})
+})


### PR DESCRIPTION
### What / why

`CompletionEndpoint`'s streaming branch (`core/http/endpoints/openai/completion.go`) only guarded `len(config.PromptStrings) > 1` before unconditionally reading `config.PromptStrings[0]`:

```go
if len(config.PromptStrings) > 1 {
    return errors.New("cannot handle more than 1 `PromptStrings` when Streaming")
}
...
predInput := config.PromptStrings[0]   // panics when len == 0
```

A completion request to `/v1/completions` (streaming) whose `prompt` field is an empty array, an array of non-strings, or omitted entirely leaves `config.PromptStrings` with length 0. The `> 1` guard passes, and `PromptStrings[0]` then panics with `index out of range [0] with length 0`, crashing the handler goroutine.

### Fix

Guard for exactly one prompt string. `len != 1` now returns a clean error for the empty case as well as the pre-existing multi-prompt case — a minimal, behavior-preserving change (a well-formed single-prompt streaming request is unaffected).

```go
if len(config.PromptStrings) != 1 {
    return errors.New("streaming completions require exactly 1 `PromptStrings`")
}
```

Fixes #11021.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
