### PR TITLE
fix: tts text wrap

### DIFF
--- a/core/http/react-ui/src/App.css
+++ b/core/http/react-ui/src/App.css
@@ -13194,6 +13194,7 @@ button.lane:hover {
   font-size: 0.6875rem;
   line-height: 1.6;
   color: var(--color-text-secondary);
+  text-wrap: auto;
 }
 
 .request-panel__method { color: var(--color-text-tertiary); }


### PR DESCRIPTION
**Description**

This PR fixes the Request section when using TTS, if the text is too long, it will make the page super wide.

Before:
<img width="1743" height="889" alt="image" src="https://github.com/user-attachments/assets/a54dc1b4-69be-452b-adb6-c575e1593d27" />

After:
<img width="1907" height="989" alt="image" src="https://github.com/user-attachments/assets/45ca3c99-6197-4330-bc77-0e6bd01c8cbb" />

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable