### PR TITLE
fix(deps): bump go-m1cpu to v0.2.2 to fix SIGSEGV on Apple M5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -498,7 +498,7 @@ require (
 	github.com/quic-go/quic-go v0.59.0 // indirect
 	github.com/quic-go/webtransport-go v0.10.0 // indirect
 	github.com/rivo/uniseg v0.4.7
-	github.com/shoenig/go-m1cpu v0.1.6 // indirect
+	github.com/shoenig/go-m1cpu v0.2.2 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/smallnest/ringbuffer v0.0.0-20241116012123-461381446e3d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1263,8 +1263,11 @@ github.com/shirou/gopsutil/v4 v4.26.3 h1:2ESdQt90yU3oXF/CdOlRCJxrP+Am1aBYubTMTfx
 github.com/shirou/gopsutil/v4 v4.26.3/go.mod h1:LZ6ewCSkBqUpvSOf+LsTGnRinC6iaNUNMGBtDkJBaLQ=
 github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFtM=
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
+github.com/shoenig/go-m1cpu v0.2.2 h1:4nc55oVv7nygGnfI9bhLCLzUEs4794y0Bkqx4q2zy7Y=
+github.com/shoenig/go-m1cpu v0.2.2/go.mod h1:KkDOw6m3ZJQAPHbrzkZki4hnx+pDRR1Lo+ldA56wD5w=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shoenig/test v1.7.0 h1:eWcHtTXa6QLnBvm0jgEabMRN/uJ4DMV3M8xUGgRkZmk=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/shurcooL/go v0.0.0-20200502201357-93f07166e636/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=


### PR DESCRIPTION
**Description**

This PR fixes #11735

`github.com/shoenig/go-m1cpu v0.1.6` segfaults inside its package `init()` on Apple M5, which takes the whole binary down before `main` runs — every command dies, including `local-ai --version`. It reaches the binary as an indirect dependency:

```
cmd/local-ai -> core/services/monitoring, core/schema, pkg/xsysinfo
             -> github.com/shirou/gopsutil/v3/{process,disk}
             -> github.com/shirou/gopsutil/v3/cpu   (darwin)
             -> github.com/shoenig/go-m1cpu
```

In v0.1.6 the cgo `getFrequency()` helper dereferences the `CFTypeRef` it is handed without a NULL check. On M5 the `pmgr` IORegistry node does not expose `voltage-states5-sram` / `voltage-states1-sram` in the expected shape, `IORegistryEntryCreateCFProperty` returns `NULL`, and `CFDataGetLength(NULL)` faults. v0.2.2 adds the missing `if (typeRef == NULL) return 0;` guard, and additionally moves the IORegistry probe out of `init()` behind a lazy `sync.Once`, so it no longer runs at process start at all.

**Notes for Reviewers**

*Why bump `go-m1cpu` rather than `gopsutil`:*

- `gopsutil/v3 v3.24.5` is the **final** v3 release, so the v3 line will never carry this fix.
- Migrating the four call sites to `gopsutil/v4` (already present in this module graph as an indirect dependency, and no longer depending on `go-m1cpu` at all) is the natural longer-term cleanup, but v4 swaps the darwin implementation from cgo to `purego` — more behaviour change than a startup-crash fix should carry. Happy to follow up with that migration in a separate PR if you'd like it.
- No `replace` directive is used; this is a plain version bump in the indirect `require` block, so it stays compatible with `go mod tidy`.

*Compatibility:*

- `gopsutil/v3/cpu/cpu_darwin.go` uses only `m1cpu.IsAppleSilicon()` and `m1cpu.PCoreHz()`. Both keep their signatures in v0.2.2 — the whole exported API is unchanged.
- `incompatible.go` (the `!darwin || !arm64 || !cgo` stub used on Linux/Windows CI) is byte-identical between v0.1.6 and v0.2.2, so non-darwin builds are unaffected.

*How it was tested* (on Apple M4 Pro / macOS 15.7.7, where v0.1.6 does **not** crash, to check for regressions):

- `make protogen-go && go build -o local-ai ./cmd/local-ai` — builds clean before and after.
- `go version -m local-ai` confirms the binary links `go-m1cpu v0.2.2` after the bump.
- `go test ./pkg/xsysinfo/...` passes.
- `go mod verify` passes; `go build -mod=readonly ./cmd/local-ai` succeeds, so `go.sum` is complete.
- Behaviour check via a standalone harness calling `gopsutil/v3/cpu.Info()` against both versions — **identical output** on M4 Pro (`model="Apple M4 Pro" cores=12 mhz=4.0`, `PCoreHz=4512000`, `ECoreHz=2592000`, `PCoreCount=8`). The bump is a pure crash fix with no observable change on hardware where v0.1.6 already worked.

The M5 crash itself was observed on Apple M5 Pro / macOS 26.5.2; see #11735 for the full trace. Every tagged release back to at least `v2.20.0` pins `go-m1cpu v0.1.6` and is affected.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable
