### PR TITLE
chore(deps): remove 16 dependabot entries for directories that no longer exist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,10 +30,6 @@ updates:
       # Check for updates to GitHub Actions every weekday
       interval: "weekly"
   - package-ecosystem: "pip"
-    directory: "/backend/python/bark"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
     directory: "/backend/python/common/template"
     schedule:
       interval: "weekly"
@@ -56,27 +52,7 @@ updates:
     - dependency-name: "torch"
     - dependency-name: "transformers"
   - package-ecosystem: "pip"
-    directory: "/backend/python/exllama"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/backend/python/exllama2"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/backend/python/mamba"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/backend/python/openvoice"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
     directory: "/backend/python/rerankers"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/backend/python/sentencetransformers"
     schedule:
       interval: "weekly"
   - package-ecosystem: "pip"
@@ -85,45 +61,5 @@ updates:
       interval: "weekly"
   - package-ecosystem: "pip"
     directory: "/backend/python/vllm"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/examples/chainlit"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/examples/functions"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/examples/langchain/langchainpy-localai-example"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/examples/langchain-chroma"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
-    directory: "/examples/streamlit-bot"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/examples/k8sgpt"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/examples/kubernetes"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/examples/langchain"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gomod"
-    directory: "/examples/semantic-todo"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "docker"
-    directory: "/examples/telegram-bot"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
**Description**

16 of the 27 update entries in `.github/dependabot.yml` point at directories that do not exist:

- 10 entries under `examples/`. The directory was emptied in cde01393 (October 2024), examples moved to the LocalAI-examples repo.
- 6 entries for removed `backend/python` backends: bark, exllama, exllama2, mamba, openvoice, sentencetransformers.

Dependabot skips a nonexistent directory without a warning, removed them. 11 entries remain pointing at existing directories.

**Notes for Reviewers**

    ls examples   # README.md, vllm-bench
    ls backend/python | grep -E 'bark|exllama|mamba|openvoice|sentencetransformers'   # empty

Found with my tool: https://github.com/DanielSwift1992/gate.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable