### PR TITLE
fix(realtime): keep the ICE interface allow-list working with a fixed UDP port

### DIFF
--- a/core/http/endpoints/openai/realtime_webrtc_ice.go
+++ b/core/http/endpoints/openai/realtime_webrtc_ice.go
@@ -2,10 +2,10 @@ package openai
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/mudler/LocalAI/core/config"
 	"github.com/mudler/xlog"
+	"github.com/pion/ice/v4"
 	"github.com/pion/webrtc/v4"
 )
 
@@ -31,13 +31,46 @@ func webRTCSettingEngine(cfg *config.ApplicationConfig) (webrtc.SettingEngine, e
 		xlog.Debug("realtime webrtc: restricting ICE interfaces", "interfaces", cfg.WebRTCICEInterfaces)
 	}
 	if cfg.WebRTCUDPPort > 0 {
-		conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero, Port: cfg.WebRTCUDPPort})
+		mux, err := udpMuxOnPort(cfg.WebRTCUDPPort, cfg.WebRTCICEInterfaces)
 		if err != nil {
-			return s, fmt.Errorf("bind WebRTC UDP port %d: %w", cfg.WebRTCUDPPort, err)
+			return s, err
 		}
-		s.SetICEUDPMux(webrtc.NewICEUDPMux(nil, conn))
+		s.SetICEUDPMux(mux)
+		xlog.Debug("realtime webrtc: sharing a fixed UDP port", "port", cfg.WebRTCUDPPort)
 	}
 	return s, nil
+}
+
+// udpMuxOnPort binds port on each interface the allow-list admits and returns a
+// mux every session shares.
+//
+// One socket per interface address rather than one wildcard socket: for a mux
+// bound to 0.0.0.0 pion derives the host candidates by enumerating interfaces
+// itself, with no filter and loopback included, and its muxed gathering path
+// never consults SetInterfaceFilter. A wildcard socket therefore silently
+// discards WebRTCICEInterfaces and re-advertises exactly the docker0/veth
+// addresses that setting exists to suppress.
+func udpMuxOnPort(port int, interfaces []string) (ice.UDPMux, error) {
+	// UDP4 only, matching the socket family this replaces.
+	opts := []ice.UDPMuxFromPortOption{ice.UDPMuxFromPortWithNetworks(ice.NetworkTypeUDP4)}
+	if filter := iceInterfaceFilter(interfaces); filter != nil {
+		opts = append(opts, ice.UDPMuxFromPortWithInterfaceFilter(filter))
+	}
+
+	mux, err := ice.NewMultiUDPMuxFromPort(port, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("bind WebRTC UDP port %d: %w", port, err)
+	}
+	// An empty mux binds nothing and would leave signaling working while no
+	// candidate is ever advertised, so report the misconfiguration instead.
+	if len(mux.GetListenAddresses()) == 0 {
+		_ = mux.Close()
+		if len(interfaces) > 0 {
+			return nil, fmt.Errorf("bind WebRTC UDP port %d: no usable IPv4 address on interfaces %v", port, interfaces)
+		}
+		return nil, fmt.Errorf("bind WebRTC UDP port %d: no usable IPv4 address on this host", port)
+	}
+	return mux, nil
 }
 
 // iceInterfaceFilter returns an interface allow-list predicate for pion, or nil

--- a/core/http/endpoints/openai/realtime_webrtc_ice_test.go
+++ b/core/http/endpoints/openai/realtime_webrtc_ice_test.go
@@ -3,10 +3,13 @@ package openai
 import (
 	"net"
 	"runtime"
+	"strings"
+	"time"
 
 	"github.com/mudler/LocalAI/core/config"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/pion/webrtc/v4"
 )
 
 var _ = Describe("webRTC ICE settings", func() {
@@ -68,5 +71,126 @@ var _ = Describe("webRTC ICE settings", func() {
 			})
 			Expect(err).To(MatchError(ContainSubstring("bind WebRTC UDP port")))
 		})
