### PR TITLE
fix(parakeet-cpp): enable Metal in macOS builds

### DIFF
--- a/backend/go/parakeet-cpp/Makefile
+++ b/backend/go/parakeet-cpp/Makefile
@@ -49,6 +49,8 @@ else ifeq ($(BUILD_TYPE),hipblas)
 	CMAKE_ARGS+=-DPARAKEET_GGML_HIP=ON
 else ifeq ($(BUILD_TYPE),vulkan)
 	CMAKE_ARGS+=-DPARAKEET_GGML_VULKAN=ON
+else ifeq ($(BUILD_TYPE),metal)
+	CMAKE_ARGS+=-DPARAKEET_GGML_METAL=ON
 endif
 
 .PHONY: parakeet-cpp-grpc package build clean purge test all


### PR DESCRIPTION
## Summary

Forward `BUILD_TYPE=metal` to `PARAKEET_GGML_METAL` so the macOS Parakeet
backend is built with Metal support.

## Verification

- Built the unpatched and patched backends on an Apple M1 MacBook Air.
- Confirmed the patched library links Metal and MetalKit and selects the Apple M1 GPU.
- Transcribed the same five-minute sample in 82.57 seconds unpatched and 50.18 seconds patched.
- Confirmed both builds produced byte-identical transcription responses.
- Passed the `parakeet-cpp` Go test suite.

Fixes #11491
