### PR TITLE
fix(downloader): make file:// installs reachable again (#11701)

### DIFF
--- a/pkg/downloader/local_source_test.go
+++ b/pkg/downloader/local_source_test.go
@@ -1,0 +1,48 @@
+package downloader_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+
+	. "github.com/mudler/LocalAI/pkg/downloader"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("file:// sources", func() {
+	var noProgress = func(string, string, string, float64) {}
+
+	It("copies a file:// source into a destination that does not exist yet", func() {
+		// the layout from issue #11701: the source sits in a nested directory,
+		// the destination is the flat models dir, so it cannot already exist
+		srcDir := GinkgoT().TempDir()
+		nested := filepath.Join(srcDir, "InternScience", "Agents-A1-4B-Q8_0-GGUF")
+		Expect(os.MkdirAll(nested, 0o755)).To(Succeed())
+		srcPath := filepath.Join(nested, "Agents-A1-4B-Q8_0.gguf")
+		payload := []byte("GGUF-not-really-but-enough-bytes")
+		Expect(os.WriteFile(srcPath, payload, 0o600)).To(Succeed())
+
+		sum := sha256.Sum256(payload)
+		destPath := filepath.Join(GinkgoT().TempDir(), "Agents-A1-4B-Q8_0.gguf")
+
+		uri := URI("file://" + srcPath)
+		Expect(uri.DownloadFile(destPath, hex.EncodeToString(sum[:]), 1, 1, noProgress)).To(Succeed())
+
+		got, err := os.ReadFile(destPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(got).To(Equal(payload))
+	})
+
+	It("reports the missing source when a file:// source does not exist", func() {
+		destPath := filepath.Join(GinkgoT().TempDir(), "absent.gguf")
+		missing := filepath.Join(GinkgoT().TempDir(), "absent.gguf")
+
+		err := URI("file://"+missing).DownloadFile(destPath, "", 1, 1, noProgress)
+		Expect(err).To(HaveOccurred())
+		// the error must name the source that could not be read, not claim the
+		// destination is an unrecognized URL
+		Expect(err.Error()).To(ContainSubstring(missing))
+	})
+})

--- a/pkg/downloader/uri.go
+++ b/pkg/downloader/uri.go
@@ -231,6 +231,20 @@ func (u URI) LooksLikeURL() bool {
 		strings.HasPrefix(string(u), GithubURI2)
 }
 
+// hasLocalSource reports whether the URI names a local file to copy from
+// rather than a URL to fetch. DownloadFileWithContext both decides whether the
+// destination is reachable and picks its source with this, so that the two
+// cannot drift apart: they did, and every "file://" install failed because the
+// reachability check admitted http(s) only, leaving the local-source branch
+// unreachable for any destination that did not already exist.
+func (u URI) hasLocalSource() bool {
+	if strings.HasPrefix(string(u), LocalPrefix) {
+		return true
+	}
+	_, err := os.Stat(u.ResolveURL())
+	return err == nil
+}
+
 func (u URI) LooksLikeHTTPURL() bool {
 	return strings.HasPrefix(string(u), HTTPPrefix) ||
 		strings.HasPrefix(string(u), HTTPSPrefix)
@@ -556,7 +570,7 @@ func (uri URI) DownloadFileWithContext(ctx context.Context, filePath, sha string
 				return nil
 			}
 		}
-	} else if !os.IsNotExist(err) || !URI(url).LooksLikeHTTPURL() {
+	} else if !os.IsNotExist(err) || !(URI(url).LooksLikeHTTPURL() || uri.hasLocalSource()) {
 		// Error occurred while checking file existence
 		return fmt.Errorf("could not fetch %q: local file does not exist (%v) and %q is not a recognized downloadable URL (supported schemes: %s)", filePath, err, url, strings.Join([]string{HTTPPrefix, HTTPSPrefix, LocalPrefix, HuggingFacePrefix, HuggingFacePrefix1, OllamaPrefix, OCIPrefix, OCIFilePrefix, GithubURI2}, ", "))
 	}
@@ -591,7 +605,7 @@ func (uri URI) DownloadFileWithContext(ctx context.Context, filePath, sha string
 
 	var source io.ReadCloser
 	var contentLength int64
-	if _, e := os.Stat(uri.ResolveURL()); strings.HasPrefix(string(uri), LocalPrefix) || e == nil {
+	if uri.hasLocalSource() {
 		file, err := os.Open(uri.ResolveURL())
 		if err != nil {
 			return fmt.Errorf("failed to open file %q: %v", uri.ResolveURL(), err)


### PR DESCRIPTION
**Description**

Fixes #11701.

`DownloadFileWithContext` already contains a branch that copies from a local file:

```go
var source io.ReadCloser
var contentLength int64
if _, e := os.Stat(uri.ResolveURL()); strings.HasPrefix(string(uri), LocalPrefix) || e == nil {
	file, err := os.Open(uri.ResolveURL())
```

That branch could never run. About 70 lines earlier the function decides whether the destination is fetchable at all:

```go
fi, err := os.Stat(filePath)
if err == nil {
	// ... cached / SHA handling, may return nil
} else if !os.IsNotExist(err) || !URI(url).LooksLikeHTTPURL() {
	return fmt.Errorf("could not fetch %q: local file does not exist (%v) and %q is not a recognized downloadable URL (supported schemes: %s)", ...)
}
```

`LooksLikeHTTPURL` is `http://`/`https://` only. Reaching the download code therefore requires the destination to be **missing** *and* the source to be an **HTTP URL** — and a `file://` source is never an HTTP URL, so the local-source branch below is unreachable.

A first import always has a missing destination, so `file://` imports could not succeed. The error even lists `file://` among the supported schemes, which is what makes the report read as a path-parsing bug: the two `%q` operands are the *destination* (`<models dir>/<basename>`) and the *source*, so they look mismatched.

Reproducing the reporter's exact output as a test:

```
could not fetch "/tmp/ginkgo787308171/Agents-A1-4B-Q8_0.gguf": local file does not exist
(stat ...: no such file or directory) and
"/tmp/ginkgo989010701/InternScience/Agents-A1-4B-Q8_0-GGUF/Agents-A1-4B-Q8_0.gguf"
is not a recognized downloadable URL (supported schemes: http://, https://, file://, ...)
```

**Fix**

The guard and the source selection are two spellings of the same question — "is this a local file or a URL?" — and they had drifted apart. This names that condition once, as `URI.hasLocalSource`, and uses it in both places so they cannot drift again:

```go
} else if !os.IsNotExist(err) || !(URI(url).LooksLikeHTTPURL() || uri.hasLocalSource()) {
```

`hasLocalSource` reproduces the existing source-selection condition exactly (`file://` prefix, or a path that stats), so no source that was previously chosen stops being chosen.

This also matches the two sibling methods on `URI`, which both already handle `LocalPrefix` explicitly — `ReadWithAuthorizationAndCallback` (with an `InTrustedRoot` check) and `ContentLength` (via `os.Stat`). `DownloadFileWithContext` was the only one of the three that did not.

Behaviour changes only for URIs that previously hit that error and returned early:

- a `file://` source that exists is now copied to the destination, hashed and SHA-verified by the existing code path;
- a `file://` source that does **not** exist now fails with `failed to open file "<source>"` instead of an error claiming the destination is an unrecognized URL.

No change for `http(s)://`, OCI, Ollama or `ocifile://`, which return before or above this guard.

**Notes**

`pkg/downloader/uri.go` is 16 insertions / 2 deletions; the rest is the test.

Verified with the package suite (`go test ./pkg/downloader/`) on both current `master` and this PR's merge base, in each case toggling only `uri.go` and keeping the test fixed:

| | test added, `uri.go` unmodified | + fix |
|---|---|---|
| `master` (`bbd3ab5`) | 78 passed, **1 failed** | **79 passed** |
| merge base (`a6cf67c`) | 34 passed, **1 failed** | **35 passed** |

`gofmt -l` and `go vet ./pkg/downloader/` are clean on both changed files. My fork is behind `master`, so this branch is cut from the fork tip; the two anchors this patch touches are byte-identical there and on current `master`, and the fix was verified against both.

I could not exercise the UI import flow end to end (no LocalAI deployment here), so that path is covered only by the unit test at the `DownloadFile` boundary where the failure occurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
