### PR TITLE
fix(quantization): record job progress without an attached listener (#11874)

### DIFF
--- a/core/services/quantization/service.go
+++ b/core/services/quantization/service.go
@@ -42,6 +42,28 @@ type QuantizationService struct {
 	// jobs is the cross-replica job store: an in-memory map kept consistent across
 	// replicas via NATS, optionally read-through to PostgreSQL in distributed mode.
 	jobs *syncstate.SyncedMap[string, *schema.QuantizationJob]
+
+	// progressMu guards progressSubs.
+	//
+	// A backend's per-job progress stream has a single destructive consumer: the
+	// backend pops each update off one queue and hands it to whoever is reading.
+	// So the service opens that stream exactly once per job — in watchProgress,
+	// started by StartJob — and fans the updates out in-process to the SSE clients
+	// registered here. Opening a second stream per client would make the two
+	// readers race for the same updates.
+	progressMu   sync.Mutex
+	progressSubs map[string][]chan *schema.QuantizationProgressEvent
+}
+
+// progressSubBuffer is the per-subscriber event buffer. It absorbs a client that
+// is briefly slow; a client that falls further behind drops events rather than
+// stalling the single reader of the backend stream.
+const progressSubBuffer = 64
+
+// isTerminalStatus reports whether a job status is final, i.e. no further
+// progress update will follow.
+func isTerminalStatus(status string) bool {
+	return status == "stopped" || status == "completed" || status == "failed"
 }
 
 // NewQuantizationService creates a new QuantizationService. In distributed mode
@@ -59,6 +81,7 @@ func NewQuantizationService(
 		appConfig:    appConfig,
 		modelLoader:  modelLoader,
 		configLoader: configLoader,
+		progressSubs: make(map[string][]chan *schema.QuantizationProgressEvent),
 	}
 
 	// Only attach a Store interface when a concrete store exists, otherwise the
@@ -240,6 +263,13 @@ func (s *QuantizationService) StartJob(ctx context.Context, userID string, req s
 	}
 	s.saveJobState(job)
 
+	// Consume the backend's progress stream for the lifetime of the job, not for
+	// the lifetime of a client's SSE connection: a job that runs with nobody
+	// attached must still reach "completed" in the store and in state.json. The
+	// request ctx is done as soon as this HTTP handler returns, so the watcher
+	// rides the application context instead.
+	go s.watchProgress(s.appConfig.Context, jobID, backendName, modelID)
+
 	return &schema.QuantizationJobResponse{
 		ID:      jobID,
 		Status:  "queued",
@@ -311,6 +341,14 @@ func (s *QuantizationService) StopJob(ctx context.Context, userID, jobID string)
 	s.saveJobState(job)
 	s.mu.Unlock()
 
+	// Release clients attached to the progress stream: the backend process is gone,
+	// so the watcher will not see a terminal update to forward.
+	s.publishProgress(jobID, &schema.QuantizationProgressEvent{
+		JobID:   jobID,
+		Status:  "stopped",
+		Message: "Quantization stopped by user",
+	})
+
 	return nil
 }
 
@@ -377,7 +415,153 @@ func (s *QuantizationService) DeleteJob(userID, jobID string) error {
 	return nil
 }
 
-// StreamProgress opens a gRPC progress stream and calls the callback for each update.
+// watchProgress is the single reader of a job's backend progress stream. It
+// records every transition on the job — in the cross-replica store and in
+// state.json — and republishes it to the clients attached via StreamProgress.
+//
+// Recording here rather than in StreamProgress is the point: the backend hands
+// each update to one consumer, so while StreamProgress was that consumer a job's
+// state only advanced while somebody was watching it.
+func (s *QuantizationService) watchProgress(ctx context.Context, jobID, backendName, modelID string) {
+	backendModel, err := s.modelLoader.Load(
+		model.WithBackendString(backendName),
+		model.WithModel(backendName),
+		model.WithModelID(modelID),
+	)
+	if err != nil {
+		xlog.Warn("Failed to load backend for quantization progress", "job_id", jobID, "error", err)
+		return
+	}
+
+	err = backendModel.QuantizationProgress(ctx, &pb.QuantizationProgressRequest{
+		JobId: jobID,
+	}, func(update *pb.QuantizationProgressUpdate) {
+		s.publishProgress(jobID, s.applyProgressUpdate(ctx, jobID, update))
+	})
+	if err != nil {
+		xlog.Warn("Quantization progress stream ended with an error", "job_id", jobID, "error", err)
+	}
+
+	// On shutdown leave the job alone: loadJobsFromDisk already reports jobs that
+	// were running at exit as stopped.
+	if ctx.Err() != nil {
+		return
+	}
+
+	// A stream that ends without a terminal update means the backend is gone and
+	// nothing further will arrive. Record that instead of leaving the job in a
+	// running state forever — which is the failure this watcher exists to prevent —
+	// and release any client still waiting on a terminal event.
+	s.mu.Lock()
+	j, ok := s.jobs.Get(jobID)
+	stale := ok && !isTerminalStatus(j.Status)
+	if stale {
+		j.Status = "failed"
+		if j.Message == "" {
+			j.Message = "Backend progress stream ended before the job reported a result"
+		}
+		if err := s.jobs.Set(ctx, j); err != nil {
+			xlog.Warn("Failed to persist orphaned job state", "job_id", jobID, "error", err)
+		}
+		s.saveJobState(j)
+	}
+	s.mu.Unlock()
+
+	if stale {
+		s.publishProgress(jobID, &schema.QuantizationProgressEvent{
+			JobID:   jobID,
+			Status:  "failed",
+			Message: "Backend progress stream ended before the job reported a result",
+		})
+	}
+}
+
+// applyProgressUpdate records a backend progress update on the job and returns
+// the event to hand to subscribers.
+func (s *QuantizationService) applyProgressUpdate(ctx context.Context, jobID string, update *pb.QuantizationProgressUpdate) *schema.QuantizationProgressEvent {
+	s.mu.Lock()
+	if j, ok := s.jobs.Get(jobID); ok {
+		// Don't let progress updates overwrite terminal states
+		if !isTerminalStatus(j.Status) {
+			j.Status = update.Status
+		}
+		if update.Message != "" {
+			j.Message = update.Message
+		}
+		if update.OutputFile != "" {
+			j.OutputFile = update.OutputFile
+		}
+		if err := s.jobs.Set(ctx, j); err != nil {
+			xlog.Warn("Failed to persist progress update", "job_id", jobID, "error", err)
+		}
+		s.saveJobState(j)
+	}
+	s.mu.Unlock()
+
+	// Convert extra metrics
+	extraMetrics := make(map[string]float32, len(update.ExtraMetrics))
+	for k, v := range update.ExtraMetrics {
+		extraMetrics[k] = v
+	}
+
+	return &schema.QuantizationProgressEvent{
+		JobID:           update.JobId,
+		ProgressPercent: update.ProgressPercent,
+		Status:          update.Status,
+		Message:         update.Message,
+		OutputFile:      update.OutputFile,
+		ExtraMetrics:    extraMetrics,
+	}
+}
+
+// subscribeProgress registers a channel to receive a job's progress events.
+func (s *QuantizationService) subscribeProgress(jobID string) chan *schema.QuantizationProgressEvent {
+	ch := make(chan *schema.QuantizationProgressEvent, progressSubBuffer)
+	s.progressMu.Lock()
+	s.progressSubs[jobID] = append(s.progressSubs[jobID], ch)
+	s.progressMu.Unlock()
+	return ch
+}
+
+// unsubscribeProgress removes a channel registered by subscribeProgress. The
+// channel is never closed, so a publish racing with an unsubscribe cannot send
+// on a closed channel.
+func (s *QuantizationService) unsubscribeProgress(jobID string, ch chan *schema.QuantizationProgressEvent) {
+	s.progressMu.Lock()
+	defer s.progressMu.Unlock()
+
+	subs := s.progressSubs[jobID]
+	for i, c := range subs {
+		if c == ch {
+			s.progressSubs[jobID] = append(subs[:i], subs[i+1:]...)
+			break
+		}
+	}
+	if len(s.progressSubs[jobID]) == 0 {
+		delete(s.progressSubs, jobID)
+	}
+}
+
+// publishProgress fans an event out to a job's subscribers.
+func (s *QuantizationService) publishProgress(jobID string, event *schema.QuantizationProgressEvent) {
+	s.progressMu.Lock()
+	subs := append([]chan *schema.QuantizationProgressEvent(nil), s.progressSubs[jobID]...)
+	s.progressMu.Unlock()
+
+	for _, ch := range subs {
+		select {
+		case ch <- event:
+		default:
+			// A subscriber that cannot keep up must not stall the reader that is
+			// recording job state for everyone else.
+			xlog.Warn("Dropping quantization progress event for a slow subscriber", "job_id", jobID)
+		}
+	}
+}
+
+// StreamProgress calls the callback for each progress event of a job until it
+// reaches a terminal status or ctx is done. It is a pure reader: the job's own
+// watcher owns the backend stream and the state transitions.
 func (s *QuantizationService) StreamProgress(ctx context.Context, userID, jobID string, callback func(event *schema.QuantizationProgressEvent)) error {
 	s.mu.Lock()
 	job, ok := s.jobs.Get(jobID)
@@ -391,59 +575,41 @@ func (s *QuantizationService) StreamProgress(ctx context.Context, userID, jobID 
 	}
 	s.mu.Unlock()
 
-	streamModelID := job.ModelID
-	if streamModelID == "" {
-		streamModelID = job.Backend + "-quantize"
+	ch := s.subscribeProgress(jobID)
+	defer s.unsubscribeProgress(jobID, ch)
+
+	// Re-read the job after subscribing: it may have finished between the lookup
+	// above and the subscription, and no further event would ever arrive. Jobs
+	// restored from disk after a restart are terminal too, and have no watcher.
+	s.mu.Lock()
+	current, ok := s.jobs.Get(jobID)
+	terminal := ok && isTerminalStatus(current.Status)
+	var final *schema.QuantizationProgressEvent
+	if terminal {
+		final = &schema.QuantizationProgressEvent{
+			JobID:      current.ID,
+			Status:     current.Status,
+			Message:    current.Message,
+			OutputFile: current.OutputFile,
+		}
 	}
-	backendModel, err := s.modelLoader.Load(
-		model.WithBackendString(job.Backend),
-		model.WithModel(job.Backend),
-		model.WithModelID(streamModelID),
-	)
-	if err != nil {
-		return fmt.Errorf("failed to load backend: %w", err)
+	s.mu.Unlock()
+	if terminal {
+		callback(final)
+		return nil
 	}
 
-	return backendModel.QuantizationProgress(ctx, &pb.QuantizationProgressRequest{
-		JobId: jobID,
-	}, func(update *pb.QuantizationProgressUpdate) {
-		// Update job status and persist
-		s.mu.Lock()
-		if j, ok := s.jobs.Get(jobID); ok {
-			// Don't let progress updates overwrite terminal states
-			isTerminal := j.Status == "stopped" || j.Status == "completed" || j.Status == "failed"
-			if !isTerminal {
-				j.Status = update.Status
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case event := <-ch:
+			callback(event)
+			if isTerminalStatus(event.Status) {
+				return nil
 			}
-			if update.Message != "" {
-				j.Message = update.Message
-			}
-			if update.OutputFile != "" {
-				j.OutputFile = update.OutputFile
-			}
-			if err := s.jobs.Set(ctx, j); err != nil {
-				xlog.Warn("Failed to persist progress update", "job_id", jobID, "error", err)
-			}
-			s.saveJobState(j)
 		}
-		s.mu.Unlock()
-
-		// Convert extra metrics
-		extraMetrics := make(map[string]float32)
-		for k, v := range update.ExtraMetrics {
-			extraMetrics[k] = v
-		}
-
-		event := &schema.QuantizationProgressEvent{
-			JobID:           update.JobId,
-			ProgressPercent: update.ProgressPercent,
-			Status:          update.Status,
-			Message:         update.Message,
-			OutputFile:      update.OutputFile,
-			ExtraMetrics:    extraMetrics,
-		}
-		callback(event)
-	})
+	}
 }
 
 // sanitizeQuantModelName replaces non-alphanumeric characters with hyphens and lowercases.

--- a/core/services/quantization/service_test.go
+++ b/core/services/quantization/service_test.go
@@ -8,6 +8,9 @@ package quantization
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -16,6 +19,7 @@ import (
 	"github.com/mudler/LocalAI/core/schema"
 	"github.com/mudler/LocalAI/core/services/distributed"
 	"github.com/mudler/LocalAI/core/services/testutil"
+	pb "github.com/mudler/LocalAI/pkg/grpc/proto"
 )
 
 // newTestService builds a standalone QuantizationService wired to the given bus.
@@ -172,6 +176,156 @@ var _ = Describe("QuantizationService", func() {
 			Expect(back.ExtraOptions).To(Equal(original.ExtraOptions))
 			Expect(back.Config).ToNot(BeNil())
 			Expect(back.Config.QuantizationType).To(Equal("q4_k_m"))
+		})
+	})
+
+	Describe("progress recording", func() {
+		var (
+			bus *testutil.FakeBus
+			s   *QuantizationService
+		)
+
+		BeforeEach(func() {
+			bus = testutil.NewFakeBus()
+			s = newTestService(bus)
+		})
+
+		AfterEach(func() {
+			Expect(s.Close()).To(Succeed())
+		})
+
+		// The reported failure: a job that ran with no SSE client attached stayed
+		// "queued" forever, because the only code that advanced job state lived
+		// inside StreamProgress' stream callback. The transition is now applied by
+		// the job's own watcher, so it lands with nobody watching.
+		It("advances job state and rewrites state.json with no subscriber attached", func() {
+			job := &schema.QuantizationJob{ID: "job-np", UserID: "user-1", Status: "queued", CreatedAt: "2026-09-05T10:00:00Z"}
+			Expect(s.jobs.Set(ctx, job)).To(Succeed())
+			Expect(s.progressSubs).To(BeEmpty())
+
+			s.applyProgressUpdate(ctx, "job-np", &pb.QuantizationProgressUpdate{
+				JobId:      "job-np",
+				Status:     "completed",
+				Message:    "Quantization complete",
+				OutputFile: "/data/quantization/job-np/model-q4_k_m.gguf",
+			})
+
+			got, err := s.GetJob("user-1", "job-np")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal("completed"))
+			Expect(got.Message).To(Equal("Quantization complete"))
+			Expect(got.OutputFile).To(Equal("/data/quantization/job-np/model-q4_k_m.gguf"))
+
+			data, err := os.ReadFile(filepath.Join(s.jobDir("job-np"), "state.json"))
+			Expect(err).ToNot(HaveOccurred())
+			var persisted schema.QuantizationJob
+			Expect(json.Unmarshal(data, &persisted)).To(Succeed())
+			Expect(persisted.Status).To(Equal("completed"))
+			Expect(persisted.OutputFile).To(Equal("/data/quantization/job-np/model-q4_k_m.gguf"))
+		})
+
+		It("does not let a late update overwrite a terminal status", func() {
+			job := &schema.QuantizationJob{ID: "job-stopped", UserID: "user-1", Status: "stopped", CreatedAt: "2026-09-05T10:00:00Z"}
+			Expect(s.jobs.Set(ctx, job)).To(Succeed())
+
+			s.applyProgressUpdate(ctx, "job-stopped", &pb.QuantizationProgressUpdate{
+				JobId:  "job-stopped",
+				Status: "quantizing",
+			})
+
+			got, err := s.GetJob("user-1", "job-stopped")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.Status).To(Equal("stopped"))
+		})
+
+		// The backend hands each update to a single consumer, so every client has
+		// to be served from one in-process fan-out rather than its own stream.
+		It("delivers one update to every attached subscriber", func() {
+			first := s.subscribeProgress("job-fan")
+			second := s.subscribeProgress("job-fan")
+			defer s.unsubscribeProgress("job-fan", first)
+			defer s.unsubscribeProgress("job-fan", second)
+
+			s.publishProgress("job-fan", &schema.QuantizationProgressEvent{JobID: "job-fan", Status: "quantizing"})
+
+			Expect((<-first).Status).To(Equal("quantizing"))
+			Expect((<-second).Status).To(Equal("quantizing"))
+		})
+
+		It("unsubscribing removes the job's entry once the last client leaves", func() {
+			ch := s.subscribeProgress("job-leave")
+			Expect(s.progressSubs).To(HaveKey("job-leave"))
+			s.unsubscribeProgress("job-leave", ch)
+			Expect(s.progressSubs).ToNot(HaveKey("job-leave"))
+		})
+
+		// A client attaching after the job finished — including a job restored from
+		// disk as "stopped" after a restart, which has no watcher — must not block
+		// waiting for an event that will never come.
+		It("returns a final event immediately for a job that already finished", func() {
+			job := &schema.QuantizationJob{
+				ID: "job-done", UserID: "user-1", Status: "completed",
+				Message: "Quantization complete", OutputFile: "/data/quantization/job-done/model-q4_k_m.gguf",
+				CreatedAt: "2026-09-05T10:00:00Z",
+			}
+			Expect(s.jobs.Set(ctx, job)).To(Succeed())
+
+			var seen []*schema.QuantizationProgressEvent
+			Expect(s.StreamProgress(ctx, "user-1", "job-done", func(e *schema.QuantizationProgressEvent) {
+				seen = append(seen, e)
+			})).To(Succeed())
+
+			Expect(seen).To(HaveLen(1))
+			Expect(seen[0].Status).To(Equal("completed"))
+			Expect(seen[0].OutputFile).To(Equal("/data/quantization/job-done/model-q4_k_m.gguf"))
+			Expect(s.progressSubs).ToNot(HaveKey("job-done"))
+		})
+
+		// StopJob kills the backend, so the watcher will never forward a terminal
+		// update; without an explicit release an attached client would hang.
+		It("releases an attached client when the job is stopped", func() {
+			job := &schema.QuantizationJob{ID: "job-stop", UserID: "user-1", Status: "quantizing", CreatedAt: "2026-09-05T10:00:00Z"}
+			Expect(s.jobs.Set(ctx, job)).To(Succeed())
+
+			ch := s.subscribeProgress("job-stop")
+			defer s.unsubscribeProgress("job-stop", ch)
+
+			// nil modelLoader: exercise the release without standing up a backend.
+			s.mu.Lock()
+			job.Status = "stopped"
+			s.mu.Unlock()
+			s.publishProgress("job-stop", &schema.QuantizationProgressEvent{
+				JobID: "job-stop", Status: "stopped", Message: "Quantization stopped by user",
+			})
+
+			event := <-ch
+			Expect(event.Status).To(Equal("stopped"))
+			Expect(isTerminalStatus(event.Status)).To(BeTrue())
+		})
+
+		It("streams published events to a client until a terminal status arrives", func() {
+			job := &schema.QuantizationJob{ID: "job-live", UserID: "user-1", Status: "queued", CreatedAt: "2026-09-05T10:00:00Z"}
+			Expect(s.jobs.Set(ctx, job)).To(Succeed())
+
+			var seen []string
+			done := make(chan error, 1)
+			go func() {
+				done <- s.StreamProgress(ctx, "user-1", "job-live", func(e *schema.QuantizationProgressEvent) {
+					seen = append(seen, e.Status)
+				})
+			}()
+
+			Eventually(func() bool {
+				s.progressMu.Lock()
+				defer s.progressMu.Unlock()
+				return len(s.progressSubs["job-live"]) == 1
+			}).Should(BeTrue())
+
+			s.publishProgress("job-live", &schema.QuantizationProgressEvent{JobID: "job-live", Status: "quantizing"})
+			s.publishProgress("job-live", &schema.QuantizationProgressEvent{JobID: "job-live", Status: "completed"})
+
+			Eventually(done).Should(Receive(BeNil()))
+			Expect(seen).To(Equal([]string{"quantizing", "completed"}))
 		})
 	})
 


