### PR TITLE
fix(ollama): accept :latest tag on model lookup

### DIFF
--- a/core/http/endpoints/ollama/models_test.go
+++ b/core/http/endpoints/ollama/models_test.go
@@ -146,6 +146,20 @@ parameters:
 			Expect(resp.Details.Format).To(Equal("gguf"))
 			Expect(resp.Details.Families).ToNot(BeEmpty())
 		})
+
+		It("looks up the model when the Ollama :latest tag is included", func() {
+			writeConfig("chat", `
+name: chat
+backend: llama-cpp
+template:
+  chat: "{{ .Input }}"
+parameters:
+  model: Llama-3-8B-Q4_K_M.gguf
+`)
+			resp := callShow("chat:latest")
+			Expect(resp.Details.Format).To(Equal("gguf"))
+			Expect(resp.Capabilities).To(ContainElement("completion"))
+		})
 	})
 
 	Describe("ListModelsEndpoint", func() {

--- a/core/http/middleware/request.go
+++ b/core/http/middleware/request.go
@@ -141,6 +141,12 @@ func (re *RequestExtractor) SetModelAndConfig(initializer func() schema.LocalAIR
 			}
 
 			modelName := input.ModelName(nil)
+			// Ollama-compat /api/tags appends ":latest" to untagged names.
+			// Strip it for lookup so the listed name works on /api/chat,
+			// /v1/chat/completions, and the other model-bearing endpoints.
+			if strings.HasSuffix(modelName, ":latest") {
+				modelName = strings.TrimSuffix(modelName, ":latest")
+			}
 			cfg, err := re.modelConfigLoader.LoadModelConfigFileByNameDefaultOptions(modelName, re.applicationConfig)
 
 			if err != nil {

--- a/core/http/middleware/request_test.go
+++ b/core/http/middleware/request_test.go
@@ -82,6 +82,13 @@ var _ = Describe("SetModelAndConfig middleware", func() {
 			Expect(resp.Error.Message).To(ContainSubstring("not found"))
 			Expect(resp.Error.Type).To(Equal("invalid_request_error"))
 		})
+
+		It("still 404s when :latest is appended to an unknown model", func() {
+			rec := postJSON(app, "/v1/chat/completions",
+				`{"model":"nonexistent-model:latest","messages":[{"role":"user","content":"hi"}]}`)
+
+			Expect(rec.Code).To(Equal(http.StatusNotFound))
+		})
 	})
 
 	Context("when the model exists as a config file", func() {
@@ -94,6 +101,13 @@ var _ = Describe("SetModelAndConfig middleware", func() {
 		It("passes through to the handler", func() {
 			rec := postJSON(app, "/v1/chat/completions",
 				`{"model":"test-model","messages":[{"role":"user","content":"hi"}]}`)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+
+		It("accepts the Ollama :latest tag that /api/tags appends", func() {
+			rec := postJSON(app, "/v1/chat/completions",
+				`{"model":"test-model:latest","messages":[{"role":"user","content":"hi"}]}`)
 
 			Expect(rec.Code).To(Equal(http.StatusOK))
 		})


### PR DESCRIPTION
/api/tags and /api/ps add `:latest` to untagged names, but `/api/chat` and `/v1/chat/completions` looked the tagged name up as-is and 404'd. Strip that default tag before config lookup so the listed name works.

Fixes #11728