### PR TITLE
fix(trl): disable inline GRPO reward code by default (RCE, #11015)

### DIFF
--- a/backend/python/trl/reward_functions.py
+++ b/backend/python/trl/reward_functions.py
@@ -5,10 +5,24 @@ All reward functions follow TRL's signature: (completions, **kwargs) -> list[flo
 """
 
 import json
+import os
 import re
 import math
 import string
 import functools
+
+
+# Opt-in flag for inline reward code. Compiling a caller-supplied Python body
+# is arbitrary code execution: the _SAFE_BUILTINS allowlist below is NOT a
+# security boundary — expressions like ().__class__.__bases__[0].__subclasses__()
+# escape it trivially to reach os.system. Since the fine-tuning endpoint is
+# unauthenticated by default, inline reward functions are disabled unless the
+# operator explicitly opts in by setting this env var to a truthy value.
+ALLOW_INLINE_ENV = "LOCALAI_TRL_ALLOW_INLINE_REWARD"
+
+
+def _inline_rewards_allowed():
+    return os.environ.get(ALLOW_INLINE_ENV, "").strip().lower() in ("1", "true", "yes", "on")
 
 
 # ---------------------------------------------------------------------------
@@ -224,6 +238,14 @@ def build_reward_functions(specs_json):
             reward_funcs.append(func)
 
         elif spec_type == "inline":
+            if not _inline_rewards_allowed():
+                raise ValueError(
+                    f"Inline reward function '{name}' rejected: inline reward code "
+                    f"executes arbitrary Python and is disabled by default. Set "
+                    f"{ALLOW_INLINE_ENV}=true on the backend to enable it (only on a "
+                    f"trusted, access-controlled instance), or use a builtin reward "
+                    f"function instead."
+                )
             code = spec.get("code", "")
             if not code.strip():
                 raise ValueError(f"Inline reward function '{name}' has no code")

--- a/backend/python/trl/test_reward_functions.py
+++ b/backend/python/trl/test_reward_functions.py
@@ -1,0 +1,48 @@
+"""
+Tests for reward_functions.py — no gRPC / model deps, pure stdlib.
+
+Covers the inline-code opt-in gate (issue #11015): inline reward code is
+arbitrary code execution and must stay disabled unless the operator opts in.
+"""
+import os
+import unittest
+
+import reward_functions as rf
+
+INLINE_SPEC = [{"type": "inline", "name": "ok", "code": "return [1.0 for _ in completions]"}]
+
+
+class TestInlineRewardGate(unittest.TestCase):
+    def setUp(self):
+        self._saved = os.environ.pop(rf.ALLOW_INLINE_ENV, None)
+
+    def tearDown(self):
+        if self._saved is None:
+            os.environ.pop(rf.ALLOW_INLINE_ENV, None)
+        else:
+            os.environ[rf.ALLOW_INLINE_ENV] = self._saved
+
+    def test_inline_refused_by_default(self):
+        with self.assertRaises(ValueError) as cm:
+            rf.build_reward_functions(INLINE_SPEC)
+        self.assertIn("disabled by default", str(cm.exception))
+
+    def test_builtin_works_without_optin(self):
+        fns = rf.build_reward_functions([{"type": "builtin", "name": "format_reward"}])
+        self.assertEqual(len(fns), 1)
+        self.assertTrue(callable(fns[0]))
+
+    def test_inline_enabled_with_optin(self):
+        os.environ[rf.ALLOW_INLINE_ENV] = "true"
+        fns = rf.build_reward_functions(INLINE_SPEC)
+        self.assertEqual(fns[0](["x"]), [1.0])
+
+    def test_optin_falsey_values_stay_disabled(self):
+        for val in ("", "0", "false", "no", "off"):
+            os.environ[rf.ALLOW_INLINE_ENV] = val
+            with self.assertRaises(ValueError):
+                rf.build_reward_functions(INLINE_SPEC)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/content/features/fine-tuning.md
+++ b/docs/content/features/fine-tuning.md
@@ -151,11 +151,15 @@ GRPO training requires reward functions to evaluate model completions. Specify t
 
 You can provide custom reward function code as a Python function body. The function receives `completions` (list of strings) and `**kwargs`, and must return `list[float]`.
 
-**Security restrictions for inline code:**
-- Allowed builtins: `len`, `int`, `float`, `str`, `list`, `dict`, `range`, `enumerate`, `zip`, `map`, `filter`, `sorted`, `min`, `max`, `sum`, `abs`, `round`, `any`, `all`, `isinstance`, `print`, `True`, `False`, `None`
-- Available modules: `re`, `math`, `json`, `string`
-- Blocked: `open`, `__import__`, `exec`, `eval`, `compile`, `os`, `subprocess`, `getattr`, `setattr`, `delattr`, `globals`, `locals`
-- Functions are compiled and validated at job start (fail-fast on syntax errors)
+{{% notice warning %}}
+**Inline reward code executes arbitrary Python and is disabled by default.**
+
+Inline code is compiled and run in the backend process. The restricted-builtins allowlist is **not** a security sandbox — trivial expressions can escape it to reach the host (arbitrary code execution). Because the fine-tuning endpoint is unauthenticated by default, inline reward functions are refused unless the operator explicitly opts in by setting `LOCALAI_TRL_ALLOW_INLINE_REWARD=true` on the backend.
+
+Only enable it on a trusted, access-controlled instance where every caller of the fine-tuning API is authorized to run code on the host. Otherwise use the builtin reward functions above.
+{{% /notice %}}
+
+The function is given the reduced builtin set (`len`, `int`, `float`, `str`, `list`, `dict`, `range`, `enumerate`, `zip`, `map`, `filter`, `sorted`, `min`, `max`, `sum`, `abs`, `round`, `any`, `all`, `isinstance`, `print`) plus the `re`, `math`, `json`, and `string` modules, and is compiled and validated at job start (fail-fast on syntax errors). Treat these as ergonomics, not as an isolation boundary.
 
 #### Example API Request
 


### PR DESCRIPTION
## Description

`POST /api/fine-tuning/jobs` accepts `reward_functions[].code`, an inline Python body, which `compile_inline_reward()` (`backend/python/trl/reward_functions.py`) `exec`s against a hand-rolled `_SAFE_BUILTINS` allowlist. That allowlist is **not** a security boundary — the classic escape

```python
().__class__.__bases__[0].__subclasses__()  # -> os._wrap_close -> os.system
```

reaches the real `os` module and yields arbitrary code execution on the host. Execution happens synchronously during a smoke test at job start, and the fine-tuning endpoint is **unauthenticated by default**, so any caller can run code on the server. (Reported in #11015.)

## Fix

Hardening the allowlist against CPython introspection is a losing game, so this doesn't try. Instead:

- **Inline reward code is refused by default.** It runs only when the operator explicitly opts in with `LOCALAI_TRL_ALLOW_INLINE_REWARD=true` on the backend — an informed choice to allow authorized API callers to execute code on that host.
- **Builtin reward functions are unaffected** — the common path keeps working with no config.
- The gate lives in `build_reward_functions()`, the single chokepoint all inline specs pass through.
- Docs (`docs/content/features/fine-tuning.md`) no longer describe the allowlist as a sandbox; they document the opt-in and warn that inline code is arbitrary execution.

## Test

Added `backend/python/trl/test_reward_functions.py` (stdlib only, no gRPC/model deps):

- inline refused by default
- builtins still work with no opt-in
- inline runs when opted in
- falsey env values (`""`, `0`, `false`, `no`, `off`) stay disabled

```
Ran 4 tests in 0.000s
OK
```

Fixes #11015