### PR DESCRIPTION
Fixes #11874.

## The bug

A quantization job that runs with no client attached to its progress stream stays `queued` forever — in the API and in `state.json` — while the finished artifact sits on disk.

`state.json` is written once, by `saveJobState` in `StartJob`, and the only code that ever advanced a job afterwards lived **inside the stream callback of `StreamProgress`**:

```go
// core/services/quantization/service.go, inside StreamProgress
j.Status = update.Status
```

`StartJob` kicks the backend off over gRPC and returns. Nothing consumes the backend's progress stream until an SSE client calls `StreamProgress`, so with nobody watching, no transition is ever recorded. Job state depended on an observer.

## Why the obvious fix needs care

The issue suggests having the job runner record transitions and letting `StreamProgress` be a pure reader. That is the right shape, but simply starting a second consumer alongside `StreamProgress` would break the case that works today.

The backend's progress stream is **single-consumer and destructive**. In `backend/python/llama-cpp-quantization/backend.py`, each job owns one `queue.Queue`:

```python
class ActiveJob:
    def __init__(self, job_id):
        self.progress_queue = queue.Queue()
```

`_send_progress` does `job.progress_queue.put(update)` and `QuantizationProgress` does `job.progress_queue.get(timeout=1.0)` — it **pops**. Two readers of that stream do not each see every update; they split them. So a background watcher running next to a live SSE reader would steal half the events from the UI.