+
+		// A fixed UDP port and an interface allow-list are the two settings an
+		// operator behind a firewall reaches for together: one to write the
+		// firewall rule against, the other to keep unreachable docker0/veth
+		// addresses out of the candidate list. Pinning the port must not cost
+		// them the filter.
+		It("honours the interface allow-list when a UDP port is pinned", func() {
+			_, err := webRTCSettingEngine(&config.ApplicationConfig{
+				WebRTCICEInterfaces: []string{"localai-no-such-interface"},
+				WebRTCUDPPort:       freeUDPPort(),
+			})
+			Expect(err).To(MatchError(ContainSubstring("localai-no-such-interface")))
+		})
+
+		It("gathers host candidates only on allowed interfaces when a UDP port is pinned", func() {
+			allowed, others := splitLocalInterfaces()
+			if allowed == "" || len(others) == 0 {
+				Skip("needs at least two non-loopback interfaces with IPv4 addresses")
+			}
+
+			engine, err := webRTCSettingEngine(&config.ApplicationConfig{
+				WebRTCICEInterfaces: []string{allowed},
+				WebRTCUDPPort:       freeUDPPort(),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			gathered := gatheredHostIPs(engine)
+			Expect(gathered).NotTo(BeEmpty(), "the allowed interface should still produce a candidate")
+			Expect(gathered).To(ConsistOf(ipsOfInterface(allowed)))
+			for _, excluded := range others {
+				for _, ip := range ipsOfInterface(excluded) {
+					Expect(gathered).NotTo(ContainElement(ip),
+						"candidate from %s leaked despite the allow-list naming only %s", excluded, allowed)
+				}
+			}
+		})
 	})
 })
+
+// freeUDPPort asks the kernel for an unused UDP port and releases it.
+func freeUDPPort() int {
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4zero})
+	Expect(err).NotTo(HaveOccurred())
+	port := conn.LocalAddr().(*net.UDPAddr).Port
+	Expect(conn.Close()).To(Succeed())
+	return port
+}
+
+// splitLocalInterfaces returns one interface to allow plus every other
+// candidate-bearing interface, so a spec can assert the others stay out.
+func splitLocalInterfaces() (allowed string, others []string) {
+	ifaces, err := net.Interfaces()
+	Expect(err).NotTo(HaveOccurred())
+	var usable []string
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if len(ipsOfInterface(iface.Name)) > 0 {
+			usable = append(usable, iface.Name)
+		}
+	}
+	if len(usable) == 0 {
+		return "", nil
+	}
+	return usable[0], usable[1:]
+}
+
+// ipsOfInterface returns the IPv4 addresses pion can gather a host candidate
+// on for the named interface.
+func ipsOfInterface(name string) []string {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil
+	}
+	var ips []string
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok || ipNet.IP.To4() == nil {
+			continue
+		}
+		ips = append(ips, ipNet.IP.String())
+	}
+	return ips
+}
+
+// gatheredHostIPs runs a peer connection through the engine and returns the
+// distinct IPs of the host candidates it advertises.
+func gatheredHostIPs(engine webrtc.SettingEngine) []string {
+	pc, err := webrtc.NewAPI(webrtc.WithSettingEngine(engine)).NewPeerConnection(webrtc.Configuration{})
+	Expect(err).NotTo(HaveOccurred())
+	defer pc.Close()
+
+	_, err = pc.CreateDataChannel("probe", nil)
+	Expect(err).NotTo(HaveOccurred())
+	offer, err := pc.CreateOffer(nil)
+	Expect(err).NotTo(HaveOccurred())
+	gathered := webrtc.GatheringCompletePromise(pc)
+	Expect(pc.SetLocalDescription(offer)).To(Succeed())
+	Eventually(gathered, 10*time.Second).Should(BeClosed())
+
+	// Candidate lines read "a=candidate:<foundation> <component> udp
+	// <priority> <ip> <port> typ host ...", so the IP is the fifth field.
+	seen := map[string]struct{}{}
+	var ips []string
+	for _, line := range strings.Split(pc.LocalDescription().SDP, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "a=candidate:") || !strings.Contains(line, " typ host") {
+			continue
+		}
+		ip := strings.Fields(line)[4]
+		if _, dup := seen[ip]; dup {
+			continue
+		}
+		seen[ip] = struct{}{}
+		ips = append(ips, ip)
+	}
+	return ips
+}

--- a/go.mod
+++ b/go.mod
@@ -322,7 +322,7 @@ require (
 	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/pion/datachannel v1.6.0 // indirect
 	github.com/pion/dtls/v3 v3.1.2 // indirect
-	github.com/pion/ice/v4 v4.2.2 // indirect
+	github.com/pion/ice/v4 v4.2.2
 	github.com/pion/interceptor v0.1.44 // indirect
 	github.com/pion/logging v0.2.4 // indirect
 	github.com/pion/mdns/v2 v2.1.0 // indirect


### PR DESCRIPTION
Follow-up to #11436, which added `LOCALAI_WEBRTC_UDP_PORT` and closed #11375.

## The bug

`LOCALAI_WEBRTC_ICE_INTERFACES` is silently ignored whenever `LOCALAI_WEBRTC_UDP_PORT` is set. Every interface is gathered regardless of the allow-list.

This matters because these two settings are naturally used together: an operator who pins a UDP port to write a firewall rule is usually the same operator who needs to keep unreachable `docker0`/`veth` addresses out of the candidate list. The result is the failure mode the interface setting was added to prevent — the browser gets unroutable `172.x` candidates, connects on a good pair, then drops when ICE consent checks fail on the others.

## Reproducer

With `WebRTCICEInterfaces: ["eno1"]` set in both runs, only the port differing, on a host with docker bridges:

| config | gathered host candidates |
|---|---|
| no UDP port | `192.168.1.73`, `2a02:…:cbe` — `eno1` only, correct |
| `WebRTCUDPPort` set | `192.168.1.73`, **`172.18.0.1`, `172.17.0.1`, `10.10.10.1`, `10.10.20.1`, `172.19.0.1`** |

## Cause

Two independent things combine:

1. `webrtc.NewICEUDPMux` over a wildcard (`0.0.0.0`) socket makes `ice.NewUDPMuxDefault` derive the candidate addresses by enumerating interfaces itself, via `localInterfaces(net, nil, nil, networks, true)` — nil interface filter, loopback included. pion even warns about this: *"UDPMuxDefault should not listening on unspecified address, use NewMultiUDPMuxFromPort instead"*.
2. `gatherCandidatesLocalUDPMux` in `pion/ice` never consults the agent's `interfaceFilter`, so `SetInterfaceFilter` has no effect on the muxed path either way.

## Fix

Use `ice.NewMultiUDPMuxFromPort`, which accepts `UDPMuxFromPortWithInterfaceFilter`, instead of a single wildcard socket. It binds one socket per admitted interface address, all on the same port, so the firewall requirement remains a single rule and the "one port serves every session" property is unchanged. Networks are pinned to UDP4 to match the socket family being replaced.

An allow-list matching no address on the host now returns an error instead of binding nothing — otherwise signaling keeps succeeding while no candidate is ever advertised, which is harder to diagnose than a clear failure.

## Tests

- An unmatched allow-list is an error.
- With a pinned port and an allow-list, a real peer connection gathers candidates only on the allowed interface and none from the excluded ones. Skipped on hosts with fewer than two non-loopback interfaces, since there is nothing to exclude there.

Verified failing before the change and passing after. The four specs added in #11436 still pass unchanged.

## Note

`github.com/pion/ice/v4` moves from indirect to direct in `go.mod`. No new module — it was already in the tree as a transitive dependency of `pion/webrtc/v4`.
