### PR TITLE
[ui] fix: send collection intervals as numbers

### DIFF
--- a/core/http/react-ui/e2e/collections.spec.js
+++ b/core/http/react-ui/e2e/collections.spec.js
@@ -19,4 +19,33 @@ test.describe('Collections page', () => {
     await input.fill('my-kb')
     await expect(input).toHaveValue('my-kb')
   })
+
+  test('posts the source update interval as a JSON number', async ({ page }) => {
+    const collectionName = 'interval-regression'
+    const collectionPath = encodeURIComponent(collectionName)
+    let postedBody
+
+    await page.route(`**/api/agents/collections/${collectionPath}/entries`, route =>
+      route.fulfill({ contentType: 'application/json', body: JSON.stringify({ entries: [] }) }))
+    await page.route(`**/api/agents/collections/${collectionPath}/sources`, async route => {
+      if (route.request().method() === 'POST') {
+        postedBody = route.request().postDataJSON()
+        await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ status: 'ok' }) })
+      } else {
+        await route.fulfill({ contentType: 'application/json', body: JSON.stringify({ sources: [] }) })
+      }
+    })
+
+    await page.goto(`/app/collections/${collectionPath}`)
+    await page.getByRole('button', { name: 'Sources' }).click()
+    await page.locator('#source-url').fill('https://example.com/feed')
+    await page.locator('#source-interval').fill('3600')
+    await page.getByRole('button', { name: 'Add Source' }).click()
+
+    await expect.poll(() => postedBody).toEqual({
+      url: 'https://example.com/feed',
+      update_interval: 3600,
+    })
+    expect(typeof postedBody.update_interval).toBe('number')
+  })
 })

--- a/core/http/react-ui/src/pages/CollectionDetails.jsx
+++ b/core/http/react-ui/src/pages/CollectionDetails.jsx
@@ -432,10 +432,12 @@ export default function CollectionDetails() {
               <input
                 id="source-interval"
                 className="input"
-                type="text"
+                type="number"
+                min="1"
+                step="1"
                 value={newSourceInterval}
                 onChange={(e) => setNewSourceInterval(e.target.value)}
-                placeholder="e.g. 1h, 30m"
+                placeholder="e.g. 60 (minutes)"
               />
             </div>
             <button className="btn btn-primary" type="submit" disabled={!newSourceUrl.trim() || addingSource}>

--- a/core/http/react-ui/src/utils/api.js
+++ b/core/http/react-ui/src/utils/api.js
@@ -457,7 +457,10 @@ export const agentCollectionsApi = {
   reset: (name, userId) => postJSON(`/api/agents/collections/${enc(name)}/reset${userQ(userId)}`),
   deleteEntry: (name, entry, userId) => fetchJSON(`/api/agents/collections/${enc(name)}/entry/delete${userQ(userId)}`, { method: 'DELETE', body: JSON.stringify({ entry }), headers: { 'Content-Type': 'application/json' } }),
   sources: (name, userId) => fetchJSON(`/api/agents/collections/${enc(name)}/sources${userQ(userId)}`),
-  addSource: (name, url, interval, userId) => postJSON(`/api/agents/collections/${enc(name)}/sources${userQ(userId)}`, { url, update_interval: interval }),
+  addSource: (name, url, interval, userId) => postJSON(`/api/agents/collections/${enc(name)}/sources${userQ(userId)}`, {
+    url,
+    update_interval: interval === undefined ? undefined : Number(interval),
+  }),
   removeSource: (name, url, userId) => fetchJSON(`/api/agents/collections/${enc(name)}/sources${userQ(userId)}`, { method: 'DELETE', body: JSON.stringify({ url }), headers: { 'Content-Type': 'application/json' } }),
 }
 

--- a/docs/content/features/agents.md
+++ b/docs/content/features/agents.md
@@ -288,6 +288,9 @@ All agent endpoints are grouped under `/api/agents/`:
 | `POST` | `/api/agents/collections/:name/upload` | Upload a document |
 | `GET` | `/api/agents/collections/:name/entries` | List entries |
 | `POST` | `/api/agents/collections/:name/search` | Search a collection |
+| `GET` | `/api/agents/collections/:name/sources` | List external sources |
+| `POST` | `/api/agents/collections/:name/sources` | Add an external source (`update_interval` is an integer number of minutes; defaults to 60) |
+| `DELETE` | `/api/agents/collections/:name/sources` | Remove an external source |
 | `POST` | `/api/agents/collections/:name/reset` | Reset a collection |
 
 ### Actions


### PR DESCRIPTION
**Description**

Fixes #11815

The collection source form keeps input values as strings, so a numeric update interval was serialized as a JSON string and rejected by the Go API. This change:

- converts the interval at the API boundary so it is sent as a JSON number
- constrains the field to positive integer minutes, matching the backend contract
- adds a Playwright regression test that inspects the posted JSON body
- documents the collection source endpoints and interval unit

**Notes for Reviewers**

The API behavior and default interval are unchanged. Empty intervals remain omitted so the server continues to apply its existing default.

**Signed commits**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable

**Validation**

- `npx eslint e2e/collections.spec.js src/utils/api.js src/pages/CollectionDetails.jsx` (0 errors; existing warnings only)
- `npm run lint:inline-styles`
- `npm run build`
- `npx playwright test e2e/collections.spec.js --project=chromium --list`
- Full Playwright execution was not available in this Windows environment because the repository's configured UI test server uses Unix paths and requires the generated Go test assets.