### PR TITLE
Fix use case for video model

### DIFF
--- a/gallery/wan-ggml.yaml
+++ b/gallery/wan-ggml.yaml
@@ -5,6 +5,8 @@ config_file: |
     backend: stablediffusion-ggml
     step: 20
     cfg_scale: 6.0
+    known_usecases:
+      - video
     options:
     - "diffusion_model"
     - "vae_decode_only:false"


### PR DESCRIPTION
gallery/wan-ggml.yaml never set known_usecases, so the four WAN 2.1 GGML entries sharing it fell back to GuessUsecases, which reads the backend name only. imageBackends carries stablediffusion-ggml, videoBackends does not, so WAN checkpoints came out FLAG_IMAGE and never FLAG_VIDEO.

So /video rejected them and the WebUI listed them under image generation. Picking one there ran a video architecture through generate_image() with no frame count, and stable-diffusion.cpp divided by the resulting zero:

```
[INFO ] stable-diffusion.cpp:5133 - generating image: 1/1 - seed 1872578027
SIGFPE: floating-point exception
```

The backend process dies, the request 500s.

Fixed the same way gallery/ltx-ggml.yaml already does it for LTX-Video.

Notes for Reviewers

- Shared base config, so this covers all four WAN entries. None override known_usecases; nothing else references the file.
- Does not fully close the crash: HasUsecases is additive, so FLAG_IMAGE still falls through to GuessUsecases. These gain /video but stay in the
image picker. A real gate needs stablediffusion-ggml handled in the GuessUsecases image/video split, or a guard in the backend. Happy to follow up if you have a preference.

Signed commits
- [x] Yes, I signed my commits.
- [x] Documentation updated, or not applicable

Co-Authored-With: Claude AI