### PR TITLE
feat(oci): acquire CNCF ModelPack artifacts via llmman serve

### DIFF
--- a/pkg/downloader/llmman.go
+++ b/pkg/downloader/llmman.go
@@ -1,0 +1,116 @@
+package downloader
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/mudler/LocalAI/pkg/llmman"
+	"github.com/mudler/xlog"
+)
+
+// fetchModelPackViaLlmman acquires a CNCF ModelPack artifact through a running
+// `llmman serve` daemon and materialises it at dst.
+//
+// The daemon does the pull (POST /api/pull, streamed so progress is not a
+// multi-gigabyte silence) but deliberately exposes no local path, so
+// `llmman resolve --no-pull` is asked where the bytes landed. Both pieces are
+// therefore required, and each missing one has its own error.
+func fetchModelPackViaLlmman(ctx context.Context, reference, dst string, downloadStatus func(string, string, string, float64)) error {
+	endpoint := llmman.Endpoint()
+
+	if err := llmman.CheckDaemon(ctx, llmman.ProbeClient(), endpoint); err != nil {
+		return err
+	}
+
+	xlog.Info("Pulling CNCF ModelPack artifact via llmman", "ref", reference, "endpoint", endpoint)
+
+	progress := func(status string, completed, total int64) {
+		if downloadStatus == nil {
+			return
+		}
+		var pct float64
+		if total > 0 {
+			pct = float64(completed) / float64(total) * 100
+		}
+		downloadStatus(reference, "", status, pct)
+	}
+	if err := llmman.Pull(ctx, llmman.DefaultClient(), endpoint, reference, progress); err != nil {
+		return err
+	}
+
+	src, err := llmman.Resolve(ctx, reference)
+	if err != nil {
+		return err
+	}
+
+	return linkOrCopyTree(src, dst)
+}
+
+// linkOrCopyTree materialises src at dst, hard-linking files where possible so
+// a model shared with llmman's store costs its bytes once rather than twice,
+// and copying when a link cannot be made (different filesystem).
+func linkOrCopyTree(src, dst string) error {
+	info, err := os.Stat(src)
+	if err != nil {
+		return fmt.Errorf("resolved path %q: %w", src, err)
+	}
+
+	if !info.IsDir() {
+		// A single-file payload (e.g. GGUF): dst names the file itself.
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			return err
+		}
+		return linkOrCopyFile(src, dst)
+	}
+
+	return filepath.Walk(src, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if fi.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		if !fi.Mode().IsRegular() {
+			// Symlinks and devices carry no model payload.
+			return nil
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return err
+		}
+		return linkOrCopyFile(path, target)
+	})
+}
+
+func linkOrCopyFile(src, dst string) error {
+	if err := os.Remove(dst); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if err := os.Link(src, dst); err == nil {
+		return nil
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}

--- a/pkg/downloader/llmman_test.go
+++ b/pkg/downloader/llmman_test.go
@@ -1,0 +1,92 @@
+package downloader
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+func TestLinkOrCopyTreeHardLinksADirectory(t *testing.T) {
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+
+	if err := os.MkdirAll(filepath.Join(src, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "config.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sub", "model.safetensors"), []byte("w"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := linkOrCopyTree(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "sub", "model.safetensors"))
+	if err != nil || string(got) != "w" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "config.json")); err != nil {
+		t.Fatal(err)
+	}
+
+	// A model shared with llmman's store should cost its bytes once.
+	var a, b syscall.Stat_t
+	if err := syscall.Stat(filepath.Join(src, "config.json"), &a); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Stat(filepath.Join(dst, "config.json"), &b); err != nil {
+		t.Fatal(err)
+	}
+	if a.Ino != b.Ino {
+		t.Errorf("expected a hard link (same inode), got %d vs %d", a.Ino, b.Ino)
+	}
+}
+
+func TestLinkOrCopyTreeHandlesASingleFilePayload(t *testing.T) {
+	// A GGUF payload resolves to the file itself, not a directory.
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "model.gguf")
+	if err := os.WriteFile(src, []byte("gguf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "nested", "model.gguf")
+
+	if err := linkOrCopyTree(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != "gguf" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}
+
+func TestLinkOrCopyTreeOverwritesAnExistingFile(t *testing.T) {
+	srcDir := t.TempDir()
+	src := filepath.Join(srcDir, "model.gguf")
+	if err := os.WriteFile(src, []byte("new"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "model.gguf")
+	if err := os.WriteFile(dst, []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := linkOrCopyTree(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := os.ReadFile(dst)
+	if string(got) != "new" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestLinkOrCopyTreeReportsAMissingSource(t *testing.T) {
+	err := linkOrCopyTree(filepath.Join(t.TempDir(), "gone"), t.TempDir())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+}

--- a/pkg/downloader/uri.go
+++ b/pkg/downloader/uri.go
@@ -600,6 +600,19 @@ func (uri URI) DownloadFileWithContext(ctx context.Context, filePath, sha string
 			xlog.Info("Image signature verified", "ref", pinned)
 		}
 
+		// A CNCF ModelPack artifact carries model files directly rather than a
+		// runnable container filesystem, so it cannot be extracted as an image
+		// tar. Acquiring it is delegated to a running `llmman serve`, which
+		// already implements the ModelPack media types and keeps a
+		// content-addressed store.
+		isModelPack, err := oci.IsModelPackImage(img)
+		if err != nil {
+			return fmt.Errorf("inspecting manifest of %q: %v", url, err)
+		}
+		if isModelPack {
+			return fetchModelPackViaLlmman(ctx, url, filePath, downloadStatus)
+		}
+
 		return oci.ExtractOCIImage(ctx, img, url, filePath, downloadStatus)
 	}
 

--- a/pkg/llmman/client.go
+++ b/pkg/llmman/client.go
@@ -1,0 +1,261 @@
+// Package llmman is a client for a running `llmman serve` daemon
+// (https://github.com/llmmanorg/llmman), used to acquire models published as
+// CNCF ModelPack (https://github.com/modelpack/model-spec) OCI artifacts.
+//
+// The daemon owns the registry work -- ModelPack media types, registry auth,
+// resumable blob download and a content-addressed local store -- so it is not
+// reimplemented here. Two pieces are needed, because the daemon deliberately
+// exposes no local path: `POST /api/pull` streams the download, and the
+// `llmman resolve --no-pull` CLI reports where the bytes landed. That means an
+// llmman-backed pull needs both the daemon reachable and the binary on PATH;
+// each missing piece has its own error.
+package llmman
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultHost matches `llmman serve`'s own default bind address.
+	DefaultHost = "127.0.0.1"
+	// DefaultPort matches `llmman serve`'s own default port.
+	DefaultPort = "17434"
+
+	// HostEnv overrides the daemon address, same variable llmman's own
+	// clients read.
+	HostEnv = "LLMMAN_HOST"
+	// BinEnv overrides the llmman binary location.
+	BinEnv = "LOCALAI_LLMMAN_BIN"
+
+	defaultBinary = "llmman"
+)
+
+// ProgressFunc receives coarse pull progress. total and completed are zero
+// when the daemon does not report byte counts for a step.
+type ProgressFunc func(status string, completed, total int64)
+
+// Endpoint returns the http origin of the llmman daemon.
+//
+// LLMMAN_HOST is parsed as [scheme://]host[:port]; a wildcard bind host
+// (0.0.0.0 or ::) is rewritten to loopback, since a client cannot connect to
+// "every interface". This mirrors llmman's own client-side resolution.
+func Endpoint() string {
+	raw := strings.TrimSpace(os.Getenv(HostEnv))
+	raw = strings.Trim(raw, `"'`)
+	if raw == "" {
+		return "http://" + net.JoinHostPort(DefaultHost, DefaultPort)
+	}
+
+	if idx := strings.Index(raw, "://"); idx >= 0 {
+		raw = raw[idx+3:]
+	}
+	if idx := strings.Index(raw, "/"); idx >= 0 {
+		raw = raw[:idx]
+	}
+
+	host, port, err := net.SplitHostPort(raw)
+	if err != nil {
+		host, port = raw, DefaultPort
+	}
+	if host == "" {
+		host = DefaultHost
+	}
+	if port == "" {
+		port = DefaultPort
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+		if ip.To4() != nil {
+			host = "127.0.0.1"
+		} else {
+			host = "::1"
+		}
+	}
+	return "http://" + net.JoinHostPort(host, port)
+}
+
+// Binary returns the llmman executable name, overridable via LOCALAI_LLMMAN_BIN.
+func Binary() string {
+	if v := strings.TrimSpace(os.Getenv(BinEnv)); v != "" {
+		return v
+	}
+	return defaultBinary
+}
+
+// CheckDaemon confirms a llmman daemon is listening and answering.
+//
+// GET /api/version is llmman's own identity endpoint; a response without a
+// version field means something else is bound to the port, which is worth
+// distinguishing from nothing listening at all.
+func CheckDaemon(ctx context.Context, client *http.Client, endpoint string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"/api/version", nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("no llmman daemon reachable at %s: %w. Start one with `llmman serve`, or point %s at an existing daemon", endpoint, err, HostEnv)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("llmman daemon at %s answered /api/version with HTTP %d", endpoint, resp.StatusCode)
+	}
+	var payload struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil || payload.Version == "" {
+		return fmt.Errorf("the server at %s is not an llmman daemon (no version in /api/version)", endpoint)
+	}
+	return nil
+}
+
+// pullLine is one newline-delimited JSON object from /api/pull. The stream
+// mirrors Ollama's ProgressResponse: repeated status objects ending in either
+// {"status":"success"} or {"error":"..."}.
+type pullLine struct {
+	Status    string `json:"status"`
+	Error     string `json:"error"`
+	Total     int64  `json:"total"`
+	Completed int64  `json:"completed"`
+}
+
+// Pull streams POST /api/pull until the daemon reports success.
+//
+// An error can arrive in-band at HTTP 200, and a stream that simply ends
+// without success is also a failure -- both are reported rather than treated
+// as a completed pull.
+func Pull(ctx context.Context, client *http.Client, endpoint, reference string, progress ProgressFunc) error {
+	body, err := json.Marshal(map[string]string{"model": reference})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+"/api/pull", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("llmman pull of %q failed: %w", reference, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("llmman pull of %q failed: HTTP %d", reference, resp.StatusCode)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	// Status lines are small, but a generous cap avoids a truncated-line
+	// error being misreported as a failed pull.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	succeeded := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var l pullLine
+		if err := json.Unmarshal([]byte(line), &l); err != nil {
+			// Tolerate a non-JSON diagnostic rather than aborting a pull
+			// that may still be progressing.
+			continue
+		}
+		if l.Error != "" {
+			return fmt.Errorf("llmman pull of %q failed: %s", reference, l.Error)
+		}
+		if l.Status == "success" {
+			succeeded = true
+			continue
+		}
+		if progress != nil && l.Status != "" {
+			progress(l.Status, l.Completed, l.Total)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("reading llmman pull stream for %q: %w", reference, err)
+	}
+	if !succeeded {
+		return fmt.Errorf("llmman pull of %q ended without reporting success", reference)
+	}
+	return nil
+}
+
+// resolveOutput is the subset of `llmman resolve`'s single-line JSON contract
+// this package consumes. Unknown fields (format, mmproj) are ignored so the
+// contract can grow.
+type resolveOutput struct {
+	Path string `json:"path"`
+}
+
+// Resolve reports where the daemon's pull left the model on disk.
+//
+// --no-pull guarantees this only reports on bytes /api/pull already fetched,
+// so the daemon stays the only thing that touches the network.
+func Resolve(ctx context.Context, reference string) (string, error) {
+	binary := Binary()
+	if _, err := exec.LookPath(binary); err != nil {
+		if _, statErr := os.Stat(binary); statErr != nil {
+			return "", fmt.Errorf("%q not found: install llmman (https://github.com/llmmanorg/llmman) and put it on PATH, or set %s to its location", binary, BinEnv)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, binary, "resolve", "--no-pull", reference)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("`%s resolve --no-pull %s` failed: %w: %s", binary, reference, err, strings.TrimSpace(stderr.String()))
+	}
+
+	return parseResolveOutput(stdout.String(), reference)
+}
+
+// parseResolveOutput takes the last non-empty stdout line, so a diagnostic
+// that leaks onto stdout does not break resolution.
+func parseResolveOutput(stdout, reference string) (string, error) {
+	var last string
+	for _, line := range strings.Split(stdout, "\n") {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			last = trimmed
+		}
+	}
+	if last == "" {
+		return "", fmt.Errorf("llmman resolve %q printed nothing on stdout", reference)
+	}
+
+	var out resolveOutput
+	if err := json.Unmarshal([]byte(last), &out); err != nil {
+		return "", fmt.Errorf("llmman resolve %q: could not parse output as JSON: %s", reference, last)
+	}
+	if strings.TrimSpace(out.Path) == "" {
+		return "", fmt.Errorf("llmman resolve %q returned an empty path", reference)
+	}
+	if _, err := os.Stat(out.Path); err != nil {
+		return "", fmt.Errorf("llmman resolve %q reported path %q which does not exist: %w", reference, out.Path, err)
+	}
+	return out.Path, nil
+}
+
+// DefaultClient is a http client with no overall timeout, since a pull of a
+// multi-gigabyte model is expected to be long-running; cancellation is the
+// caller's context.
+func DefaultClient() *http.Client {
+	return &http.Client{Transport: http.DefaultTransport}
+}
+
+// ProbeClient is used only for the short /api/version reachability check.
+func ProbeClient() *http.Client {
+	return &http.Client{Timeout: 5 * time.Second}
+}

--- a/pkg/llmman/client_test.go
+++ b/pkg/llmman/client_test.go
@@ -1,0 +1,228 @@
+package llmman
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEndpointDefaultsToLlmmanServeDefault(t *testing.T) {
+	t.Setenv(HostEnv, "")
+	if got := Endpoint(); got != "http://127.0.0.1:17434" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestEndpointParsesHostForms(t *testing.T) {
+	cases := map[string]string{
+		"1.2.3.4:9999":                "http://1.2.3.4:9999",
+		"1.2.3.4":                     "http://1.2.3.4:17434",
+		"http://1.2.3.4:9999":         "http://1.2.3.4:9999",
+		"http://1.2.3.4:9999/ignored": "http://1.2.3.4:9999",
+		`"1.2.3.4:9999"`:              "http://1.2.3.4:9999",
+		// A wildcard bind is meaningful to the server but not to a client,
+		// which cannot connect to "every interface".
+		"0.0.0.0:9999": "http://127.0.0.1:9999",
+		"[::]:9999":    "http://[::1]:9999",
+	}
+	for in, want := range cases {
+		t.Setenv(HostEnv, in)
+		if got := Endpoint(); got != want {
+			t.Errorf("Endpoint(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestCheckDaemonAcceptsALlmmanDaemon(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/version" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"version": "0.1.0", "pid": 1})
+	}))
+	defer srv.Close()
+
+	if err := CheckDaemon(context.Background(), srv.Client(), srv.URL); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckDaemonRejectsANonLlmmanServer(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"hello":"world"}`))
+	}))
+	defer srv.Close()
+
+	err := CheckDaemon(context.Background(), srv.Client(), srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "not an llmman daemon") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestCheckDaemonReportsNothingListening(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing listening now
+
+	err := CheckDaemon(context.Background(), ProbeClient(), url)
+	if err == nil || !strings.Contains(err.Error(), "llmman serve") {
+		t.Fatalf("expected an actionable error, got %v", err)
+	}
+}
+
+func ndjson(lines ...map[string]any) string {
+	var b strings.Builder
+	for _, l := range lines {
+		raw, _ := json.Marshal(l)
+		b.Write(raw)
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+func pullServer(t *testing.T, body string, status int) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/pull" || r.Method != http.MethodPost {
+			t.Errorf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		var req map[string]string
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req["model"] == "" {
+			t.Error("expected a model field in the pull request")
+		}
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestPullSucceedsAndForwardsProgress(t *testing.T) {
+	srv := pullServer(t, ndjson(
+		map[string]any{"status": "pulling manifest"},
+		map[string]any{"status": "pulling blobs", "completed": 50, "total": 100},
+		map[string]any{"status": "success"},
+	), http.StatusOK)
+	defer srv.Close()
+
+	var seen []string
+	var lastCompleted, lastTotal int64
+	err := Pull(context.Background(), srv.Client(), srv.URL, "ghcr.io/org/model:tag",
+		func(status string, completed, total int64) {
+			seen = append(seen, status)
+			lastCompleted, lastTotal = completed, total
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(seen) != 2 || seen[0] != "pulling manifest" {
+		t.Fatalf("progress = %v", seen)
+	}
+	if lastCompleted != 50 || lastTotal != 100 {
+		t.Fatalf("byte progress = %d/%d", lastCompleted, lastTotal)
+	}
+}
+
+func TestPullReportsInBandErrorAtHTTP200(t *testing.T) {
+	// The daemon streams errors in-band, so a 200 does not mean success.
+	srv := pullServer(t, ndjson(
+		map[string]any{"status": "pulling manifest"},
+		map[string]any{"error": "unauthorized"},
+	), http.StatusOK)
+	defer srv.Close()
+
+	err := Pull(context.Background(), srv.Client(), srv.URL, "ref", nil)
+	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestPullRejectsAStreamThatEndsWithoutSuccess(t *testing.T) {
+	srv := pullServer(t, ndjson(map[string]any{"status": "pulling blobs"}), http.StatusOK)
+	defer srv.Close()
+
+	err := Pull(context.Background(), srv.Client(), srv.URL, "ref", nil)
+	if err == nil || !strings.Contains(err.Error(), "without reporting success") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestPullReportsNonOKStatus(t *testing.T) {
+	srv := pullServer(t, `{"error":"bad request"}`, http.StatusBadRequest)
+	defer srv.Close()
+
+	if err := Pull(context.Background(), srv.Client(), srv.URL, "ref", nil); err == nil {
+		t.Fatal("expected an error")
+	}
+}
+
+func TestPullToleratesANonJSONDiagnosticLine(t *testing.T) {
+	body := "not json\n" + ndjson(map[string]any{"status": "success"})
+	srv := pullServer(t, body, http.StatusOK)
+	defer srv.Close()
+
+	if err := Pull(context.Background(), srv.Client(), srv.URL, "ref", nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseResolveOutput(t *testing.T) {
+	dir := t.TempDir()
+
+	got, err := parseResolveOutput(`{"reference":"r","path":"`+dir+`","format":"safetensors"}`, "r")
+	if err != nil || got != dir {
+		t.Fatalf("got %q, %v", got, err)
+	}
+
+	// A diagnostic leaking onto stdout must not break resolution.
+	got, err = parseResolveOutput("pulling...\n{\"path\":\""+dir+"\"}\n", "r")
+	if err != nil || got != dir {
+		t.Fatalf("got %q, %v", got, err)
+	}
+
+	// Unknown fields are ignored so the contract can grow.
+	if _, err := parseResolveOutput(`{"path":"`+dir+`","mmproj":"/x","future":1}`, "r"); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, bad := range []string{
+		"",
+		"   \n\n",
+		"not json",
+		`{"no_path":1}`,
+		`{"path":""}`,
+		`{"path":"/nonexistent/xyzzy"}`,
+	} {
+		if _, err := parseResolveOutput(bad, "r"); err == nil {
+			t.Errorf("expected an error for %q", bad)
+		}
+	}
+}
+
+func TestBinaryHonoursTheOverride(t *testing.T) {
+	t.Setenv(BinEnv, "")
+	if Binary() != "llmman" {
+		t.Fatalf("got %q", Binary())
+	}
+	t.Setenv(BinEnv, "/opt/bin/llmman")
+	if Binary() != "/opt/bin/llmman" {
+		t.Fatalf("got %q", Binary())
+	}
+	// An empty override is a mistake, not a request to run the empty string.
+	t.Setenv(BinEnv, "   ")
+	if Binary() != "llmman" {
+		t.Fatalf("got %q", Binary())
+	}
+}
+
+func TestResolveReportsAMissingBinary(t *testing.T) {
+	t.Setenv(BinEnv, filepath.Join(t.TempDir(), "definitely-not-here"))
+	_, err := Resolve(context.Background(), "ref")
+	if err == nil || !strings.Contains(err.Error(), "install llmman") {
+		t.Fatalf("expected an actionable error, got %v", err)
+	}
+}

--- a/pkg/oci/modelpack.go
+++ b/pkg/oci/modelpack.go
@@ -1,0 +1,43 @@
+package oci
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// CNCF ModelPack (https://github.com/modelpack/model-spec) discriminators. A
+// manifest declaring either carries model files directly rather than a
+// runnable container filesystem, so it cannot be extracted as an image tar.
+const (
+	ModelPackArtifactType    = "application/vnd.cncf.model.manifest.v1+json"
+	ModelPackConfigMediaType = "application/vnd.cncf.model.config.v1+json"
+)
+
+// manifestEnvelope is the subset of an OCI manifest ModelPack detection needs.
+// go-containerregistry's v1.Manifest has no ArtifactType field, so the raw
+// manifest is parsed instead.
+type manifestEnvelope struct {
+	ArtifactType string `json:"artifactType"`
+	Config       struct {
+		MediaType string `json:"mediaType"`
+	} `json:"config"`
+}
+
+// IsModelPackImage reports whether img is a CNCF ModelPack artifact.
+//
+// artifactType is the spec's discriminator. The config mediaType is checked as
+// well, for registries and clients that predate artifactType or strip it.
+func IsModelPackImage(img v1.Image) (bool, error) {
+	raw, err := img.RawManifest()
+	if err != nil {
+		return false, fmt.Errorf("reading manifest: %w", err)
+	}
+	env := &manifestEnvelope{}
+	if err := json.Unmarshal(raw, env); err != nil {
+		return false, fmt.Errorf("parsing manifest: %w", err)
+	}
+	return env.ArtifactType == ModelPackArtifactType ||
+		env.Config.MediaType == ModelPackConfigMediaType, nil
+}

--- a/pkg/oci/modelpack_internal_test.go
+++ b/pkg/oci/modelpack_internal_test.go
@@ -1,0 +1,59 @@
+package oci
+
+import (
+	"encoding/json"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// fakeManifestImage serves a hand-written manifest, so artifactType and the
+// config descriptor can be varied without a registry.
+type fakeManifestImage struct {
+	v1.Image
+	manifest []byte
+}
+
+func (i *fakeManifestImage) RawManifest() ([]byte, error) { return i.manifest, nil }
+
+func manifestJSON(fields map[string]any) []byte {
+	fields["schemaVersion"] = 2
+	raw, _ := json.Marshal(fields)
+	return raw
+}
+
+var _ = Describe("ModelPack detection", func() {
+	It("recognizes a manifest by its artifactType", func() {
+		img := &fakeManifestImage{manifest: manifestJSON(map[string]any{
+			"artifactType": ModelPackArtifactType,
+		})}
+		Expect(IsModelPackImage(img)).To(BeTrue())
+	})
+
+	It("recognizes a manifest identified only by its config mediaType", func() {
+		// Some registries and older clients drop artifactType.
+		img := &fakeManifestImage{manifest: manifestJSON(map[string]any{
+			"config": map[string]any{"mediaType": ModelPackConfigMediaType},
+		})}
+		Expect(IsModelPackImage(img)).To(BeTrue())
+	})
+
+	It("does not claim a plain container image", func() {
+		img := &fakeManifestImage{manifest: manifestJSON(map[string]any{
+			"config": map[string]any{"mediaType": "application/vnd.oci.image.config.v1+json"},
+			"layers": []any{},
+		})}
+		Expect(IsModelPackImage(img)).To(BeFalse())
+	})
+
+	It("does not claim a manifest with neither discriminator", func() {
+		img := &fakeManifestImage{manifest: manifestJSON(map[string]any{})}
+		Expect(IsModelPackImage(img)).To(BeFalse())
+	})
+
+	It("errors on an unparseable manifest rather than guessing", func() {
+		_, err := IsModelPackImage(&fakeManifestImage{manifest: []byte("{not json")})
+		Expect(err).To(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## Description

The `oci://` scheme extracts the reference as a **container image**: `ExtractOCIImage` writes the layers to a docker-save tar and unions that filesystem into the destination. A [CNCF ModelPack](https://github.com/modelpack/model-spec) artifact is not a runnable image -- its layers are typed `application/vnd.cncf.model.{weight,weight.config,doc,code,dataset}.v1.{raw,tar,tar+gzip,tar+zstd}`, an uncompressed layer is a *bare file* rather than a tar, and there is no filesystem to union. So `oci://` today works for a model baked into a container image, but not for a model *artifact*.

```yaml
name: my-model
parameters:
  model: oci://ghcr.io/org/model:tag
```

## Implementation

**Detection stays local** (`pkg/oci/modelpack.go`): `artifactType == application/vnd.cncf.model.manifest.v1+json`, falling back to the config descriptor's mediaType for registries and clients that predate or strip `artifactType`. `v1.Manifest` has no `ArtifactType` field, so the raw manifest is parsed.

**Acquisition is delegated to a running [`llmman serve`](https://github.com/llmmanorg/llmman)** rather than hand-rolled here. llmman already implements the ModelPack media types, registry auth, resumable blob download and a content-addressed store -- that is registry protocol code LocalAI has no particular interest in owning, and it covers layouts a hand-rolled reader would have to grow one at a time (`.raw` vs `.tar` vs `.tar+gzip` vs `.tar+zstd`, filepath annotations, image indexes).

New `pkg/llmman` is the client:

- `GET /api/version` probes reachability *and* identity -- a server answering without a `version` field is reported as "not an llmman daemon", which is worth distinguishing from nothing listening.
- `POST /api/pull` streams NDJSON so a multi-gigabyte fetch is not silent; status/`completed`/`total` map onto the existing `downloadStatus` callback. An error arrives **in-band at HTTP 200**, and a stream that simply ends without `success` is also a failure -- both are treated as errors rather than a completed pull.
- `llmman resolve --no-pull` reports where the bytes landed. The daemon deliberately exposes no local path (`/api/show` returns only a digest and size), so the CLI is the documented interface for this; `--no-pull` guarantees it only reports on what `/api/pull` already fetched, keeping the daemon the only thing that touches the network.

So a pull needs **both** the daemon reachable and the binary on `PATH` (or `LOCALAI_LLMMAN_BIN`); each missing piece has its own actionable error. `LLMMAN_HOST` is honoured with the same parsing llmman's own clients use, including rewriting a wildcard bind (`0.0.0.0`, `[::]`) to loopback.

Files are **hard-linked** out of llmman's store where possible, falling back to a copy across filesystems, so a model shared with llmman costs its bytes once rather than twice.

`pkg/downloader/uri.go` gains one branch after signature verification. **A manifest that is not ModelPack takes exactly the path it did before**, so container-image behaviour is bit-for-bit unchanged.

## Testing

Verified, actually executed:

```
$ go test ./pkg/oci/ ./pkg/llmman/ ./pkg/downloader/
ok  github.com/mudler/LocalAI/pkg/oci         188.364s
ok  github.com/mudler/LocalAI/pkg/llmman
ok  github.com/mudler/LocalAI/pkg/downloader    6.198s
```

- **`pkg/llmman`** (13 tests, against a real `httptest` server -- no daemon needed): endpoint defaults and every `LLMMAN_HOST` form incl. wildcard-to-loopback rewriting; `/api/version` accepted, a non-llmman server rejected, nothing-listening reported actionably; pull success with forwarded byte progress; in-band error at HTTP 200; stream ending without `success`; non-OK status; a non-JSON diagnostic line tolerated; the full `resolve` output contract incl. leaked-diagnostic and unknown-field tolerance and six malformed cases; `LOCALAI_LLMMAN_BIN` default/override/empty-override; missing-binary error.
- **`pkg/downloader`** (4 tests): `linkOrCopyTree` over a nested directory, asserting **`st_ino` equality** to prove the file was hard-linked rather than copied; a single-file (GGUF) payload; overwriting a stale destination; a missing source.
- **`pkg/oci`** (5 specs): detection by `artifactType`, by config mediaType, a plain container image **not** claimed, neither-discriminator not claimed, unparseable manifest errors.

- [x] `go build ./pkg/...`, `go vet`, `gofmt -l` all clean on touched files (note: `pkg/downloader/cancel_test.go` is unformatted on `master` already; untouched here)

Not verified here, flagged rather than implied: no run against a real registry serving a ModelPack artifact, and no end-to-end model load against a live `llmman serve`. Coverage is at the client/protocol level with a stub server.

## Notes for Reviewers

Two judgement calls worth a look:

1. **Why a daemon and a binary, rather than just one.** `llmman serve` owns the download but exposes no path; `llmman resolve` knows the path but would pull in-process. Using `/api/pull` + `resolve --no-pull` keeps all network I/O in the daemon (one shared cache, one place to configure registry credentials) while still learning where the files are. The cost is two dependencies instead of one, which is why each has a distinct error message.
2. **Hard-linking rather than copying.** This assumes LocalAI's models directory and llmman's store are usually on the same filesystem. When they are not, it degrades to a copy silently, which is the pre-existing behaviour anyway.

**[X] Yes, I signed my commits.**

> Disclosure: this change was written with AI assistance. I have reviewed it.
