### PR TITLE
fix(nix): legacy-peer-deps for react-ui flake build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,9 @@
           npmRoot = ./core/http/react-ui;
         };
         npmConfigHook = pkgs.importNpmLock.npmConfigHook;
+        # Avoid EOVERRIDE when importNpmLock rewrites the same-version hono
+        # override to a file: tarball that conflicts with the direct dependency.
+        npmFlags = [ "--legacy-peer-deps" ];
         npmBuildScript = "build";
 
         installPhase = ''


### PR DESCRIPTION
## Summary

Building LocalAI from the flake currently fails in the react-ui package with EOVERRIDE on hono.

Root cause is the same-version hono direct dep plus overrides entry; the nix lock importer turns the override into a store path that conflicts.

This PR only touches flake.nix: set npmFlags to legacy-peer-deps on the react-ui buildNpmPackage (same workaround the failing drv log suggests). Left package.json and bun.lock alone so we do not collide with open #11633.

Fixes #11804

cc @mudler — small flake-only path if this looks right.

## Test plan

- [x] Confirmed open #11633 is the only package.json/bun.lock PR in flight; no other PR targets #11804 / this flake path
- [x] Diff is flake.nix only
- [ ] Full flake rebuild past the react-ui phase (no nix on my box for a complete rebuild; happy to iterate if anything else pops up)
