### PR TITLE
fix(react-ui): stop traces page crash when switching trace tabs

### DIFF
--- a/core/http/react-ui/e2e/traces-live.spec.js
+++ b/core/http/react-ui/e2e/traces-live.spec.js
@@ -20,3 +20,46 @@ test('marks an API trace with no response status as in progress', async ({ page 
   await expect(row.locator('[title="In progress"]')).toBeVisible()
   await expect(row.locator('.fa-check-circle')).toHaveCount(0)
 })
+
+// Regression for #11376: switching from Backend Traces back to API Traces
+// used to crash the page. `traces` holds whichever list was fetched last, so
+// right after `setActiveTab('api')` — before the refetch effect lands — the
+// API table renders the previous tab's backend rows, which carry no
+// `response` envelope. The status column must tolerate that instead of
+// dereferencing `trace.response.status` and tearing down the React tree.
+test('switching from backend to API traces with a response-less row does not crash', async ({ page }) => {
+  const pageErrors = []
+  page.on('pageerror', (e) => pageErrors.push(e.message))
+
+  await page.route('**/api/traces?*', route => route.fulfill({
+    json: [{
+      id: 'api-1',
+      timestamp: '2026-08-05T02:00:00Z',
+      request: { method: 'POST', path: '/v1/chat/completions' },
+      response: { status: 200 },
+    }],
+    headers: { 'X-Total-Count': '1' },
+  }))
+  await page.route('**/api/backend-traces?*', route => route.fulfill({
+    json: [{
+      id: 'backend-1',
+      type: 'llm',
+      timestamp: '2026-08-05T02:00:00Z',
+      model_name: 'mock-model',
+      summary: 'generated a reply',
+    }],
+    headers: { 'X-Total-Count': '1' },
+  }))
+
+  await page.goto('/app/traces')
+  await expect(page.locator('tbody tr').filter({ hasText: '/v1/chat/completions' })).toBeVisible()
+
+  await page.getByRole('button', { name: /Backend Traces/ }).click()
+  await expect(page.locator('tbody tr').filter({ hasText: 'generated a reply' })).toBeVisible()
+
+  await page.getByRole('button', { name: /API Traces/ }).click()
+  // The stale backend row renders in the API table for one frame; the status
+  // column falls back to a neutral placeholder rather than throwing.
+  await expect(page.locator('tbody tr').filter({ hasText: '/v1/chat/completions' })).toBeVisible()
+  expect(pageErrors).toEqual([])
+})

--- a/core/http/react-ui/src/pages/Traces.jsx
+++ b/core/http/react-ui/src/pages/Traces.jsx
@@ -667,6 +667,8 @@ export default function Traces() {
                     <td>
                       {trace.response?.status === 0
                         ? <span className="badge badge-info">Running</span>
+                        : trace.response?.status == null
+                        ? <span className="badge badge--soft">-</span>
                         : <span className={`badge ${trace.response.status < 400 ? 'badge-success' : 'badge-error'}`}>{trace.response.status}</span>}
                     </td>
                     <td><LatencyCell ns={trace.duration} max={slowestTrace} /></td>


### PR DESCRIPTION
Fixes #11376

## What

Switching from **Backend Traces** to **API Traces** crashed the whole traces page with `can't access property "status", e.response is undefined`.

## Root cause

`core/http/react-ui/src/pages/Traces.jsx` held a single `traces` array shared by both tabs. On a tab switch, React renders with the new `activeTab` before the refetch `useEffect` lands, so the API table briefly renders the previous tab's backend rows. Backend trace records have no `request`/`response` envelope, and the API status column dereferenced it unguarded:

```jsx
{trace.response?.status === 0
  ? <span className="badge badge-info">Running</span>
  : <span className={`badge ${trace.response.status < 400 ? ... }`}>...}
```

`trace.response?.status === 0` is safe, but the else branch's `trace.response.status` throws when `response` is undefined, tearing down the React tree.

## Fix

Render a neutral `-` placeholder when the row has no response instead of crashing, and add a regression spec that reproduces the exact tab-switch sequence.

## Verification

- New regression spec `traces-live.spec.js` **fails on the pre-fix code** (page error) and **passes with the fix**
- All 23 trace e2e specs pass (`playwright test e2e/traces*.spec.js`)
- `eslint` clean (no new warnings)