### PR TITLE
docs(llama-cpp): clarify multimodal speculative decoding

### DIFF
--- a/docs/content/advanced/model-configuration.md
+++ b/docs/content/advanced/model-configuration.md
@@ -389,7 +389,7 @@ The canonical names match upstream llama.cpp (dash-separated). For backward comp
 Multiple types can be chained by passing a comma-separated list to `spec_type` (e.g. `spec_type:ngram-simple,ngram-mod`). The runtime tries them in order and accepts the first proposal that meets the acceptance criteria.
 
 {{% notice note %}}
-The current LocalAI llama.cpp backend supports speculative decoding with multimodal models that load an `mmproj`, including MTP. LocalAI passes both configurations to llama.cpp and does not disable speculation merely because an `mmproj` is present; older llama.cpp builds before [ggml-org/llama.cpp#19493](https://github.com/ggml-org/llama.cpp/pull/19493) did impose that restriction.
+The current LocalAI llama.cpp backend supports speculative decoding with multimodal models that load an `mmproj`, including MTP. LocalAI passes both configurations to llama.cpp and does not disable speculation merely because an `mmproj` is present. Upstream llama.cpp removed the former general multimodal/speculative restriction in [ggml-org/llama.cpp#19493](https://github.com/ggml-org/llama.cpp/pull/19493); [ggml-org/llama.cpp#22673](https://github.com/ggml-org/llama.cpp/pull/22673) later added MTP support and explicitly documented its compatibility with vision input.
 
 Compatibility still depends on the installed backend version and the target/draft model architecture. Check the backend logs for successful projector loading and speculative-context initialization, then look for the `draft acceptance` statistics line and its `accepted / generated` counts. A representative run with zero accepted draft tokens receives no speculative speedup and can indicate that the model or settings need tuning.
 {{% /notice %}}

--- a/docs/content/advanced/model-configuration.md
+++ b/docs/content/advanced/model-configuration.md
@@ -389,7 +389,9 @@ The canonical names match upstream llama.cpp (dash-separated). For backward comp
 Multiple types can be chained by passing a comma-separated list to `spec_type` (e.g. `spec_type:ngram-simple,ngram-mod`). The runtime tries them in order and accepts the first proposal that meets the acceptance criteria.
 
 {{% notice note %}}
-Speculative decoding is automatically disabled when multimodal models (with `mmproj`) are active. The `n_draft` parameter can also be overridden per-request.
+The current LocalAI llama.cpp backend supports speculative decoding with multimodal models that load an `mmproj`, including MTP. LocalAI passes both configurations to llama.cpp and does not disable speculation merely because an `mmproj` is present; older llama.cpp builds before [ggml-org/llama.cpp#19493](https://github.com/ggml-org/llama.cpp/pull/19493) did impose that restriction.
+
+Compatibility still depends on the installed backend version and the target/draft model architecture. Check the backend logs for successful projector loading and speculative-context initialization, then look for the `draft acceptance` statistics line and its `accepted / generated` counts. A representative run with zero accepted draft tokens receives no speculative speedup and can indicate that the model or settings need tuning.
 {{% /notice %}}
 
 ##### Multi-Token Prediction (MTP)
@@ -419,7 +421,7 @@ Detection runs both at **import time** (the `/import-model` UI / `POST /models/i
 | `spec_type` | `draft-mtp` | Activates MTP. Can be chained with other types (see below). |
 | `spec_n_max` / `draft_max` | `2`-`6` | Number of draft tokens per step. Upstream's PR suggests 2-3 for the tightest acceptance window; LocalAI's auto-default is 6 to favour throughput on models with high acceptance. |
 | `spec_p_min` | `0.75` | Pinned because upstream marks the current default with a "change to 0.0f" TODO; locking it here keeps acceptance thresholds stable across future llama.cpp bumps. |
-| `mmproj_use_gpu` | `false` (or unset `mmproj`) | MTP has a prompt-processing overhead; if the model is non-vision, drop the mmproj entirely to save VRAM. |
+| `mmproj_use_gpu` | `true` for vision | MTP does not require disabling the projector. Keep `mmproj` configured for image input; set this option to `false` to keep the projector on CPU when VRAM is tight. Remove `mmproj` only for text-only use when vision is not needed. |
 
 **Minimal config** (override-only, since auto-detection already covers this for MTP-capable GGUFs):
 
@@ -431,6 +433,23 @@ parameters:
 options:
   - spec_type:draft-mtp
   - spec_n_max:3
+```
+
+**With vision enabled:**
+
+```yaml
+name: qwen3-vision-mtp
+backend: llama-cpp
+known_usecases:
+  - chat
+  - vision
+parameters:
+  model: qwen3-with-mtp.gguf
+mmproj: mmproj-qwen3.gguf
+options:
+  - spec_type:draft-mtp
+  - spec_n_max:3
+  - spec_p_min:0.75
 ```
 
 **With a separate MTP head file:**


### PR DESCRIPTION
**Description**

Upstream llama.cpp removed the former general multimodal/speculative restriction in [ggml-org/llama.cpp#19493](https://github.com/ggml-org/llama.cpp/pull/19493), while [ggml-org/llama.cpp#22673](https://github.com/ggml-org/llama.cpp/pull/22673) later added MTP support and explicitly documented compatibility with vision input. This page still said LocalAI automatically disabled speculation whenever `mmproj` was active.

This PR:

- documents that current llama.cpp backends can use `mmproj` with speculative decoding, including MTP;
- keeps the backend-version and model-architecture compatibility caveats;
- tells operators to verify projector/speculative initialization and the `draft acceptance` counts;
- corrects the `mmproj_use_gpu` guidance so vision users do not remove the projector unnecessarily;
- adds a combined vision + MTP model configuration example; and
- removes the adjacent unsupported claim that `n_draft` can be overridden through each OpenAI request.

No issue was opened because this is a focused correction to one stale documentation section and does not require a code change.

**Runtime evidence**

Tested the official `qwythos-9b-v2` Gallery configuration, which combines an embedded MTP head with `mmproj`, using a real base64 image request on an NVIDIA RTX PRO 2000 Blackwell (16,311 MiB):

- LocalAI `v4.8.2-gpu-nvidia-cuda-12` (`sha256:90b8eb9505b4ea5f60e6f1057621a96100cde559fb4d92dd743ed5091b6b4b9f`) with its default installed llama.cpp backend.
- LocalAI `master-gpu-nvidia-cuda-12`, commit `38ba3fec636e684f81320e5d8ab497f5f1e985a0` (`sha256:65487335cacd5395fd16c1bf78d3d23f90a41911bc7e98f663212352a4a84dd7`).
- The same master image with the explicitly installed `cuda12-llama-cpp-development` backend (`master-gpu-nvidia-cuda-12-llama-cpp`, amd64 digest `sha256:805c89619771eb12ac0261f9c1a60c2105d38f816e603a287d242c3c9f15ec3c`).

All three runs logged both:

- `creating MTP draft context against the target model`
- `loaded multimodal model, '...mmproj-Qwythos-9B-v2-BF16.gguf'`

The image request completed successfully, and both recorded inference runs reported:

`draft acceptance = 0.97143 (102 accepted / 105 generated)`

**Verification**

- `hugo v0.146.3+extended ... --minify` — built 223 documentation pages successfully (matching the version pinned in Pages CI)
- `go test ./core/config --count=1`
- `git diff --check upstream/master..HEAD`
- Independent read-only review: no remaining Critical, Important, or Minor findings

**Notes for Reviewers**

The current LocalAI gRPC bridge forwards `MMProj` and the speculative settings independently. Upstream #19493 removed the old general multimodal/speculative exclusion; #22673 later added MTP with explicit vision-input compatibility.

AI assistance is disclosed in the commit's `Assisted-by` trailer in accordance with the repository policy.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable
