### PR TITLE
fix(tts): forward the OpenAI speed field to the backend (#11097)

### DIFF
--- a/core/http/endpoints/localai/tts.go
+++ b/core/http/endpoints/localai/tts.go
@@ -36,6 +36,10 @@ func TTSEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, appConfig 
 			return echo.ErrBadRequest
 		}
 
+		if err := applyTTSSpeed(input); err != nil {
+			return err
+		}
+
 		xlog.Debug("LocalAI TTS Request received", "model", input.Model)
 
 		if cfg.Backend == "" && input.Backend != "" {

--- a/core/http/endpoints/localai/tts_speed.go
+++ b/core/http/endpoints/localai/tts_speed.go
@@ -22,14 +22,17 @@ const (
 // speed=0.8 returns HTTP 200 with an unchanged playback rate instead of either
 // honouring or rejecting it (#11097).
 //
-// An explicit params["speed"] wins so the LocalAI-native extension keeps
+// An explicit `"speed": 0` is invalid (below the documented minimum) and is
+// rejected with 400 rather than treated as unset, which is why Speed is a
+// pointer. An explicit params["speed"] wins so the LocalAI-native extension keeps
 // precedence over the OpenAI-compatible field. Backends whose model exposes no
 // rate control ignore the param, exactly like they ignore `instructions`.
 func applyTTSSpeed(input *schema.TTSRequest) error {
-	if input.Speed == 0 {
+	if input.Speed == nil {
 		return nil
 	}
-	if input.Speed < ttsSpeedMin || input.Speed > ttsSpeedMax {
+	speed := *input.Speed
+	if speed < ttsSpeedMin || speed > ttsSpeedMax {
 		return echo.NewHTTPError(http.StatusBadRequest,
 			fmt.Sprintf("speed must be between %g and %g", ttsSpeedMin, ttsSpeedMax))
 	}
@@ -37,7 +40,7 @@ func applyTTSSpeed(input *schema.TTSRequest) error {
 		input.Params = make(map[string]string)
 	}
 	if _, ok := input.Params["speed"]; !ok {
-		input.Params["speed"] = strconv.FormatFloat(float64(input.Speed), 'g', -1, 32)
+		input.Params["speed"] = strconv.FormatFloat(float64(speed), 'g', -1, 32)
 	}
 	return nil
 }

--- a/core/http/endpoints/localai/tts_speed.go
+++ b/core/http/endpoints/localai/tts_speed.go
@@ -1,0 +1,43 @@
+package localai
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"github.com/mudler/LocalAI/core/schema"
+)
+
+// ttsSpeedMin and ttsSpeedMax mirror the range the OpenAI Speech API documents
+// for the `speed` field.
+const (
+	ttsSpeedMin = 0.25
+	ttsSpeedMax = 4.0
+)
+
+// applyTTSSpeed normalises the OpenAI `speed` field onto the backend-specific
+// params map, which is what actually reaches the gRPC TTSRequest. Without this
+// the field is parsed off the request and then dropped, so a call with
+// speed=0.8 returns HTTP 200 with an unchanged playback rate instead of either
+// honouring or rejecting it (#11097).
+//
+// An explicit params["speed"] wins so the LocalAI-native extension keeps
+// precedence over the OpenAI-compatible field. Backends whose model exposes no
+// rate control ignore the param, exactly like they ignore `instructions`.
+func applyTTSSpeed(input *schema.TTSRequest) error {
+	if input.Speed == 0 {
+		return nil
+	}
+	if input.Speed < ttsSpeedMin || input.Speed > ttsSpeedMax {
+		return echo.NewHTTPError(http.StatusBadRequest,
+			fmt.Sprintf("speed must be between %g and %g", ttsSpeedMin, ttsSpeedMax))
+	}
+	if input.Params == nil {
+		input.Params = make(map[string]string)
+	}
+	if _, ok := input.Params["speed"]; !ok {
+		input.Params["speed"] = strconv.FormatFloat(float64(input.Speed), 'g', -1, 32)
+	}
+	return nil
+}

--- a/core/http/endpoints/localai/tts_speed_test.go
+++ b/core/http/endpoints/localai/tts_speed_test.go
@@ -9,6 +9,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// f32 returns a pointer to v, matching how the OpenAI `speed` field is decoded
+// (a pointer so an explicit zero is distinguishable from an omitted field).
+func f32(v float32) *float32 { return &v }
+
 // Regression for #11097: /v1/audio/speech accepted the documented OpenAI
 // `speed` field, dropped it before the request reached the backend, and
 // returned 200 with an unchanged playback rate. The field must now be
@@ -16,7 +20,7 @@ import (
 // and an out-of-range value must be rejected instead of silently ignored.
 var _ = Describe("applyTTSSpeed", func() {
 	It("forwards speed onto the backend params map", func() {
-		input := &schema.TTSRequest{Speed: 0.8}
+		input := &schema.TTSRequest{Speed: f32(0.8)}
 		Expect(applyTTSSpeed(input)).To(Succeed())
 		Expect(input.Params).To(HaveKeyWithValue("speed", "0.8"))
 	})
@@ -27,14 +31,28 @@ var _ = Describe("applyTTSSpeed", func() {
 		Expect(input.Params).To(BeNil())
 	})
 
+	It("treats an omitted speed as unset but rejects an explicit zero", func() {
+		omitted := &schema.TTSRequest{}
+		Expect(applyTTSSpeed(omitted)).To(Succeed())
+		Expect(omitted.Params).To(BeNil())
+
+		explicitZero := &schema.TTSRequest{Speed: f32(0)}
+		err := applyTTSSpeed(explicitZero)
+		Expect(err).To(HaveOccurred())
+		httpErr, ok := err.(*echo.HTTPError)
+		Expect(ok).To(BeTrue())
+		Expect(httpErr.Code).To(Equal(http.StatusBadRequest))
+		Expect(explicitZero.Params).To(BeNil())
+	})
+
 	It("keeps an explicit params entry over the OpenAI field", func() {
-		input := &schema.TTSRequest{Speed: 0.8, Params: map[string]string{"speed": "1.5"}}
+		input := &schema.TTSRequest{Speed: f32(0.8), Params: map[string]string{"speed": "1.5"}}
 		Expect(applyTTSSpeed(input)).To(Succeed())
 		Expect(input.Params).To(HaveKeyWithValue("speed", "1.5"))
 	})
 
 	It("preserves unrelated params", func() {
-		input := &schema.TTSRequest{Speed: 2, Params: map[string]string{"ref_text": "hello"}}
+		input := &schema.TTSRequest{Speed: f32(2), Params: map[string]string{"ref_text": "hello"}}
 		Expect(applyTTSSpeed(input)).To(Succeed())
 		Expect(input.Params).To(HaveKeyWithValue("ref_text", "hello"))
 		Expect(input.Params).To(HaveKeyWithValue("speed", "2"))
@@ -42,7 +60,7 @@ var _ = Describe("applyTTSSpeed", func() {
 
 	DescribeTable("rejects values outside the OpenAI range",
 		func(speed float32) {
-			input := &schema.TTSRequest{Speed: speed}
+			input := &schema.TTSRequest{Speed: f32(speed)}
 			err := applyTTSSpeed(input)
 			Expect(err).To(HaveOccurred())
 			httpErr, ok := err.(*echo.HTTPError)
@@ -53,11 +71,12 @@ var _ = Describe("applyTTSSpeed", func() {
 		Entry("below the minimum", float32(0.1)),
 		Entry("above the maximum", float32(4.5)),
 		Entry("negative", float32(-1)),
+		Entry("explicit zero (distinct from an omitted field)", float32(0)),
 	)
 
 	DescribeTable("accepts the documented bounds",
 		func(speed float32, want string) {
-			input := &schema.TTSRequest{Speed: speed}
+			input := &schema.TTSRequest{Speed: f32(speed)}
 			Expect(applyTTSSpeed(input)).To(Succeed())
 			Expect(input.Params).To(HaveKeyWithValue("speed", want))
 		},

--- a/core/http/endpoints/localai/tts_speed_test.go
+++ b/core/http/endpoints/localai/tts_speed_test.go
@@ -1,0 +1,67 @@
+package localai
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/mudler/LocalAI/core/schema"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Regression for #11097: /v1/audio/speech accepted the documented OpenAI
+// `speed` field, dropped it before the request reached the backend, and
+// returned 200 with an unchanged playback rate. The field must now be
+// normalised onto the params map that is forwarded to the gRPC TTSRequest,
+// and an out-of-range value must be rejected instead of silently ignored.
+var _ = Describe("applyTTSSpeed", func() {
+	It("forwards speed onto the backend params map", func() {
+		input := &schema.TTSRequest{Speed: 0.8}
+		Expect(applyTTSSpeed(input)).To(Succeed())
+		Expect(input.Params).To(HaveKeyWithValue("speed", "0.8"))
+	})
+
+	It("leaves params untouched when speed is unset", func() {
+		input := &schema.TTSRequest{}
+		Expect(applyTTSSpeed(input)).To(Succeed())
+		Expect(input.Params).To(BeNil())
+	})
+
+	It("keeps an explicit params entry over the OpenAI field", func() {
+		input := &schema.TTSRequest{Speed: 0.8, Params: map[string]string{"speed": "1.5"}}
+		Expect(applyTTSSpeed(input)).To(Succeed())
+		Expect(input.Params).To(HaveKeyWithValue("speed", "1.5"))
+	})
+
+	It("preserves unrelated params", func() {
+		input := &schema.TTSRequest{Speed: 2, Params: map[string]string{"ref_text": "hello"}}
+		Expect(applyTTSSpeed(input)).To(Succeed())
+		Expect(input.Params).To(HaveKeyWithValue("ref_text", "hello"))
+		Expect(input.Params).To(HaveKeyWithValue("speed", "2"))
+	})
+
+	DescribeTable("rejects values outside the OpenAI range",
+		func(speed float32) {
+			input := &schema.TTSRequest{Speed: speed}
+			err := applyTTSSpeed(input)
+			Expect(err).To(HaveOccurred())
+			httpErr, ok := err.(*echo.HTTPError)
+			Expect(ok).To(BeTrue())
+			Expect(httpErr.Code).To(Equal(http.StatusBadRequest))
+			Expect(input.Params).To(BeNil())
+		},
+		Entry("below the minimum", float32(0.1)),
+		Entry("above the maximum", float32(4.5)),
+		Entry("negative", float32(-1)),
+	)
+
+	DescribeTable("accepts the documented bounds",
+		func(speed float32, want string) {
+			input := &schema.TTSRequest{Speed: speed}
+			Expect(applyTTSSpeed(input)).To(Succeed())
+			Expect(input.Params).To(HaveKeyWithValue("speed", want))
+		},
+		Entry("minimum", float32(0.25), "0.25"),
+		Entry("maximum", float32(4), "4"),
+	)
+})

--- a/core/schema/localai.go
+++ b/core/schema/localai.go
@@ -78,6 +78,10 @@ type TTSRequest struct {
 	Format   string `json:"response_format,omitempty" yaml:"response_format,omitempty"` // (optional) output format
 	Stream     bool   `json:"stream,omitempty" yaml:"stream,omitempty"`                   // (optional) enable streaming TTS
 	SampleRate int    `json:"sample_rate,omitempty" yaml:"sample_rate,omitempty"`         // (optional) desired output sample rate
+	// Speed is the OpenAI `speed` field (0.25-4.0). It is normalised into
+	// Params["speed"] so it reaches the backend over the same channel as the
+	// other per-request generation parameters.
+	Speed float32 `json:"speed,omitempty" yaml:"speed,omitempty"`
 	// Instructions is a free-form, per-request style/voice description. It maps to
 	// the OpenAI `instructions` field and is forwarded to the backend so expressive
 	// TTS models (e.g. Qwen3-TTS CustomVoice/VoiceDesign) can vary tone or designed

--- a/core/schema/localai.go
+++ b/core/schema/localai.go
@@ -78,10 +78,12 @@ type TTSRequest struct {
 	Format   string `json:"response_format,omitempty" yaml:"response_format,omitempty"` // (optional) output format
 	Stream     bool   `json:"stream,omitempty" yaml:"stream,omitempty"`                   // (optional) enable streaming TTS
 	SampleRate int    `json:"sample_rate,omitempty" yaml:"sample_rate,omitempty"`         // (optional) desired output sample rate
-	// Speed is the OpenAI `speed` field (0.25-4.0). It is normalised into
-	// Params["speed"] so it reaches the backend over the same channel as the
-	// other per-request generation parameters.
-	Speed float32 `json:"speed,omitempty" yaml:"speed,omitempty"`
+	// Speed is the OpenAI `speed` field (0.25-4.0). It is a pointer so an
+	// explicit `"speed": 0` (invalid, rejected with 400) is distinguishable
+	// from an omitted field (left at the backend default). It is normalised
+	// into Params["speed"] so it reaches the backend over the same channel as
+	// the other per-request generation parameters.
+	Speed *float32 `json:"speed,omitempty" yaml:"speed,omitempty"`
 	// Instructions is a free-form, per-request style/voice description. It maps to
 	// the OpenAI `instructions` field and is forwarded to the backend so expressive
 	// TTS models (e.g. Qwen3-TTS CustomVoice/VoiceDesign) can vary tone or designed

--- a/docs/content/features/text-to-audio.md
+++ b/docs/content/features/text-to-audio.md
@@ -466,22 +466,6 @@ curl http://localhost:8080/v1/audio/speech -H "Content-Type: application/json" -
    }' | aplay
 ```
 
-The OpenAI [`speed`](https://platform.openai.com/docs/api-reference/audio/createSpeech)
-field (0.25-4.0) is accepted as well and is forwarded to the backend as `params.speed`,
-so it can be used without the LocalAI-specific extension:
-
-```
-curl http://localhost:8080/v1/audio/speech -H "Content-Type: application/json" -d '{
-     "model": "qwen-tts",
-     "input": "Hello world, this is a test.",
-     "speed": 0.8
-   }' | aplay
-```
-
-A value outside that range is rejected with `400 Bad Request`. An explicit
-`params.speed` takes precedence over the `speed` field, and backends whose model has
-no rate control simply ignore it.
-
 #### Voice Clone Mode
 
 Voice Clone allows you to clone a voice from reference audio. Configure the model with an `AudioPath` and optional `ref_text`:

--- a/docs/content/features/text-to-audio.md
+++ b/docs/content/features/text-to-audio.md
@@ -466,6 +466,22 @@ curl http://localhost:8080/v1/audio/speech -H "Content-Type: application/json" -
    }' | aplay
 ```
 
+The OpenAI [`speed`](https://platform.openai.com/docs/api-reference/audio/createSpeech)
+field (0.25-4.0) is accepted as well and is forwarded to the backend as `params.speed`,
+so it can be used without the LocalAI-specific extension:
+
+```
+curl http://localhost:8080/v1/audio/speech -H "Content-Type: application/json" -d '{
+     "model": "qwen-tts",
+     "input": "Hello world, this is a test.",
+     "speed": 0.8
+   }' | aplay
+```
+
+A value outside that range is rejected with `400 Bad Request`. An explicit
+`params.speed` takes precedence over the `speed` field, and backends whose model has
+no rate control simply ignore it.
+
 #### Voice Clone Mode
 
 Voice Clone allows you to clone a voice from reference audio. Configure the model with an `AudioPath` and optional `ref_text`:


### PR DESCRIPTION
### Description

Fixes #11097.

`/v1/audio/speech` accepted the documented OpenAI `speed` field and then dropped it. `schema.TTSRequest` has no `Speed` member, so the value was parsed off the JSON body by the binder and discarded before the handler ran — it never reached `proto.TTSRequest`, and the request returned `200` with an unchanged playback rate. That is why the reporter saw byte-identical durations for `speed=1.0` and `speed=0.8`.

This PR fixes the API boundary:

- `schema.TTSRequest` gains `Speed float32` (`json:"speed"`).
- A new `applyTTSSpeed` helper normalises it into the existing per-request `params` map, which `core/backend.newTTSRequest` forwards verbatim into `proto.TTSRequest.Params`. That is the same channel `ref_text`, `seed` and the Chatterbox generation parameters already use, and backends that merge params generically (e.g. `qwen-tts`) pick it up without further changes.
- An explicit `params.speed` keeps precedence over the OpenAI-compatible field, so the LocalAI-native extension is not overridden.
- A value outside the documented `0.25`–`4.0` range now returns `400` instead of being silently accepted. Validation runs before any voice profile is leased.

### Scope note

This restores the field end-to-end at the LocalAI layer. For `omnivoice-cpp` specifically the synthesis rate still will not change, because that backend's C entrypoint (`omni_tts(text, lang, instruct, ref_samples, ref_n, ref_text, seed, denoise, out_n)`) exposes no rate/duration argument at all — there is nothing to forward it to. Adding one belongs in the omnivoice library rather than here, so I kept this PR to the request-handling defect the issue identifies, which is the part that affects every TTS backend.

The reporter's side note about `instructions` free-form text returning `500` instead of a `400` naming the allowed vocabulary is left out of scope.

### Tests

`core/http/endpoints/localai/tts_speed_test.go` covers forwarding, the unset case (params stays `nil`), explicit-`params` precedence, preservation of unrelated params, both range bounds, and rejection below/above the range and for negatives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
