### PR TITLE
fix(utils): reject tar hardlinks that escape the extraction root

### DIFF
--- a/pkg/utils/untar.go
+++ b/pkg/utils/untar.go
@@ -70,6 +70,11 @@ func ExtractArchive(archive, dst string) error {
 		if f.FileInfo.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("archive contains a symlink")
 		}
+		if linkname, ok := archiveMemberLinkname(f); ok {
+			if err := validateArchiveMemberPath(extractRoot, linkname); err != nil {
+				return err
+			}
+		}
 		return nil
 	})
 
@@ -92,6 +97,18 @@ func archiveMemberName(f archiver.File) string {
 		return h.Name
 	default:
 		return f.Name()
+	}
+}
+
+// archiveMemberLinkname reports the target of a tar hardlink member, which carries a regular file mode and so is not caught by the symlink check.
+func archiveMemberLinkname(f archiver.File) (string, bool) {
+	switch h := f.Header.(type) {
+	case tar.Header:
+		return h.Linkname, h.Typeflag == tar.TypeLink
+	case *tar.Header:
+		return h.Linkname, h.Typeflag == tar.TypeLink
+	default:
+		return "", false
 	}
 }
 

--- a/pkg/utils/untar_test.go
+++ b/pkg/utils/untar_test.go
@@ -3,6 +3,7 @@ package utils_test
 import (
 	"archive/tar"
 	"archive/zip"
+	"compress/gzip"
 	"os"
 	"path/filepath"
 
@@ -60,12 +61,45 @@ var _ = Describe("utils/archive tests", func() {
 		Expect(filepath.Join(tmpDir, "escaped.txt")).ToNot(BeAnExistingFile())
 	})
 
+	It("rejects tar hardlinks that overwrite a file outside the destination", func() {
+		tmpDir := GinkgoT().TempDir()
+		archivePath := filepath.Join(tmpDir, "model.tar.gz")
+		extractPath := filepath.Join(tmpDir, "models")
+		outsidePath := filepath.Join(tmpDir, "outside.txt")
+
+		Expect(os.WriteFile(outsidePath, []byte("original"), 0o600)).To(Succeed())
+		Expect(writeTarGzArchiveWithHardlinkedFile(archivePath, "payload.bin", "../outside.txt", "overwritten")).To(Succeed())
+
+		err := ExtractArchive(archivePath, extractPath)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unsafe path"))
+
+		contents, readErr := os.ReadFile(outsidePath)
+		Expect(readErr).ToNot(HaveOccurred())
+		Expect(string(contents)).To(Equal("original"))
+	})
+
+	It("extracts tar hardlinks that stay inside the destination", func() {
+		tmpDir := GinkgoT().TempDir()
+		archivePath := filepath.Join(tmpDir, "model.tar.gz")
+		extractPath := filepath.Join(tmpDir, "models")
+
+		Expect(writeTarGzArchiveWithInternalHardlink(archivePath, "model.bin", "alias.bin", "weights")).To(Succeed())
+
+		Expect(ExtractArchive(archivePath, extractPath)).To(Succeed())
+
+		extracted, err := os.ReadFile(filepath.Join(extractPath, "alias.bin"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(extracted)).To(Equal("weights"))
+	})
+
 	It("rejects tar hardlinks that point outside the destination", func() {
 		tmpDir := GinkgoT().TempDir()
 		archivePath := filepath.Join(tmpDir, "model.tar")
 		extractPath := filepath.Join(tmpDir, "models")
 
-		Expect(writeTarArchiveWithHardlink(archivePath, "payload.bin", "../../escaped.txt")).To(Succeed())
+		Expect(writeTarArchiveWithHardlink(archivePath, "payload.bin", "../escaped.txt")).To(Succeed())
 
 		err := ExtractArchive(archivePath, extractPath)
 
@@ -162,6 +196,98 @@ func writeTarArchiveWithHardlink(path, name, linkname string) (err error) {
 	return writer.WriteHeader(&tar.Header{
 		Name:     name,
 		Linkname: linkname,
+		Typeflag: tar.TypeLink,
+		Mode:     0o600,
+	})
+}
+
+func writeTarGzArchiveWithHardlinkedFile(path, name, linkname, contents string) (err error) {
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := out.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	compressor := gzip.NewWriter(out)
+	defer func() {
+		if closeErr := compressor.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	writer := tar.NewWriter(compressor)
+	defer func() {
+		if closeErr := writer.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	if err := writer.WriteHeader(&tar.Header{
+		Name:     name,
+		Linkname: linkname,
+		Typeflag: tar.TypeLink,
+		Mode:     0o600,
+	}); err != nil {
+		return err
+	}
+
+	data := []byte(contents)
+	if err := writer.WriteHeader(&tar.Header{
+		Name: name,
+		Mode: 0o600,
+		Size: int64(len(data)),
+	}); err != nil {
+		return err
+	}
+	_, err = writer.Write(data)
+
+	return err
+}
+
+func writeTarGzArchiveWithInternalHardlink(path, targetName, linkName, contents string) (err error) {
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := out.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	compressor := gzip.NewWriter(out)
+	defer func() {
+		if closeErr := compressor.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	writer := tar.NewWriter(compressor)
+	defer func() {
+		if closeErr := writer.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	data := []byte(contents)
+	if err := writer.WriteHeader(&tar.Header{
+		Name: targetName,
+		Mode: 0o600,
+		Size: int64(len(data)),
+	}); err != nil {
+		return err
+	}
+	if _, err := writer.Write(data); err != nil {
+		return err
+	}
+
+	return writer.WriteHeader(&tar.Header{
+		Name:     linkName,
+		Linkname: targetName,
 		Typeflag: tar.TypeLink,
 		Mode:     0o600,
 	})

--- a/pkg/utils/untar_test.go
+++ b/pkg/utils/untar_test.go
@@ -59,6 +59,20 @@ var _ = Describe("utils/archive tests", func() {
 		Expect(err.Error()).To(ContainSubstring("unsafe path"))
 		Expect(filepath.Join(tmpDir, "escaped.txt")).ToNot(BeAnExistingFile())
 	})
+
+	It("rejects tar hardlinks that point outside the destination", func() {
+		tmpDir := GinkgoT().TempDir()
+		archivePath := filepath.Join(tmpDir, "model.tar")
+		extractPath := filepath.Join(tmpDir, "models")
+
+		Expect(writeTarArchiveWithHardlink(archivePath, "payload.bin", "../../escaped.txt")).To(Succeed())
+
+		err := ExtractArchive(archivePath, extractPath)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("unsafe path"))
+		Expect(filepath.Join(tmpDir, "escaped.txt")).ToNot(BeAnExistingFile())
+	})
 })
 
 func writeZipArchive(path string, files map[string]string) (err error) {
@@ -125,4 +139,30 @@ func writeTarArchive(path string, files map[string]string) (err error) {
 	}
 
 	return nil
+}
+
+func writeTarArchiveWithHardlink(path, name, linkname string) (err error) {
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := out.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	writer := tar.NewWriter(out)
+	defer func() {
+		if closeErr := writer.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	return writer.WriteHeader(&tar.Header{
+		Name:     name,
+		Linkname: linkname,
+		Typeflag: tar.TypeLink,
+		Mode:     0o600,
+	})
 }


### PR DESCRIPTION
**Description**

`ExtractArchive` in `pkg/utils/untar.go` walks archive members before extracting and rejects two things: member paths that resolve outside the destination, and symlinks. Tar hardlink entries are covered by neither. `Header.FileInfo()` reports a regular file mode for a hardlink, so the symlink test does not match, and `Header.Linkname` is never inspected. An archive can therefore name a link target outside the extraction directory and the extractor will create it.

This passes `Linkname` through the same validation already applied to member names, so a hardlink pointing outside the extraction root is rejected with the existing "unsafe path" error. Hardlinks whose target resolves inside the root still extract normally, so ordinary archives are unaffected.

`pkg/oci/image.go` already handles this on the OCI image path, resolving `tar.TypeLink` targets against the extraction root before using them. This brings the archive path in line with it.

**Notes for Reviewers**

Three tests cover this, all in `pkg/utils/untar_test.go`.

`rejects tar hardlinks that point outside the destination` writes a tar holding a single `tar.TypeLink` entry whose `Linkname` is `../escaped.txt`, then asserts extraction fails and nothing lands outside the destination. Without the fix it fails, and the failure output shows the underlying archiver attempting to create the link outside the extraction directory.

`rejects tar hardlinks that overwrite a file outside the destination` uses a `.tar.gz`, which is where `ExtractArchive` binds a `Tar` config with `OverwriteExisting` set, and follows the link entry with a regular entry of the same name. Without the fix that pair links to a file above the extraction root and then truncates it through the link, so `ExtractArchive` returns nil and the outside file comes back holding the archive's contents instead of its own. The plain `.tar` case never reaches the write.

`extracts tar hardlinks that stay inside the destination` links to an earlier member of the same archive and expects extraction to succeed, so the new check is not rejecting ordinary archives.

The full `pkg/utils` package passes on Linux with go1.26.0, 59 specs. `gofmt -l` and `go vet ./pkg/utils/` are clean. `golangci-lint` would not run because the released binary is built with Go 1.25 while the module targets 1.26.0.

Unrelated to this change and not touched here: the same package's suite hangs on Windows. `InTrustedRoot` in `pkg/utils/path.go` loops `for path != "/"`, and `filepath.Dir` on a Windows volume root returns its input unchanged, so the loop never terminates. I mention it only to explain why I verified on Linux.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable

