### PR TITLE
fix (gallery): Parse harmony output of gpt-oss-* models correctly (#8037)

### DIFF
--- a/gallery/harmony.yaml
+++ b/gallery/harmony.yaml
@@ -5,65 +5,19 @@ config_file: |
     known_usecases:
         - chat
     mmap: true
+    # Delegate templating to llama.cpp's jinja runtime so the C++ autoparser
+    # can classify the harmony <|channel|> sections into reasoning_content /
+    # content / tool_calls natively. Without use_jinja the autoparser falls
+    # back to a "pure content" PEG parser that leaks the channel tags into
+    # content.
+    options:
+        - use_jinja:true
+    template:
+        use_tokenizer_template: true
     stopwords:
         - <|im_end|>
         - <dummy32000>
         - </s>
         - <|endoftext|>
         - <|return|>
-    template:
-        chat: |-
-            <|start|>system<|message|>You are ChatGPT, a large language model trained by OpenAI.
-            Knowledge cutoff: 2024-06
-            Current date: {{ now | date "Mon Jan 2 15:04:05 MST 2006" }}
-
-            Reasoning: {{if eq .ReasoningEffort ""}}medium{{else}}{{.ReasoningEffort}}{{end}}
-
-            # {{with .Metadata}}{{ if ne .system_prompt "" }}{{ .system_prompt }}{{ end }}{{else}}You are a friendly and helpful assistant.{{ end }}<|end|>{{- .Input -}}<|start|>assistant
-        chat_message: |-
-            <|start|>{{ if .FunctionCall -}}functions.{{ .FunctionCall.Name }} to=assistant{{ else if eq .RoleName "assistant"}}assistant<|channel|>final<|message|>{{else}}{{ .RoleName }}{{end}}<|message|>
-            {{- if .Content -}}
-            {{- .Content -}}
-            {{- end -}}
-            {{- if .FunctionCall -}}
-            {{- toJson .FunctionCall -}}
-            {{- end -}}<|end|>
-        completion: |
-            {{.Input}}
-        function: |-
-            <|start|>system<|message|>You are ChatGPT, a large language model trained by OpenAI.
-            Knowledge cutoff: 2024-06
-            Current date: {{ now | date "Mon Jan 2 15:04:05 MST 2006" }}
-
-            Reasoning: {{if eq .ReasoningEffort ""}}medium{{else}}{{.ReasoningEffort}}{{end}}
-
-            # {{with .Metadata}}{{ if ne .system_prompt "" }}{{ .system_prompt }}{{ end }}{{else}}You are a friendly and helpful assistant.{{ end }}<|end|>{{- .Input -}}<|start|>assistant
-
-            # Tools
-
-            ## functions
-
-            namespace functions {
-            {{-range .Functions}}
-            {{if .Description }}
-            // {{ .Description }}
-            {{- end }}
-            {{- if and .Parameters.Properties (gt (len .Parameters.Properties) 0) }}
-            type {{ .Name }} = (_: {
-            {{- range $name, $prop := .Parameters.Properties }}
-            {{- if $prop.Description }}
-              // {{ $prop.Description }}
-            {{- end }}
-              {{ $name }}: {{ if gt (len $prop.Type) 1 }}{{ range $i, $t := $prop.Type }}{{ if $i }} | {{ end }}{{ $t }}{{ end }}{{ else }}{{ index $prop.Type 0 }}{{ end }},
-            {{- end }}
-            }) => any;
-            {{- else }}
-            type {{ .Function.Name }} = () => any;
-            {{- end }}
-            {{- end }}{{/* end of range .Functions */}}
-            } // namespace functions
-
-            # Instructions
-
-            <|end|>{{.Input -}}<|start|>assistant
 name: harmony


### PR DESCRIPTION
* Delegate templating to llama.cpp's jinja runtime

Assisted-by: opencode:GLM-5.2

**Description**

This PR should fix #8037 

**Notes for Reviewers**
* I tested the change locally with the gpt-oss-20b model -> in that scenario, the change fixes the issue describe in the reference issue and now works as expected in the chat and from opencode.
* I did _not_ test any of the other gallery models referencing `harmony.yaml`, as I don't have them running anywhere.
* As far as I can see, the adapted file is not tested or documented anywhere, therefore I did not adapt anything else.
* (Inspired by the `qwen3.yaml` config template)

Thx for having a look!

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->