### PR TITLE
fix(ui): omit empty system prompt so model default applies

### DIFF
--- a/core/http/endpoints/openai/chat.go
+++ b/core/http/endpoints/openai/chat.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -24,16 +25,45 @@ import (
 	"github.com/mudler/xlog"
 )
 
+// messageText returns the textual content of a message, preferring the
+// middleware-populated StringContent and falling back to a string Content.
+func messageText(m schema.Message) string {
+	if m.StringContent != "" {
+		return m.StringContent
+	}
+	if s, ok := m.Content.(string); ok {
+		return s
+	}
+	return ""
+}
+
 // hasSystemMessage reports whether the message slice already contains a
-// system-role message — used to avoid clobbering a caller-supplied system
-// prompt when the LocalAI Assistant modality is on.
+// non-empty system-role message — used to avoid clobbering a caller-supplied
+// system prompt when the LocalAI Assistant modality is on. Empty / whitespace
+// system turns (historically sent by the web Chat UI) are ignored so they do
+// not suppress the model config system_prompt.
 func hasSystemMessage(messages []schema.Message) bool {
 	for _, m := range messages {
-		if m.Role == "system" {
+		if m.Role == "system" && strings.TrimSpace(messageText(m)) != "" {
 			return true
 		}
 	}
 	return false
+}
+
+// stripEmptySystemMessages drops system-role messages whose content is empty
+// or whitespace-only. An explicit blank system turn would otherwise satisfy
+// tokenizer chat templates' `messages[0].role == "system"` check and suppress
+// both the model's configured system_prompt and any template default.
+func stripEmptySystemMessages(messages []schema.Message) []schema.Message {
+	out := messages[:0:0]
+	for _, m := range messages {
+		if m.Role == "system" && strings.TrimSpace(messageText(m)) == "" {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
 }
 
 // mergeToolCallDeltas merges streaming tool call deltas into complete tool calls.
@@ -148,6 +178,18 @@ func ChatEndpoint(cl *config.ModelConfigLoader, ml *model.ModelLoader, evaluator
 		}
 
 		xlog.Debug("Chat endpoint configuration read", "config", config)
+
+		// Drop blank system turns from the web UI (and similar clients) so they
+		// cannot suppress the model YAML system_prompt / tokenizer defaults.
+		input.Messages = stripEmptySystemMessages(input.Messages)
+
+		// Tokenizer-template models pass messages through to the backend as-is,
+		// so apply the configured system_prompt when the request did not supply
+		// one. Go-template models already receive SystemPrompt via PromptTemplateData.
+		if config.TemplateConfig.UseTokenizerTemplate && config.SystemPrompt != "" && !hasSystemMessage(input.Messages) {
+			prompt := config.SystemPrompt
+			input.Messages = append([]schema.Message{{Role: "system", Content: prompt, StringContent: prompt}}, input.Messages...)
+		}
 
 		// Cloud-proxy bail. Bypasses the local pipeline (templating,
 		// MCP injection, gRPC backend) and forwards via the cloud-

--- a/core/http/endpoints/openai/chat_test.go
+++ b/core/http/endpoints/openai/chat_test.go
@@ -357,3 +357,47 @@ var _ = Describe("mergeToolCallDeltas", func() {
 		})
 	})
 })
+
+var _ = Describe("system message helpers", func() {
+	Describe("hasSystemMessage", func() {
+		It("ignores empty and whitespace-only system turns", func() {
+			Expect(hasSystemMessage([]schema.Message{
+				{Role: "system", Content: "", StringContent: ""},
+				{Role: "user", Content: "hi", StringContent: "hi"},
+			})).To(BeFalse())
+			Expect(hasSystemMessage([]schema.Message{
+				{Role: "system", Content: "   ", StringContent: "   "},
+			})).To(BeFalse())
+		})
+
+		It("detects a real system prompt", func() {
+			Expect(hasSystemMessage([]schema.Message{
+				{Role: "system", Content: "You are helpful.", StringContent: "You are helpful."},
+				{Role: "user", Content: "hi", StringContent: "hi"},
+			})).To(BeTrue())
+		})
+	})
+
+	Describe("stripEmptySystemMessages", func() {
+		It("removes blank system turns and keeps the rest", func() {
+			in := []schema.Message{
+				{Role: "system", Content: "", StringContent: ""},
+				{Role: "system", Content: "  ", StringContent: "  "},
+				{Role: "user", Content: "Explain how this works", StringContent: "Explain how this works"},
+			}
+			out := stripEmptySystemMessages(in)
+			Expect(out).To(HaveLen(1))
+			Expect(out[0].Role).To(Equal("user"))
+		})
+
+		It("keeps a non-empty system turn", func() {
+			in := []schema.Message{
+				{Role: "system", Content: "You are LocalAI.", StringContent: "You are LocalAI."},
+				{Role: "user", Content: "hi", StringContent: "hi"},
+			}
+			out := stripEmptySystemMessages(in)
+			Expect(out).To(HaveLen(2))
+			Expect(out[0].StringContent).To(Equal("You are LocalAI."))
+		})
+	})
+})

--- a/core/http/react-ui/src/hooks/useChat.js
+++ b/core/http/react-ui/src/hooks/useChat.js
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react'
 import { API_CONFIG } from '../utils/config'
 import { apiUrl } from '../utils/basePath'
+import { effectiveSystemPrompt } from '../utils/systemPrompt'
 import { useDebouncedEffect } from './useDebounce'
 
 const thinkingTagRegex = /<thinking>([\s\S]*?)<\/thinking>|<think>([\s\S]*?)<\/think>|<\|channel>thought([\s\S]*?)<channel\|>/g
@@ -348,8 +349,12 @@ export function useChat(initialModel = '') {
     // Build messages array for API
     const chat = chats.find(c => c.id === chatId)
     const messages = []
-    if (chat?.systemPrompt) {
-      messages.push({ role: 'system', content: chat.systemPrompt })
+    // Omit empty/whitespace system prompts so the model YAML system_prompt
+    // (and tokenizer chat-template defaults) are not suppressed by a blank
+    // system turn from Chat Settings.
+    const systemPrompt = effectiveSystemPrompt(chat?.systemPrompt)
+    if (systemPrompt) {
+      messages.push({ role: 'system', content: systemPrompt })
     }
     // Filter out thinking/reasoning/tool_call/tool_result messages.
     // options.baseHistory lets callers (e.g. mid-conversation retry) pass the
@@ -358,6 +363,7 @@ export function useChat(initialModel = '') {
     const baseHistory = options.baseHistory || chat?.history || []
     const historyForApi = baseHistory.filter(m =>
       m.role !== 'thinking' && m.role !== 'reasoning' && m.role !== 'tool_call' && m.role !== 'tool_result'
+      && !(m.role === 'system' && !effectiveSystemPrompt(typeof m.content === 'string' ? m.content : ''))
     )
     messages.push(...historyForApi, { role: 'user', content: messageContent })
 

--- a/core/http/react-ui/src/utils/systemPrompt.js
+++ b/core/http/react-ui/src/utils/systemPrompt.js
@@ -1,0 +1,17 @@
+/**
+ * Normalize a chat UI system prompt for the /v1/chat/completions payload.
+ * Empty / whitespace-only values must be omitted so the backend can apply the
+ * model's configured system_prompt (and tokenizer chat templates are not fed
+ * an explicit blank system turn).
+ */
+export function effectiveSystemPrompt(prompt) {
+  if (typeof prompt !== 'string') return ''
+  return prompt.trim()
+}
+
+/**
+ * True when the UI should include a system message in the request.
+ */
+export function shouldSendSystemPrompt(prompt) {
+  return effectiveSystemPrompt(prompt) !== ''
+}

--- a/core/http/react-ui/src/utils/systemPrompt.test.js
+++ b/core/http/react-ui/src/utils/systemPrompt.test.js
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { effectiveSystemPrompt, shouldSendSystemPrompt } from './systemPrompt.js'
+
+test('empty string is omitted', () => {
+  assert.equal(effectiveSystemPrompt(''), '')
+  assert.equal(shouldSendSystemPrompt(''), false)
+})
+
+test('whitespace-only is omitted', () => {
+  assert.equal(effectiveSystemPrompt('   \n\t  '), '')
+  assert.equal(shouldSendSystemPrompt(' \t'), false)
+})
+
+test('non-empty prompt is kept trimmed', () => {
+  assert.equal(effectiveSystemPrompt('  You are helpful.  '), 'You are helpful.')
+  assert.equal(shouldSendSystemPrompt('You are helpful.'), true)
+})
+
+test('non-strings are treated as empty', () => {
+  assert.equal(effectiveSystemPrompt(null), '')
+  assert.equal(effectiveSystemPrompt(undefined), '')
+  assert.equal(shouldSendSystemPrompt(0), false)
+})

--- a/core/http/static/chat.js
+++ b/core/http/static/chat.js
@@ -1149,13 +1149,21 @@ async function promptGPT(systemPrompt, input) {
   messages = chatStore.messages();
 
   // Exclude thinking/reasoning from API payload (backend chat templates expect only system/user/assistant)
-  messages = messages.filter((m) => m.role !== "thinking" && m.role !== "reasoning");
+  // Also drop blank system turns so they cannot suppress the model default.
+  messages = messages.filter((m) =>
+    m.role !== "thinking" &&
+    m.role !== "reasoning" &&
+    !(m.role === "system" && !(typeof m.content === "string" && m.content.trim()))
+  );
 
-  // if systemPrompt isn't empty, push it at the start of messages
-  if (systemPrompt) {
+  // Omit empty/whitespace system prompts so the model YAML system_prompt
+  // (and tokenizer chat-template defaults) are not suppressed by a blank
+  // system turn from Chat Settings.
+  const trimmedSystemPrompt = typeof systemPrompt === "string" ? systemPrompt.trim() : "";
+  if (trimmedSystemPrompt) {
     messages.unshift({
       role: "system",
-      content: systemPrompt
+      content: trimmedSystemPrompt
     });
   }
 
@@ -2275,7 +2283,8 @@ storesystemPrompt = localStorage.getItem("system_prompt");
 if (storesystemPrompt) {
   document.getElementById("systemPrompt").value = storesystemPrompt;
 } else {
-  document.getElementById("systemPrompt").value = null;
+  // Use "" — assigning null stringifies to "null" on textarea.value.
+  document.getElementById("systemPrompt").value = "";
 }
 
 marked.setOptions({

--- a/core/templates/evaluator.go
+++ b/core/templates/evaluator.go
@@ -192,8 +192,10 @@ func (e *Evaluator) TemplateMessages(input schema.OpenAIRequest, messages []sche
 					marshalAny(i.ToolCalls)
 				}
 			}
-			// Special Handling: System. We care if it was printed at all, not the r branch, so check separately
-			if contentExists && role == "system" {
+			// Special Handling: System. We care if it was printed at all, not the r branch, so check separately.
+			// Whitespace-only system content must not suppress the model config system_prompt
+			// (web Chat UI historically sent a blank system turn).
+			if contentExists && role == "system" && strings.TrimSpace(i.StringContent) != "" {
 				suppressConfigSystemPrompt = true
 			}
 		}


### PR DESCRIPTION
## Summary

Fresh chats from the web UI were effectively sending a blank system turn when Chat Settings → System Prompt was left untouched. Tokenizer chat templates treat `messages[0].role == "system"` as authoritative, so that empty turn suppressed the model YAML `system_prompt` (and any template default). Same prompt via curl without a system message worked fine.

This change:

- Omits empty / whitespace-only system prompts in the React chat hook and the Alpine `chat.js` path
- Strips blank system turns server-side before templating / backend handoff
- For `use_tokenizer_template` models, injects `config.SystemPrompt` when the request has no real system message (Go-template models already get it via `PromptTemplateData`)
- Stops treating whitespace-only system content as a reason to set `SuppressSystemPrompt`
- Fixes the legacy Alpine path that assigned `textarea.value = null` (which becomes the string `"null"`)

Fixes #11834

## Test plan

- [x] `node --test core/http/react-ui/src/utils/systemPrompt.test.js`
- [x] `go test ./core/http/endpoints/openai/ -ginkgo.focus='hasSystemMessage|stripEmpty'`
- [x] `go test ./core/templates/`
- [ ] Manual: new chat, leave System Prompt empty, send a suggestion like "Explain how this works" on a model with `system_prompt` in YAML — response should use the configured prompt (prompt_tokens should reflect it). Same request with an explicit System Prompt in settings should still override.

## Checklist

- [ ] Yes, I signed my commits. *(needs human DCO sign-off before merge if required)*
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable