### PR TITLE
fix(grammars): bound JSON-schema recursion to survive cyclic $ref (#11020)

### DIFF
--- a/pkg/functions/grammars/json_schema.go
+++ b/pkg/functions/grammars/json_schema.go
@@ -10,9 +10,18 @@ import (
 	"strings"
 )
 
+// maxVisitDepth bounds recursion in visit(). Client-supplied schemas can
+// contain cyclic $ref chains (e.g. "A": {"$ref": "#/$defs/A"}) which would
+// otherwise recurse until the goroutine stack is exhausted, crashing the whole
+// process with a fatal "stack overflow". A legitimate function-calling schema
+// nests far shallower than this.
+// ponytail: flat depth cap, switch to per-ref cycle tracking if real schemas ever exceed it
+const maxVisitDepth = 100
+
 type JSONSchemaConverter struct {
 	propOrder map[string]int
 	rules     Rules
+	depth     int
 }
 
 func NewJSONSchemaConverter(propOrder string) *JSONSchemaConverter {
@@ -60,6 +69,12 @@ func (sc *JSONSchemaConverter) addRule(name, rule string) string {
 }
 
 func (sc *JSONSchemaConverter) visit(schema map[string]any, name string, rootSchema map[string]any) (string, error) {
+	sc.depth++
+	defer func() { sc.depth-- }()
+	if sc.depth > maxVisitDepth {
+		return "", fmt.Errorf("schema recursion depth exceeded %d (possible cyclic $ref)", maxVisitDepth)
+	}
+
 	st, existType := schema["type"]
 	var schemaType string
 	var schemaTypes []string

--- a/pkg/functions/grammars/json_schema_test.go
+++ b/pkg/functions/grammars/json_schema_test.go
@@ -548,6 +548,20 @@ realvalue
 	})
 })
 
+var _ = Describe("JSON schema cyclic $ref (issue #11020)", func() {
+	It("errors instead of crashing on a self-referencing $ref", func() {
+		// "A" references itself, so a naive converter recurses until the
+		// goroutine stack overflows and takes down the whole process.
+		const cyclic = `{
+			"$defs": {"A": {"$ref": "#/$defs/A"}},
+			"oneOf": [{"type": "object", "properties": {"x": {"$ref": "#/$defs/A"}}}]
+		}`
+		_, err := NewJSONSchemaConverter("").GrammarFromBytes([]byte(cyclic))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("recursion depth"))
+	})
+})
+
 var _ = Describe("JSON schema property ordering (issue #10052)", func() {
 	// A function-call shaped schema. The grammar must honor the configured
 	// properties_order. Before the fix, the sort guard `aOrder != 0 && bOrder != 0`


### PR DESCRIPTION
## Description

`JSONSchemaConverter.visit()` (`pkg/functions/grammars/json_schema.go`) resolves `$ref` by recursing into itself with no cycle detection and no depth limit. A client-supplied `grammar_json_functions` schema whose `$defs` contains a self-referencing entry — e.g. `"A": {"$ref": "#/$defs/A"}` — recurses until the goroutine stack is exhausted, producing an unrecoverable `fatal error: stack overflow` that **kills the whole process**, not just the offending request.

The converter runs synchronously in the HTTP handler for `POST /v1/chat/completions` (before any backend call), and the same code is reachable from realtime `response.create` and llama3.1 schema handling, so any unauthenticated caller can crash the server.

## Fix

Add a single depth cap inside the shared `visit()`, so every call path is covered by one guard. When the depth is exceeded the converter returns an error instead of recursing forever — the request fails cleanly and the process stays up.

A flat depth limit (100) also catches any other unbounded nesting, not just the specific cyclic-`$ref` PoC. Real function-calling schemas nest far shallower.

## Test

Added a case under `json_schema_test.go` that feeds the cyclic schema from the report and asserts a `recursion depth` error is returned rather than the process crashing.

Fixes #11020