### PR TITLE
fix(whisper): honour positional listen address argument

### DIFF
--- a/backend/go/whisper/addr_test.go
+++ b/backend/go/whisper/addr_test.go
@@ -1,0 +1,44 @@
+package main
+
+import "testing"
+
+func TestResolveAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagAddr string
+		args     []string
+		want     string
+	}{
+		{
+			name:     "explicit flag wins over positional",
+			flagAddr: "127.0.0.1:12345",
+			args:     []string{"127.0.0.1:59999"},
+			want:     "127.0.0.1:12345",
+		},
+		{
+			name:     "positional used when flag is at default",
+			flagAddr: defaultAddr,
+			args:     []string{"127.0.0.1:59999"},
+			want:     "127.0.0.1:59999",
+		},
+		{
+			name:     "default kept when no positional",
+			flagAddr: defaultAddr,
+			args:     nil,
+			want:     defaultAddr,
+		},
+		{
+			name:     "first positional wins among several",
+			flagAddr: defaultAddr,
+			args:     []string{"127.0.0.1:59999", "extra"},
+			want:     "127.0.0.1:59999",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveAddr(tt.flagAddr, tt.args); got != tt.want {
+				t.Errorf("resolveAddr(%q, %v) = %q, want %q", tt.flagAddr, tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/backend/go/whisper/addr_test.go
+++ b/backend/go/whisper/addr_test.go
@@ -1,44 +1,35 @@
 package main
 
-import "testing"
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
 
-func TestResolveAddr(t *testing.T) {
-	tests := []struct {
-		name     string
-		flagAddr string
-		args     []string
-		want     string
-	}{
-		{
-			name:     "explicit flag wins over positional",
-			flagAddr: "127.0.0.1:12345",
-			args:     []string{"127.0.0.1:59999"},
-			want:     "127.0.0.1:12345",
-		},
-		{
-			name:     "positional used when flag is at default",
-			flagAddr: defaultAddr,
-			args:     []string{"127.0.0.1:59999"},
-			want:     "127.0.0.1:59999",
-		},
-		{
-			name:     "default kept when no positional",
-			flagAddr: defaultAddr,
-			args:     nil,
-			want:     defaultAddr,
-		},
-		{
-			name:     "first positional wins among several",
-			flagAddr: defaultAddr,
-			args:     []string{"127.0.0.1:59999", "extra"},
-			want:     "127.0.0.1:59999",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := resolveAddr(tt.flagAddr, tt.args); got != tt.want {
-				t.Errorf("resolveAddr(%q, %v) = %q, want %q", tt.flagAddr, tt.args, got, tt.want)
-			}
-		})
-	}
-}
+// Specs for resolveAddr run under the suite bootstrap in gowhisper_test.go
+// (TestWhisper); they need no native library, so they never skip.
+var _ = Describe("resolveAddr", func() {
+	It("prefers an explicitly set -addr over a positional argument", func() {
+		Expect(resolveAddr("127.0.0.1:12345", true, []string{"127.0.0.1:59999"})).To(Equal("127.0.0.1:12345"))
+	})
+
+	It("keeps an explicit -addr equal to the default over a positional argument", func() {
+		Expect(resolveAddr(defaultAddr, true, []string{"127.0.0.1:59999"})).To(Equal(defaultAddr))
+	})
+
+	It("falls back to the positional argument when -addr is unset", func() {
+		Expect(resolveAddr(defaultAddr, false, []string{"127.0.0.1:59999"})).To(Equal("127.0.0.1:59999"))
+	})
+
+	It("keeps the default when -addr is unset and no positional argument is given", func() {
+		Expect(resolveAddr(defaultAddr, false, nil)).To(Equal(defaultAddr))
+	})
+
+	It("uses the first positional argument among several", func() {
+		Expect(resolveAddr(defaultAddr, false, []string{"127.0.0.1:59999", "extra"})).To(Equal("127.0.0.1:59999"))
+	})
+
+	It("treats an explicitly empty -addr as unset", func() {
+		Expect(resolveAddr("", true, []string{"127.0.0.1:59999"})).To(Equal("127.0.0.1:59999"))
+		Expect(resolveAddr("", true, nil)).To(Equal(defaultAddr))
+	})
+})

--- a/backend/go/whisper/main.go
+++ b/backend/go/whisper/main.go
@@ -18,13 +18,15 @@ var (
 	addr = flag.String("addr", defaultAddr, "the address to listen on")
 )
 
-// resolveAddr picks the address the gRPC server binds to. An explicit -addr
-// value always wins. Launchers may hand us the listen address as a bare
+// resolveAddr picks the address the gRPC server binds to. An explicitly set
+// -addr always wins. Launchers may hand us the listen address as a bare
 // positional argument, which Go's flag package silently drops — honour it
 // next so the server binds the port its caller actually allocated instead of
-// the default one (#11623).
-func resolveAddr(flagAddr string, args []string) string {
-	if flagAddr != defaultAddr {
+// the default one (#11623). An explicitly empty -addr counts as unset:
+// binding the empty address would listen on an OS-chosen port on every
+// interface instead of the one the caller allocated.
+func resolveAddr(flagAddr string, addrSet bool, args []string) string {
+	if addrSet && flagAddr != "" {
 		return flagAddr
 	}
 	if len(args) > 0 {
@@ -80,7 +82,16 @@ func main() {
 
 	flag.Parse()
 
-	if err := grpc.StartServer(resolveAddr(*addr, flag.Args()), &Whisper{}); err != nil {
+	// flag.Visit reports only flags that were explicitly set, so an -addr
+	// equal to the default is still distinguished from an untouched one.
+	addrSet := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "addr" {
+			addrSet = true
+		}
+	})
+
+	if err := grpc.StartServer(resolveAddr(*addr, addrSet, flag.Args()), &Whisper{}); err != nil {
 		panic(err)
 	}
 }

--- a/backend/go/whisper/main.go
+++ b/backend/go/whisper/main.go
@@ -10,9 +10,28 @@ import (
 	grpc "github.com/mudler/LocalAI/pkg/grpc"
 )
 
-var (
-	addr = flag.String("addr", "localhost:50051", "the address to connect to")
+const (
+	defaultAddr = "localhost:50051"
 )
+
+var (
+	addr = flag.String("addr", defaultAddr, "the address to listen on")
+)
+
+// resolveAddr picks the address the gRPC server binds to. An explicit -addr
+// value always wins. Launchers may hand us the listen address as a bare
+// positional argument, which Go's flag package silently drops — honour it
+// next so the server binds the port its caller actually allocated instead of
+// the default one (#11623).
+func resolveAddr(flagAddr string, args []string) string {
+	if flagAddr != defaultAddr {
+		return flagAddr
+	}
+	if len(args) > 0 {
+		return args[0]
+	}
+	return defaultAddr
+}
 
 type LibFuncs struct {
 	FuncPtr any
@@ -61,7 +80,7 @@ func main() {
 
 	flag.Parse()
 
-	if err := grpc.StartServer(*addr, &Whisper{}); err != nil {
+	if err := grpc.StartServer(resolveAddr(*addr, flag.Args()), &Whisper{}); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
**Description**

This PR fixes #11623

The whisper backend parsed its gRPC listen address exclusively through Go's `flag` package (`-addr`), while `backend/go/whisper/run.sh` forwards launcher arguments verbatim (`exec "$CURDIR"/whisper "$@"`). A bare positional address was silently dropped by `flag.Parse()`, so the server always bound the default `localhost:50051` instead of the port LocalAI actually allocated — LocalAI then connected to its allocated port, found nothing there, and failed with a misleading `rpc error: code = Unavailable ... EOF`.

**What changed**

- `backend/go/whisper/main.go`: new `resolveAddr` helper that resolves the listen address in this order:
  1. an explicitly set `-addr` flag (detected via `flag.FlagSet.Visit`, so `-addr localhost:50051` explicitly still wins over a positional),
  2. the first positional argument (the launcher-passed address),
  3. the previous default (`localhost:50051`) for no-argument launches.
  An explicitly empty `-addr=""` is treated as unset rather than binding an OS-chosen port on all interfaces.
- `backend/go/whisper/addr_test.go`: Ginkgo v2 specs covering all resolution branches (explicit flag wins, explicit-default wins over positional, positional fallback, no-arg default, first-positional-wins, empty-flag-as-unset).

**Scope note**: 31 other Go backends under `backend/go/` share the same flag-only parsing pattern and could hit the same failure. This PR intentionally keeps the fix scoped to the reported backend; happy to follow up with a shared helper for the rest if maintainers agree.

**Testing**

- `go build ./backend/go/whisper/` — clean
- `go test ./backend/go/whisper/ -count=1` — all specs pass (6 new address-resolution specs + existing suite)
- `go vet ./backend/go/whisper/` — clean (one pre-existing warning in untouched `gowhisper.go`)
- `gofmt -l backend/go/whisper/` — clean

**Notes for Reviewers**

- The address-resolution logic is covered by unit tests at the exact seam `main()` uses; a full runtime smoke of the built binary requires natively building `libgowhisper` (cmake build of whisper.cpp) and was not run here.
- This change was developed with AI assistance per [.agents/ai-coding-assistants.md](.agents/ai-coding-assistants.md); attribution is recorded via the `Assisted-by:` commit trailers. All code was reviewed and tested by the human submitter.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [ ] Documentation updated (docs/content/) for user-facing changes, or not applicable
