### PR TITLE
fix(gallery): use published F16 mmproj for qwythos-9b

### DIFF
--- a/core/gallery/variants_lint_test.go
+++ b/core/gallery/variants_lint_test.go
@@ -540,6 +540,29 @@ var _ = Describe("gallery/index.yaml Higgs Audio entry", func() {
 	})
 })
 
+var _ = Describe("gallery/index.yaml qwythos-9b-claude-mythos-5-1m mmproj", func() {
+	It("points at the published F16 mmproj artifact", func() {
+		entries, err := loadGalleryIndex()
+		Expect(err).ToNot(HaveOccurred())
+
+		models := make([]*gallery.GalleryModel, 0, len(entries))
+		for i := range entries {
+			models = append(models, &entries[i])
+		}
+		entry := gallery.FindGalleryElement(models, "qwythos-9b-claude-mythos-5-1m")
+		Expect(entry).ToNot(BeNil())
+		Expect(entry.Overrides).To(HaveKeyWithValue(
+			"mmproj",
+			"llama-cpp/mmproj/Qwythos-9B-Claude-Mythos-5-1M-GGUF/mmproj-Qwythos-9B-Claude-Mythos-5-1M-F16.gguf",
+		))
+		Expect(entry.AdditionalFiles).To(ContainElement(gallery.File{
+			Filename: "llama-cpp/mmproj/Qwythos-9B-Claude-Mythos-5-1M-GGUF/mmproj-Qwythos-9B-Claude-Mythos-5-1M-F16.gguf",
+			SHA256:   "f977efc337a2ac2ba183eea0c73e25b75fc240d56c05ed4d9b56ab451f64c82c",
+			URI:      "https://huggingface.co/empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF/resolve/main/mmproj-Qwythos-9B-Claude-Mythos-5-1M-F16.gguf",
+		}))
+	})
+})
+
 // The lint rules above check the catalog as text. This drives the real
 // resolution path for the entry a user actually clicked and failed to install,
 // so the fix is proven at the layer that broke and not only at the layer that

--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -7133,7 +7133,7 @@
         disable: true
     known_usecases:
       - chat
-    mmproj: llama-cpp/mmproj/Qwythos-9B-Claude-Mythos-5-1M-GGUF/mmproj-Qwythos-9B-Claude-Mythos-5-1M-f16.gguf
+    mmproj: llama-cpp/mmproj/Qwythos-9B-Claude-Mythos-5-1M-GGUF/mmproj-Qwythos-9B-Claude-Mythos-5-1M-F16.gguf
     options:
       - use_jinja:true
       - spec_type:draft-mtp
@@ -7147,9 +7147,9 @@
     - filename: llama-cpp/models/Qwythos-9B-Claude-Mythos-5-1M-GGUF/Qwythos-9B-Claude-Mythos-5-1M-MTP-Q4_K_M.gguf
       uri: https://huggingface.co/empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF/resolve/main/Qwythos-9B-Claude-Mythos-5-1M-MTP-Q4_K_M.gguf
       sha256: 318caed45110f5e3c60bff1142e0d1e658e046e670830d9be643df33940f4f98
-    - filename: llama-cpp/mmproj/Qwythos-9B-Claude-Mythos-5-1M-GGUF/mmproj-Qwythos-9B-Claude-Mythos-5-1M-f16.gguf
-      sha256: f70dc3509053962b0d0d3ee8a7eacebf5d60aa560cad78254ae8698516ae029f
-      uri: https://huggingface.co/empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF/resolve/main/mmproj-Qwythos-9B-Claude-Mythos-5-1M-f16.gguf
+    - filename: llama-cpp/mmproj/Qwythos-9B-Claude-Mythos-5-1M-GGUF/mmproj-Qwythos-9B-Claude-Mythos-5-1M-F16.gguf
+      sha256: f977efc337a2ac2ba183eea0c73e25b75fc240d56c05ed4d9b56ab451f64c82c
+      uri: https://huggingface.co/empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF/resolve/main/mmproj-Qwythos-9B-Claude-Mythos-5-1M-F16.gguf
 - name: "glm-5.2"
   url: "github:mudler/LocalAI/gallery/virtual.yaml@master"
   urls:


### PR DESCRIPTION
Installing qwythos-9b-claude-mythos-5-1m 404s: the gallery still points at mmproj-...-f16.gguf, but Hugging Face only has mmproj-...-F16.gguf (and a different sha256). Point filename, uri, and overrides at the published file and update the checksum.

Related to #10659

- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable