### PR TITLE
docs(adopters): add walcz.de

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -27,6 +27,7 @@ To be removed, open a pull request deleting your row, or email
 
 | Organisation | What they use it for | Status |
 |---|---|---|
+| [walcz.de](https://walcz.de) | Self-hosted appliance for a German B2B consultancy: local-only inference on AMD Strix Halo (gfx1151/ROCm), agents with MCP tools, RAG over an internal knowledge base, and a document/bookkeeping pipeline. | Production |
 | _Your organisation here_ | | |
 
 ## What this list is not


### PR DESCRIPTION
Adds walcz.de to `ADOPTERS.md`.

We run LocalAI as the inference layer of a self-hosted appliance for a German
B2B consultancy — local-only, on AMD Strix Halo (gfx1151) with ROCm. It has been
in daily production use for months: agents with MCP tools, RAG over an internal
knowledge base, and a document/bookkeeping pipeline.

I am the person who runs it, so this is a first-party statement rather than a
third-party listing — which is what the file asks for.

Branched from `upstream/master`, so the diff is the single row and nothing else.
Signed off per DCO.