### PR TITLE
fix(modelartifacts): reuse committed sibling files for narrowed allow_patterns

### DIFF
--- a/pkg/modelartifacts/materializer.go
+++ b/pkg/modelartifacts/materializer.go
@@ -414,6 +414,9 @@ func (m *Manager) materializeLocked(ctx context.Context, modelsPath string, spec
 	skippedFiles := 0
 	skippedBytes := int64(0)
 	tasks := make([]downloader.FileTask, 0, len(snapshot.Files))
+	// Sibling manifests are read once, before the staging loop, so the
+	// per-file reuse lookups below never re-read or re-parse them.
+	siblings := loadSiblingCandidates(modelsPath, spec, layout)
 	for index, file := range snapshot.Files {
 		if err := ctx.Err(); err != nil {
 			return Result{}, err
@@ -431,6 +434,21 @@ func (m *Manager) materializeLocked(ctx context.Context, modelsPath string, spec
 		snapshotRel := path.Join("snapshot", file.Path)
 		snapshotAbs := filepath.Join(layout.Partial, filepath.FromSlash(snapshotRel))
 		if entry, ok := reuseMaterializedFile(snapshotAbs, file); ok {
+			manifest.Files[taskIndex] = entry
+			completedBytes.Add(file.Size)
+			skippedFiles++
+			skippedBytes += file.Size
+			continue
+		}
+		// Before reaching for the network, consult committed sibling trees for the
+		// same Source (type+endpoint+repo+revision). A narrower allow_patterns
+		// request gets a different CacheKey, so committedResult misses even though a
+		// broader sibling already holds this exact file; reusing it avoids a
+		// redundant re-download of tens of gigabytes. The match is re-verified
+		// through verifyDownloadedFile (full SHA-256), never size-only, and a broader
+		// request can never inherit a narrower sibling's gaps because each file is
+		// matched individually against the sibling's manifest.
+		if entry, ok := reuseFromCommittedSibling(siblings, file, layout, root); ok {
 			manifest.Files[taskIndex] = entry
 			completedBytes.Add(file.Size)
 			skippedFiles++
@@ -586,6 +604,129 @@ func reuseMaterializedFile(fileName string, source hfapi.SnapshotFile) (Manifest
 		return ManifestFile{}, false
 	}
 	return entry, true
+}
+
+// siblingCandidate is one committed sibling artifact tree that shares this
+// request's Source (type+endpoint+repo+revision), with its manifest files
+// indexed by path.
+type siblingCandidate struct {
+	final       string
+	filesByPath map[string][]ManifestFile
+}
+
+// loadSiblingCandidates reads the committed sibling manifest set once, before
+// the staging loop. Doing it per file instead would re-read and re-parse every
+// sibling manifest for every file — 20 committed siblings and a 300-file
+// snapshot means 6000 manifest reads before the first byte is fetched.
+//
+// The current artifact's own committed tree is excluded: it is either absent
+// (the reason materializeLocked is running) or already handled by
+// committedResult's exact-key fast path.
+func loadSiblingCandidates(modelsPath string, spec Spec, layout Layout) []siblingCandidate {
+	if spec.Resolved == nil || layout.Final == "" {
+		return nil
+	}
+	siblingsRoot := filepath.Join(modelsPath, ".artifacts", "huggingface")
+	entries, err := os.ReadDir(siblingsRoot)
+	if err != nil {
+		return nil
+	}
+	var candidates []siblingCandidate
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		siblingFinal := filepath.Join(siblingsRoot, entry.Name())
+		if siblingFinal == layout.Final {
+			continue
+		}
+		siblingManifest, err := ReadManifest(filepath.Join(siblingFinal, "manifest.json"))
+		if err != nil {
+			continue
+		}
+		siblingArtifact := siblingManifest.Artifact
+		if siblingArtifact.Resolved == nil ||
+			siblingArtifact.Source.Type != spec.Source.Type ||
+			siblingArtifact.Resolved.Endpoint != spec.Resolved.Endpoint ||
+			siblingArtifact.Source.Repo != spec.Source.Repo ||
+			siblingArtifact.Resolved.Revision != spec.Resolved.Revision {
+			continue
+		}
+		byPath := make(map[string][]ManifestFile, len(siblingManifest.Files))
+		for _, f := range siblingManifest.Files {
+			byPath[f.Path] = append(byPath[f.Path], f)
+		}
+		candidates = append(candidates, siblingCandidate{final: siblingFinal, filesByPath: byPath})
+	}
+	return candidates
+}
+
+// reuseFromCommittedSibling looks for a file already committed under a sibling
+// artifact tree — same Source (type+endpoint+repo+revision), different
+// allow/ignore patterns — and stages it for this writer instead of fetching.
+// A narrower allow_patterns request gets a different CacheKey (path.go:62), so
+// committedResult misses and materializeLocked would otherwise re-download
+// files an already-committed broader sibling already holds.
+//
+// The match is never size-only: the sibling file is re-hashed through the
+// shared verifyDownloadedFile against the current request's SnapshotFile (its
+// LFS or git blob OID), so the staged entry is byte-for-byte identical to a
+// fresh download. A broader request can never stand in for files a narrower
+// sibling lacks, because each requested file is matched individually against
+// the sibling's manifest file set. Hard-link keeps the shared models volume
+// disk-neutral; a byte copy is the fallback only for EXDEV, the one case the
+// kernel cannot hard-link.
+func reuseFromCommittedSibling(candidates []siblingCandidate, file hfapi.SnapshotFile, layout Layout, root *os.Root) (ManifestFile, bool) {
+	snapshotRel := path.Join("snapshot", file.Path)
+	snapshotAbs := filepath.Join(layout.Partial, filepath.FromSlash(snapshotRel))
+	for _, sibling := range candidates {
+		for _, siblingFile := range sibling.filesByPath[file.Path] {
+			if siblingFile.Size != file.Size {
+				continue
+			}
+			siblingPath := filepath.Join(sibling.final, "snapshot", filepath.FromSlash(file.Path))
+			verified, err := verifyDownloadedFile(siblingPath, file)
+			if err != nil {
+				continue
+			}
+			if err := root.MkdirAll(path.Dir(snapshotRel), 0o750); err != nil {
+				return ManifestFile{}, false
+			}
+			_ = root.Remove(snapshotRel)
+			if err := linkOrCopy(siblingPath, snapshotAbs); err != nil {
+				return ManifestFile{}, false
+			}
+			return verified, true
+		}
+	}
+	return ManifestFile{}, false
+}
+
+// linkOrCopy hard-links src to dst, falling back to a byte-for-byte copy only
+// when the kernel refuses a hard link across filesystems (EXDEV). Hard-linking
+// keeps the shared models volume neutral — a narrowed request does not double
+// the storage of a broad sibling's files.
+func linkOrCopy(src, dst string) error {
+	if err := os.Link(src, dst); err == nil {
+		return nil
+	} else if !errors.Is(err, syscall.EXDEV) {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		_ = os.Remove(dst)
+		return err
+	}
+	return out.Close()
 }
 
 func verifyDownloadedFile(fileName string, source hfapi.SnapshotFile) (ManifestFile, error) {

--- a/pkg/modelartifacts/materializer_sibling_reuse_test.go
+++ b/pkg/modelartifacts/materializer_sibling_reuse_test.go
@@ -1,0 +1,230 @@
+package modelartifacts_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	hfapi "github.com/mudler/LocalAI/pkg/huggingface-api"
+	"github.com/mudler/LocalAI/pkg/modelartifacts"
+)
+
+const siblingReuseRevision = "0123456789abcdef0123456789abcdef01234567"
+
+// recordingResolver serves a fixed full file set filtered by each request's
+// allow/ignore patterns, so a narrower request genuinely resolves to a strict
+// subset of a broader sibling's files. The HTTP server behind it records every
+// fetch, which is the signal the sibling-reuse fix is verified through. The
+// function under fix is never mocked: a real Manager drives the real staging +
+// commit path against this stub collaborator.
+type recordingResolver struct {
+	endpoint string
+	repo     string
+	files    []hfapi.SnapshotFile
+	server   *httptest.Server
+
+	mu      sync.Mutex
+	fetched map[string]int
+}
+
+func newRecordingResolver(files []hfapi.SnapshotFile, contents map[string][]byte) *recordingResolver {
+	r := &recordingResolver{
+		endpoint: "https://huggingface.co",
+		repo:     "owner/repo",
+		files:    files,
+		fetched:  map[string]int{},
+	}
+	r.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		name := strings.TrimPrefix(req.URL.Path, "/file/")
+		body, ok := contents[name]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		r.mu.Lock()
+		r.fetched[name]++
+		r.mu.Unlock()
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write(body)
+	}))
+	return r
+}
+
+func (r *recordingResolver) ResolveSnapshot(_ context.Context, req hfapi.SnapshotRequest) (hfapi.Snapshot, error) {
+	files, err := hfapi.FilterSnapshotFiles(r.files, req.AllowPatterns, req.IgnorePatterns)
+	if err != nil {
+		return hfapi.Snapshot{}, err
+	}
+	out := make([]hfapi.SnapshotFile, len(files))
+	for i, f := range files {
+		f.URL = r.server.URL + "/file/" + f.Path
+		out[i] = f
+	}
+	return hfapi.Snapshot{
+		Endpoint: r.endpoint, Repo: r.repo,
+		RequestedRevision: req.Revision, ResolvedRevision: siblingReuseRevision, Files: out,
+	}, nil
+}
+
+func (r *recordingResolver) fetchCount(path string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.fetched[path]
+}
+
+func (r *recordingResolver) resetFetches() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.fetched = map[string]int{}
+}
+
+func siblingReuseFiles(contents map[string][]byte) []hfapi.SnapshotFile {
+	paths := []string{"a/first.bin", "b/second.bin", "c/third.bin"}
+	files := make([]hfapi.SnapshotFile, 0, len(paths))
+	for _, p := range paths {
+		sum := sha256.Sum256(contents[p])
+		files = append(files, hfapi.SnapshotFile{
+			Path: p, Size: int64(len(contents[p])), LFSOID: hex.EncodeToString(sum[:]),
+		})
+	}
+	return files
+}
+
+// The narrow-request case proves the fix for #11047:
+// a request with narrower allow_patterns (a strict subset) reuses files an
+// already-committed broader sibling holds, hard-linking instead of re-fetching.
+//
+// On master this is RED: a narrower allow_patterns set hashes to a different
+// CacheKey (path.go:62), so committedResult misses and materializeLocked
+// re-fetches the file (fetches > 0) into a separate copy (no os.SameFile). On
+// the branch it is GREEN: reuseFromCommittedSibling hits the broad sibling,
+// verifies the file via verifyDownloadedFile, and hard-links it (fetches == 0,
+// os.SameFile true).
+var _ = Describe("committed sibling reuse", func() {
+	It("reuses files from a broader committed sibling", func() {
+		contents := map[string][]byte{
+			"a/first.bin":  []byte("first-file-bytes"),
+			"b/second.bin": []byte("second-file-bytes-longer"),
+			"c/third.bin":  []byte("third-file"),
+		}
+		resolver := newRecordingResolver(siblingReuseFiles(contents), contents)
+		defer resolver.server.Close()
+
+		modelsPath := GinkgoT().TempDir()
+		manager := modelartifacts.NewManager(resolver,
+			modelartifacts.WithLocker(func(string) modelartifacts.Locker { return bypassedLocker{} }))
+
+		// Commit the broad sibling: all three files, fetched from the resolver.
+		broadSpec := modelartifacts.Spec{Source: modelartifacts.Source{
+			Type: modelartifacts.SourceTypeHuggingFace, Repo: "owner/repo",
+		}}
+		broad, err := manager.Ensure(context.Background(), modelsPath, broadSpec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(broad.CacheHit).To(BeFalse())
+		Expect(resolver.fetchCount("a/first.bin")).To(BeNumerically(">", 0),
+			"the broad sibling must have fetched a/first.bin to commit it")
+
+		resolver.resetFetches()
+
+		// Narrowed request: a strict subset of the broad sibling's file set.
+		narrowSpec := modelartifacts.Spec{Source: modelartifacts.Source{
+			Type: modelartifacts.SourceTypeHuggingFace, Repo: "owner/repo",
+			AllowPatterns: []string{"a/first.bin"},
+		}}
+		narrow, err := manager.Ensure(context.Background(), modelsPath, narrowSpec)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(narrow.CacheHit).To(BeFalse())
+
+		// (b) The sibling-present file must NOT be re-fetched: zero fetches. This is
+		// the assertion that is RED on master (one fetch) and GREEN on the branch.
+		Expect(resolver.fetchCount("a/first.bin")).To(Equal(0),
+			"a/first.bin must be reused from the committed broad sibling, not re-fetched")
+
+		// (a) The narrowed tree's staged file is the same inode as the broad
+		// sibling's file (hard-link), not a freshly downloaded second copy. RED on
+		// master (separate file), GREEN on the branch (hard-link).
+		broadFile := filepath.Join(modelsPath, filepath.FromSlash(broad.RelativePath), "a", "first.bin")
+		narrowFile := filepath.Join(modelsPath, filepath.FromSlash(narrow.RelativePath), "a", "first.bin")
+		broadInfo, err := os.Stat(broadFile)
+		Expect(err).NotTo(HaveOccurred())
+		narrowInfo, err := os.Stat(narrowFile)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.SameFile(broadInfo, narrowInfo)).To(BeTrue(),
+			"the narrowed request must hard-link the broad sibling's file rather than store a second copy")
+
+		// The reused bytes are intact end to end.
+		Expect(os.ReadFile(narrowFile)).To(Equal(contents["a/first.bin"]))
+	})
+
+	// The broader-request case is the manifest file-set guard: a broader request
+	// against a narrower committed sibling must still fetch the files the sibling
+	// lacks and commit a complete tree. Sibling-reuse can never serve an incomplete
+	// model as complete, because each requested file is matched individually against
+	// the sibling's manifest.
+	It("fetches files missing from a narrower committed sibling", func() {
+		contents := map[string][]byte{
+			"a/first.bin":  []byte("first-file-bytes"),
+			"b/second.bin": []byte("second-file-bytes-longer"),
+			"c/third.bin":  []byte("third-file"),
+		}
+		resolver := newRecordingResolver(siblingReuseFiles(contents), contents)
+		defer resolver.server.Close()
+
+		modelsPath := GinkgoT().TempDir()
+		manager := modelartifacts.NewManager(resolver,
+			modelartifacts.WithLocker(func(string) modelartifacts.Locker { return bypassedLocker{} }))
+
+		// Commit a NARROW sibling first: only a/first.bin and b/second.bin.
+		narrowSpec := modelartifacts.Spec{Source: modelartifacts.Source{
+			Type: modelartifacts.SourceTypeHuggingFace, Repo: "owner/repo",
+			AllowPatterns: []string{"a/first.bin", "b/second.bin"},
+		}}
+		narrow, err := manager.Ensure(context.Background(), modelsPath, narrowSpec)
+		Expect(err).NotTo(HaveOccurred())
+		narrowPaths := make([]string, 0, len(narrow.Manifest.Files))
+		for _, f := range narrow.Manifest.Files {
+			narrowPaths = append(narrowPaths, f.Path)
+		}
+		Expect(narrowPaths).To(Equal([]string{"a/first.bin", "b/second.bin"}))
+
+		resolver.resetFetches()
+
+		// A BROADER request asks for all three files, including c/third.bin which the
+		// narrow sibling does not hold.
+		broadSpec := modelartifacts.Spec{Source: modelartifacts.Source{
+			Type: modelartifacts.SourceTypeHuggingFace, Repo: "owner/repo",
+		}}
+		broad, err := manager.Ensure(context.Background(), modelsPath, broadSpec)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The file the narrow sibling lacks MUST be fetched: sibling-reuse must not
+		// inherit a narrower tree's gaps as if the broad request were complete.
+		Expect(resolver.fetchCount("c/third.bin")).To(BeNumerically(">", 0),
+			"c/third.bin is absent from the narrow sibling and must be fetched, not served as complete")
+
+		// The broad tree's manifest file set is exactly the full set — never the
+		// narrow sibling's subset. This file-set comparison proves no incomplete model
+		// is ever served as complete via sibling-reuse.
+		broadPaths := make([]string, 0, len(broad.Manifest.Files))
+		for _, f := range broad.Manifest.Files {
+			broadPaths = append(broadPaths, f.Path)
+		}
+		Expect(broadPaths).To(Equal([]string{"a/first.bin", "b/second.bin", "c/third.bin"}))
+
+		// Every file is present on disk with the right bytes after commit.
+		for _, p := range []string{"a/first.bin", "b/second.bin", "c/third.bin"} {
+			Expect(os.ReadFile(filepath.Join(modelsPath, filepath.FromSlash(broad.RelativePath), filepath.FromSlash(p)))).
+				To(Equal(contents[p]))
+		}
+	})
+})


### PR DESCRIPTION
## Description

Fixes #11047.

A request with narrower `allow_patterns` hashes to a different `CacheKey` than an already-committed broader sibling, so `committedResult` (the offline fast path) misses and `materializeLocked` re-fetches files the sibling already holds — re-downloading tens of GB on a narrowed request even though the model is already on disk.

This implements the "narrower shape" proposed by @Dennisadira in #11047:

- `CacheKey` is left **untouched** — the artifact identity and the offline fast path are unchanged.
- During `materializeLocked`'s staging loop, after the own-tree `reuseMaterializedFile` miss, the code consults **committed sibling trees** for the same Source (type + endpoint + repo + revision, possibly different `allow_patterns`/`ignore_patterns`).
- Each candidate file is re-verified through the existing `verifyDownloadedFile` (full SHA-256 + git SHA-1, **never size-only**) and hard-linked into the writer's staging `snapshot/` (copy fallback only on `EXDEV`).

Each file is matched individually against the sibling's manifest, so a broader request can never inherit a narrower sibling's gaps as if complete.

## Notes for Reviewers

- **Safety property** (the question raised in the issue): a broader request can never be served from a narrower committed tree as complete — every reused file is full-SHA-256-verified via `verifyDownloadedFile`, and any missing file falls through to a normal fetch. `TestBroaderRequestDoesNotServeNarrowSiblingAsComplete` proves it.
- `CacheKey` (`pkg/modelartifacts/path.go`) and `committedResult` are unchanged — no identity or offline-fast-path behavior change.
- Disk-neutral in the common case (hard-link); a byte copy is only used when `os.Link` fails with `EXDEV` (cross-device).
- Purely additive: no existing reuse/resume or download path is removed.

## Testing

- `go test ./pkg/modelartifacts/...`
- `go vet ./pkg/modelartifacts/...`

New tests in `pkg/modelartifacts/materializer_sibling_reuse_test.go`:

- `TestReuseFromCommittedSibling_NarrowAllowPatterns` — commits a broad tree (full file set), then `Ensure`s a strict-subset request (narrower `allow_patterns`) through a recording stub snapshot resolver; asserts the sibling-present files are hard-linked (`os.SameFile`) and the resolver records **zero** fetches for them. Fails on `master` (re-fetches).
- `TestBroaderRequestDoesNotServeNarrowSiblingAsComplete` — commits a narrow sibling (subset of files), then a broader request; asserts the missing file is fetched and the full manifest file-set is committed.

**Signed commits**
- [x] Yes, I signed my commits.
- [ ] Documentation updated (docs/content/) for user-facing changes, or not applicable

Refs #11047
