### PR TITLE
docs: add reverse proxy timeout guidance

### DIFF
--- a/docs/content/advanced/reverse-proxy-tls.md
+++ b/docs/content/advanced/reverse-proxy-tls.md
@@ -144,11 +144,12 @@ Adjust the `60m` values for the slowest request you expect to serve. The
 important setting for long non-streaming requests is `proxy_read_timeout`: if
 the proxy stops waiting before LocalAI finishes, clients receive a proxy-generated
 `504 Gateway Time-out` even though inference may still be running. OpenResty,
-Nginx Proxy Manager, Caddy, Traefik, and HAProxy have equivalent upstream
-response timeout settings.
+Nginx Proxy Manager, Caddy, Traefik, HAProxy, and ingress controllers have
+equivalent upstream response timeout settings.
 
 For bulk jobs on a trusted private network, you can also bypass the public
-reverse proxy and connect directly to LocalAI.
+reverse proxy and connect directly to LocalAI, for example
+`http://localai-host:8080/v1`.
 
 ## Serving Under a Sub-Path
 


### PR DESCRIPTION
## What this change does

This PR is now a small follow-up to the timeout guidance that landed in #11065. It clarifies that equivalent upstream response timeout settings may also live in ingress controllers, and it adds an example private LocalAI URL for trusted bulk jobs that bypass the public reverse proxy:

- `http://localai-host:8080/v1`

References #11046.

## How it was tested

- Ran `hugo` from `docs/` successfully after initializing the pinned `docs/themes/hugo-theme-relearn` submodule.
- Verified the generated documentation previously rendered the reverse proxy TLS page successfully.

## Breaking changes or migration steps

None. Documentation-only change.