### PR TITLE
feat(ui): add 'Focus mode' option in chat settings to persistently toggle the sidebar auto-collapse

### DIFF
--- a/core/http/react-ui/public/locales/en/chat.json
+++ b/core/http/react-ui/public/locales/en/chat.json
@@ -33,6 +33,8 @@
     "title": "Chat Settings",
     "manageMode": "Manage mode",
     "manageModeDesc": "Let this chat install models, switch backends, and edit configs by talking to LocalAI.",
+    "focusMode": "Focus mode",
+    "focusModeDesc": "Collapse the sidebar and slim the header while a conversation is active. Esc restores them temporarily; turn this off to keep the full layout.",
     "systemPrompt": "System Prompt",
     "systemPromptPlaceholder": "You are a helpful assistant...",
     "temperature": "Temperature",

--- a/core/http/react-ui/src/pages/Chat.jsx
+++ b/core/http/react-ui/src/pages/Chat.jsx
@@ -21,6 +21,8 @@ import { useOperations } from '../hooks/useOperations'
 import { relativeTime } from '../utils/format'
 import { copyToClipboard } from '../utils/clipboard'
 
+const FOCUS_MODE_KEY = 'localai_chat_focus_mode'
+
 function getLastMessagePreview(chat) {
   if (!chat.history || chat.history.length === 0) return ''
   for (let i = chat.history.length - 1; i >= 0; i--) {
@@ -405,11 +407,19 @@ export default function Chat() {
   // Focus mode: once a conversation has at least one message we slim the
   // surrounding chrome (collapse the global app rail, fade non-essential
   // header items). Esc gives the user back the full chrome for the rest of
-  // this session.
+  // this session. The settings drawer offers a persistent opt-out.
   const isInConversation = (activeChat?.history?.length || 0) > 0
   const [focusOverride, setFocusOverride] = useState(false)
-  const focusActive = isInConversation && !focusOverride
+  const [focusModeEnabled, setFocusModeEnabled] = useState(() => {
+    try { return localStorage.getItem(FOCUS_MODE_KEY) !== 'false' } catch (_) { return true }
+  })
+  const focusActive = focusModeEnabled && isInConversation && !focusOverride
   const prevAppCollapseRef = useRef(null)
+
+  const toggleFocusMode = (next) => {
+    setFocusModeEnabled(next)
+    try { localStorage.setItem(FOCUS_MODE_KEY, String(next)) } catch (_) {}
+  }
 
   const artifacts = useMemo(
     () => canvasMode ? extractCodeArtifacts(activeChat?.history, 'role', 'assistant') : [],
@@ -1110,6 +1120,20 @@ export default function Chat() {
                 />
               </div>
             )}
+            <div className="form-group chat-settings-toggle-row">
+              <div className="chat-settings-toggle-text">
+                <span className="chat-settings-toggle-title">
+                  <i className="fas fa-compress" /> {t('settings.focusMode')}
+                </span>
+                <span className="chat-settings-toggle-desc">
+                  {t('settings.focusModeDesc')}
+                </span>
+              </div>
+              <Toggle
+                checked={focusModeEnabled}
+                onChange={toggleFocusMode}
+              />
+            </div>
             <div className="form-group">
               <label className="form-label">{t('settings.systemPrompt')}</label>
               <textarea


### PR DESCRIPTION
Assisted-by: Claude:claude-fable-5

**Description**

Add an option to toggle the focus mode when chat is active. Keeps the current default, and allows the user to disable the side bar collapse.



**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [ ] Documentation updated (docs/content/) for user-facing changes, or not applicable
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->