### PR TITLE
refactor(worker): iterate node label pairs with SplitSeq

### DIFF
--- a/core/cli/worker/labels.go
+++ b/core/cli/worker/labels.go
@@ -10,7 +10,7 @@ func ParseNodeLabels(input string) map[string]string {
 	if input == "" {
 		return labels
 	}
-	for _, pair := range strings.Split(input, ",") {
+	for pair := range strings.SplitSeq(input, ",") {
 		pair = strings.TrimSpace(pair)
 		if k, v, ok := strings.Cut(pair, "="); ok {
 			labels[strings.TrimSpace(k)] = strings.TrimSpace(v)


### PR DESCRIPTION
**Description**

Use strings.SplitSeq in ParseNodeLabels because label pairs are consumed once. Trimming, malformed-pair skipping, and last-value-wins behavior remain unchanged.

**Notes for Reviewers**



**Signed commits**
- [x] Yes, I signed my commits.
- [x] Documentation update is not applicable for this internal refactor.