### PR TITLE
fix(ace-step): drop nonexistent Get* proto accessors in SoundGeneration (#11069)

### DIFF
--- a/backend/python/ace-step/backend.py
+++ b/backend/python/ace-step/backend.py
@@ -401,16 +401,16 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 "sample_query": request.text or "",
                 "sample_mode": True,
                 "thinking": True,
-                "vocal_language": request.language or request.GetLanguage() or "en",
+                "vocal_language": request.language or "en",
                 "instrumental": request.instrumental if request.HasField("instrumental") else False,
             }
         else:
-            caption = request.caption or request.GetCaption() or request.text
+            caption = request.caption or request.text
             payload = {
                 "prompt": caption,
                 "lyrics": request.lyrics or request.lyrics or "",
                 "thinking": request.think if request.HasField("think") else False,
-                "vocal_language": request.language or request.GetLanguage() or "en",
+                "vocal_language": request.language or "en",
             }
             if request.HasField("bpm"):
                 payload["bpm"] = request.bpm


### PR DESCRIPTION
## What

The `ace-step` backend's `SoundGeneration` handler calls `request.GetLanguage()` and `request.GetCaption()`. The generated **Python** protobuf message exposes fields as plain attributes (`request.language`, `request.caption`); the `Get*()` accessor convention is from gRPC-Go/Java, not Python.

Because `request.language` is an empty string when the field is unset, this expression:

```python
"vocal_language": request.language or request.GetLanguage() or "en",
```

falls through to `request.GetLanguage()`, which does not exist on the message, raising `AttributeError`. Clients see:

```
rpc error: code = Unknown desc = Exception calling application: GetLanguage
```

So **every** `/v1/sound-generation` request that omits `language` (the common case) fails 100% of the time. Same problem with `request.GetCaption()`.

## Fix

Drop the bogus accessor calls in `SoundGeneration` (3 sites). The `TTS` handler a few lines below already uses the correct plain-attribute form, so this just makes `SoundGeneration` consistent:

```python
"vocal_language": request.language or "en",
...
caption = request.caption or request.text
```

No behavior change when the fields *are* set; the fallback default (`"en"` / `request.text`) is preserved.

Fixes #11069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
