### PR TITLE
fix(python-backends): re-attach media markers under use_tokenizer_template (#11621)

### DIFF
--- a/backend/python/common/python_utils.py
+++ b/backend/python/common/python_utils.py
@@ -37,6 +37,46 @@ def parse_options(options_list):
     return opts
 
 
+def attach_media_parts(messages_dicts, n_images=0, n_videos=0):
+    """Rebuild the last user message as content *parts* carrying media markers.
+
+    Backends that let the tokenizer do the templating hand plain string content
+    to ``apply_chat_template``, but a chat template only emits the model's own
+    media tokens (``<|vision_start|><|image_pad|><|vision_end|>`` for the
+    Qwen-VL family, and the equivalents elsewhere) when the content is a list
+    of parts. Without those markers the engine's multimodal processor finds
+    nothing to substitute and silently discards the pixels, even though they
+    were forwarded correctly out of band.
+
+    Returns a new list whose last user message has
+    ``[{"type": "image"} * n_images, {"type": "video"} * n_videos, text]`` as
+    its content, or ``None`` when there is nothing to attach - no media, no
+    user turn, or content that is already a list of parts - so the caller can
+    keep using the original string-content list.
+    """
+    if not n_images and not n_videos:
+        return None
+    idx = next(
+        (
+            i
+            for i in reversed(range(len(messages_dicts)))
+            if messages_dicts[i].get("role") == "user"
+        ),
+        None,
+    )
+    if idx is None:
+        return None
+    text = messages_dicts[idx].get("content") or ""
+    if not isinstance(text, str):
+        return None
+    parts = [{"type": "image"}] * n_images + [{"type": "video"}] * n_videos
+    if text:
+        parts.append({"type": "text", "text": text})
+    patched = list(messages_dicts)
+    patched[idx] = dict(patched[idx], content=parts)
+    return patched
+
+
 def messages_to_dicts(proto_messages):
     """Convert proto ``Message`` objects to dicts suitable for ``apply_chat_template``.
 

--- a/backend/python/common/python_utils_test.py
+++ b/backend/python/common/python_utils_test.py
@@ -14,7 +14,7 @@ import json
 import types
 import unittest
 
-from python_utils import messages_to_dicts, parse_options
+from python_utils import attach_media_parts, messages_to_dicts, parse_options
 
 
 def _msg(**fields):
@@ -116,6 +116,64 @@ class TestMessagesToDicts(unittest.TestCase):
     def test_tool_calls_invalid_json_dropped(self):
         out = messages_to_dicts([_msg(role="assistant", tool_calls="{not json")])
         self.assertNotIn("tool_calls", out[0])
+
+
+class TestAttachMediaParts(unittest.TestCase):
+    def test_image_marker_added_to_last_user_turn(self):
+        messages = [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "first"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": "how high is the water?"},
+        ]
+        out = attach_media_parts(messages, n_images=1)
+        self.assertEqual(
+            out[3]["content"],
+            [{"type": "image"}, {"type": "text", "text": "how high is the water?"}],
+        )
+        # Earlier turns and the input list itself are untouched.
+        self.assertEqual(out[:3], messages[:3])
+        self.assertEqual(messages[3]["content"], "how high is the water?")
+
+    def test_counts_and_order_images_then_videos(self):
+        out = attach_media_parts(
+            [{"role": "user", "content": "describe"}], n_images=2, n_videos=1
+        )
+        self.assertEqual(
+            out[0]["content"],
+            [
+                {"type": "image"},
+                {"type": "image"},
+                {"type": "video"},
+                {"type": "text", "text": "describe"},
+            ],
+        )
+
+    def test_empty_text_yields_media_only_parts(self):
+        out = attach_media_parts([{"role": "user", "content": ""}], n_images=1)
+        self.assertEqual(out[0]["content"], [{"type": "image"}])
+
+    def test_other_message_keys_are_preserved(self):
+        out = attach_media_parts(
+            [{"role": "user", "content": "hi", "name": "bob"}], n_images=1
+        )
+        self.assertEqual(out[0]["name"], "bob")
+
+    def test_no_media_is_a_no_op(self):
+        self.assertIsNone(attach_media_parts([{"role": "user", "content": "hi"}]))
+
+    def test_no_user_turn_is_a_no_op(self):
+        self.assertIsNone(
+            attach_media_parts([{"role": "system", "content": "hi"}], n_images=1)
+        )
+
+    def test_content_already_parts_is_a_no_op(self):
+        self.assertIsNone(
+            attach_media_parts(
+                [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+                n_images=1,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/backend/python/sglang/backend.py
+++ b/backend/python/sglang/backend.py
@@ -40,6 +40,7 @@ import grpc
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'common'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'common'))
+from python_utils import attach_media_parts
 from grpc_auth import get_auth_interceptors
 
 # sglang imports. Engine is the stable public entry point; parser modules
@@ -354,6 +355,24 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 pass
         if request.Metadata.get("enable_thinking", "").lower() == "true":
             template_kwargs["enable_thinking"] = True
+
+        # sglang locates the attached images/videos by scanning the rendered
+        # prompt for the model's own media token, so the template has to be
+        # given content *parts* - string content renders a prompt with no
+        # placeholder and the media are dropped without a word (#11621).
+        media_dicts = attach_media_parts(
+            messages_dicts, len(request.Images), len(request.Videos)
+        )
+        if media_dicts is not None:
+            try:
+                return self.tokenizer.apply_chat_template(media_dicts, **template_kwargs)
+            except Exception as e:
+                # A text-only template cannot iterate content parts; fall
+                # through to the text-only prompt instead of failing.
+                print(
+                    f"chat template rejected multimodal content parts: {e!r}",
+                    file=sys.stderr,
+                )
 
         try:
             return self.tokenizer.apply_chat_template(messages_dicts, **template_kwargs)

--- a/backend/python/vllm/backend.py
+++ b/backend/python/vllm/backend.py
@@ -20,6 +20,7 @@ import backend_pb2_grpc
 import grpc
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'common'))
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'common'))
+from python_utils import attach_media_parts
 from grpc_auth import get_auth_interceptors
 
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -576,13 +577,33 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
             if request.Metadata.get("enable_thinking", "").lower() == "true":
                 template_kwargs["enable_thinking"] = True
 
-            try:
-                prompt = self.tokenizer.apply_chat_template(messages_dicts, **template_kwargs)
-            except TypeError:
-                # Some tokenizers don't support tools/enable_thinking kwargs — retry without them
-                prompt = self.tokenizer.apply_chat_template(
-                    messages_dicts, tokenize=False, add_generation_prompt=True
-                )
+            # vLLM substitutes multi_modal_data into the model's own media
+            # token, so the template has to be given content *parts* - string
+            # content renders a prompt with no placeholder and the media are
+            # dropped without a word (#11621).
+            prompt = None
+            media_dicts = attach_media_parts(
+                messages_dicts, len(image_data), len(video_data)
+            )
+            if media_dicts is not None:
+                try:
+                    prompt = self.tokenizer.apply_chat_template(media_dicts, **template_kwargs)
+                except Exception as e:
+                    # A text-only template cannot iterate content parts; fall
+                    # through to the text-only prompt instead of failing.
+                    print(
+                        f"chat template rejected multimodal content parts: {e!r}",
+                        file=sys.stderr,
+                    )
+
+            if prompt is None:
+                try:
+                    prompt = self.tokenizer.apply_chat_template(messages_dicts, **template_kwargs)
+                except TypeError:
+                    # Some tokenizers don't support tools/enable_thinking kwargs — retry without them
+                    prompt = self.tokenizer.apply_chat_template(
+                        messages_dicts, tokenize=False, add_generation_prompt=True
+                    )
 
         # Generate text using the LLM engine
         request_id = random_uuid()


### PR DESCRIPTION
**Description**

Fixes #11621.

With `template.use_tokenizer_template: true`, an `image_url` content part is silently ignored on the sglang and vllm backends — HTTP 200, nothing in the log, and the model answers as if no image had been attached.

The pixels are forwarded correctly. What is missing is the **media placeholder in the prompt**:

* `_build_prompt()` (sglang) / the templating block in `_predict()` (vllm) pass **string** content to `tokenizer.apply_chat_template()`.
* A chat template only emits the model's own media tokens — `<|vision_start|><|image_pad|><|vision_end|>` for the Qwen-VL family — when the message content is a **list of parts**.
* Both engines locate the attached media by scanning the rendered prompt for that token (`sglang/srt/multimodal/processors/qwen_vl.py`; vLLM substitutes `multi_modal_data` into it). With no placeholder present, the media are dropped without a word.

This is option **(a)** from the issue: backend-local, no protocol change.

**Change**

* `backend/python/common/python_utils.py` — new `attach_media_parts(messages_dicts, n_images, n_videos)`. It rebuilds the **last user turn** as `[{"type": "image"} * n, {"type": "video"} * n, {"type": "text", "text": ...}]` and returns a new list, or `None` when there is nothing to attach (no media, no user turn, content already a list of parts). It never mutates its input.
* `backend/python/sglang/backend.py`, `backend/python/vllm/backend.py` — call it just before templating. The pixels keep travelling out of band via `image_data` / `multi_modal_data` exactly as before.
* `backend/python/common/python_utils_test.py` — 7 new cases for the helper.

**Backwards compatibility**

* **Text-only requests are untouched.** With no images and no videos the helper returns `None` on its first line and the existing string-content path runs verbatim.
* **Text-only templates still work.** If a template cannot iterate content parts, the parts render is caught and the request falls back to the previous string-content prompt (with a note on stderr) instead of failing. The pre-existing `except TypeError` retry is preserved underneath.

**Verification**

Helper unit tests (stdlib only, no backend venv — the target the Makefile already runs):

```
$ cd backend/python/common && python3 -m unittest python_utils_test
..............
Ran 14 tests in 0.000s
OK
```

End-to-end on the real code path, without loading a model: the `_messages_to_dicts` / `_build_prompt` methods are lifted out of the actual `backend.py` files with `ast` and driven with a tokenizer stub that renders the real `chat_template.json` of `Qwen/Qwen2-VL-7B-Instruct` through jinja2.

| request | before | after |
| --- | --- | --- |
| 1 image | 0 `<\|vision_start\|><\|image_pad\|><\|vision_end\|>` | **1** |
| 2 images | 0 | **2** |
| 1 video | 0 `<\|vision_start\|><\|video_pad\|><\|vision_end\|>` | **1** |
| text only | `<\|im_start\|>user\nWie hoch steht das Wasser?<\|im_end\|>` | identical |
| text-only template + 1 image | renders, no crash | renders, no crash (falls back) |

Rendered user turn after the change, 1 image:

```
<|im_start|>system
You are a helpful assistant.<|im_end|>
<|im_start|>user
<|vision_start|><|image_pad|><|vision_end|>Wie hoch steht das Wasser?<|im_end|>
<|im_start|>assistant
```

Both backends produce the same before/after table.

**Scope**

Option (b) from the issue — carrying media per message in `backend.proto` — is deliberately **not** attempted here. That is the only way to get images in *different* turns of a multi-turn conversation right, and it belongs in its own protocol-level change. This PR covers every single-image and last-turn request, which is effectively all real vision traffic today.

**Notes**

* The branch is based on an older `master` commit rather than the current tip — the token used here has no `workflow` scope, so GitHub refuses to sync the fork. The diff is nonetheless exactly the four files above, and it merges into the current `master` cleanly (GitHub reports the PR as mergeable). I re-ran the before/after table on the auto-merged trees of both backends to confirm the merge is semantically right, not just conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