That rules out "add a watcher and leave `StreamProgress` as-is". The stream has to be opened exactly once per job.

## The change

`core/services/quantization/service.go` only:

- `StartJob` starts `watchProgress` on the application context (not the request context, which is done the moment the HTTP handler returns). That goroutine is the single reader of the backend stream for the job's lifetime.
- `applyProgressUpdate` — the state-recording half of the old `StreamProgress` callback, unchanged in behaviour (terminal statuses still win over late updates) — now runs from the watcher, so transitions land in the SyncedMap and in `state.json` whether or not anyone is attached.
- `StreamProgress` becomes a pure reader: it subscribes to an in-process fan-out and returns when a terminal event arrives or `ctx` is done. It no longer loads a backend or opens a gRPC stream.
- A client that attaches to a job which already finished gets one final event built from the stored job instead of blocking. This also covers jobs hydrated from disk after a restart, which `loadJobsFromDisk` marks `stopped` and which have no watcher.
- A subscriber that cannot keep up drops events (buffer 64) rather than stalling the reader that is recording state for everyone else.

Two paths that used to end a client's stream by breaking the gRPC connection now need an explicit release, since the client is no longer holding that connection:

- `StopJob` kills the backend process, so no terminal update will ever reach the watcher — it publishes the `stopped` event itself.
- If the watcher's stream ends *without* a terminal update the backend is gone, so the job is recorded as `failed` and that is published, rather than leaving it in a running state forever — the same failure mode this change exists to prevent. Skipped when `ctx` is already done, so a shutdown still leaves jobs for `loadJobsFromDisk` to report as stopped.

