### PR TITLE
docs(ecosystem): add Walcz to contributors

### DIFF
--- a/website/data/ecosystem.yaml
+++ b/website/data/ecosystem.yaml
@@ -26,6 +26,7 @@ contributors:
   companies:
     - { name: "Microsoft",       people: 3, commits: 20 }
     - { name: "Spectro Cloud",   people: 3, commits: 11 }
+    - { name: "Walcz",           people: 1, commits: 9 }
     - { name: "VictoriaMetrics", people: 1, commits: 5 }
     - { name: "Acronis",         people: 1, commits: 5 }
     - { name: "BearingPoint",    people: 1, commits: 4 }


### PR DESCRIPTION
Adds one row to the `contributors` list in `website/data/ecosystem.yaml`.

Evidence, per the criteria stated at the top of that file:

- **Commits in this repository:** 9, all merged. The larger ones are native
  Prometheus metrics for agent chat runs (#10689), PII/audit events as a
  Prometheus counter (#10641) and optional Anthropic prompt-cache breakpoints
  (#11158); the rest are fixes to cloud-proxy, the agent UI and the Python
  backend. Count taken from the GitHub commit search API on 2026-08-18.
- **Public profile names the employer:** yes — the `company` field on
  https://github.com/walcz-de.

Placed by commit count, between Spectro Cloud and VictoriaMetrics.

Full disclosure: I am the contributor in question, so this is a self-listing.
The file describes this list as checkable without anybody's permission, which is
why I am proposing the row rather than asking for it — but please drop it if you
would rather compile the list yourself on the next refresh. No hard feelings
either way.

Branched from `upstream/master`; the diff is the single line. Signed off per DCO.