### PR TITLE
docs: replace dead chatbot-ui example link with repo root

### DIFF
--- a/docs/content/advanced/advanced-usage.md
+++ b/docs/content/advanced/advanced-usage.md
@@ -38,7 +38,7 @@ For a complete reference of all available configuration options, see the [Model 
    local-ai run github://mudler/LocalAI/examples/configurations/phi-2.yaml@master
    ```
 
-See also [chatbot-ui](https://github.com/mudler/LocalAI-examples/tree/main/chatbot-ui) as an example on how to use config files.
+See also [chatbot-ui](https://github.com/mudler/LocalAI-examples) as an example on how to use config files.
 
 ### Prompt templates 
 


### PR DESCRIPTION
The advanced-usage docs link to `LocalAI-examples/tree/main/chatbot-ui` which returns 404 — the chatbot-ui directory was removed from the examples repo. Updated to point to the repo root, which is live and still shows available examples.