### PR TITLE
docs: document POST /models/reload under model management

### DIFF
--- a/docs/content/advanced/advanced-usage.md
+++ b/docs/content/advanced/advanced-usage.md
@@ -93,6 +93,25 @@ curl --location 'http://localhost:8080/models/apply' \
 ```
 
 
+### Reloading model configurations at runtime
+
+If you add or edit a model YAML file in the models directory while LocalAI is running,
+the change is not picked up automatically. Ask LocalAI to re-read the models directory:
+
+```bash
+curl -X POST http://localhost:8080/models/reload
+# {"success":true,"message":"Model configurations reloaded successfully"}
+```
+
+Unlike `/models/apply` above, this does not download anything — it only re-reads
+configuration that is already present on disk.
+
+{{% alert note %}}
+Reloading is additive: it adds new configurations and replaces existing ones with the
+same name, but it does **not** drop configurations whose file has been deleted. A model
+whose YAML you removed stays listed in `/v1/models` until LocalAI is restarted.
+{{% /alert %}}
+
 ### Preloading models during startup
 
 In order to allow the API to start-up with all the needed model on the first-start, the model gallery files can be used during startup. 

--- a/docs/content/advanced/model-configuration.md
+++ b/docs/content/advanced/model-configuration.md
@@ -70,6 +70,7 @@ When using `--models-config-file`, you can define multiple models as a list:
 | `backend` | string | Backend to use (e.g. `llama-cpp`, `vllm`, `diffusers`, `whisper`) | `llama-cpp` |
 | `description` | string | Human-readable description of the model | `A conversational AI model` |
 | `usage` | string | Usage instructions or notes | `Best for general conversation` |
+| `alias` | string | Redirects this name to another model. See [Model Aliases]({{%relref "features/model-aliases" %}}). | `my-llama-3` |
 
 ### Model File and Downloads
 


### PR DESCRIPTION
## What

Adds `POST /models/reload` to the model-management docs, plus one missing row in the model config field table.

`/models/reload` is currently mentioned only in `operations/middleware.md`, in the context of router configs. Someone managing models reads **Advanced usage → Install models using the API**, finds only `/models/apply` — which installs from a gallery definition and downloads files — and concludes that a locally written YAML needs a restart. This puts the endpoint next to `/models/apply` and states the difference.

It also records a limit that is documented nowhere and is easy to get wrong: reloading **adds** new configurations and **replaces** changed ones, but does **not** drop a configuration whose file was deleted — that entry stays in `/v1/models` until restart.

The second hunk is a single row adding `alias` to the field table in the model configuration reference, linking to the existing [Model Aliases](https://localai.io/features/model-aliases/) page.

## Verified

Against a running v4.7.1, not inferred from the source: adding an alias config and re-pointing an existing one both took effect after `/models/reload` without a restart; deleting the file did **not** remove the entry.

Docs only — no code changes.

---

Assisted-by: Claude:claude-opus-5 — per `CONTRIBUTING.md`, I have reviewed the change and am responsible for it.