No schema, API, or route changes; the SSE payload is byte-for-byte the same `QuantizationProgressEvent`.

## Tests

Seven specs added to `core/services/quantization/service_test.go` (white-box, no backend needed — the existing suite already drives the service with a nil model loader):

- **`advances job state and rewrites state.json with no subscriber attached`** — the reported failure, asserted with `progressSubs` empty: `GetJob` reports `completed` and the on-disk `state.json` is rewritten with the status and output file.
- `does not let a late update overwrite a terminal status` — pins the existing terminal-state guard that moved with the code.
- `delivers one update to every attached subscriber` — the fan-out that replaces per-client gRPC streams.
- `unsubscribing removes the job's entry once the last client leaves` — no map growth per finished job.
- `returns a final event immediately for a job that already finished` — the attach-after-completion / post-restart path.
- `releases an attached client when the job is stopped` — the stop path that no longer ends by breaking a gRPC connection.
- `streams published events to a client until a terminal status arrives` — end of stream on terminal status.

```
$ make protogen-go && go test -race -count=2 ./core/services/quantization/
ok  	github.com/mudler/LocalAI/core/services/quantization
```

`gofmt -l` and `go vet` on the package are clean.

**Scope of verification:** the specs above and the package build/vet are what I actually ran. I did not re-run the end-to-end reproduction against a live `llama-cpp-quantization` backend — the single-consumer queue behaviour is read from `backend.py` as quoted above, and the failure mode is the one in the issue report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
