### PR TITLE
fix(ui): preserve percent signs in route parameters

### DIFF
--- a/core/http/react-ui/e2e/route-param-decoding.spec.js
+++ b/core/http/react-ui/e2e/route-param-decoding.spec.js
@@ -1,0 +1,67 @@
+import { test, expect } from './coverage-fixtures.js'
+
+const MODEL_NAME = 'rate%model'
+const SKILL_NAME = 'cache%skill'
+const encodedModel = encodeURIComponent(MODEL_NAME)
+const encodedSkill = encodeURIComponent(SKILL_NAME)
+
+test.describe('Encoded route parameters', () => {
+  test('model editor preserves a literal percent in the model name', async ({ page }) => {
+    let requestedPath = ''
+    await page.route('**/api/models/config-metadata?section=all', (route) => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ sections: [], fields: [] }),
+    }))
+    await page.route(`**/api/models/edit/${encodedModel}`, (route) => {
+      requestedPath = new URL(route.request().url()).pathname
+      route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({
+          name: MODEL_NAME,
+          config: `name: ${MODEL_NAME}\nbackend: mock-backend\n`,
+        }),
+      })
+    })
+
+    await page.goto(`/app/model-editor/${encodedModel}`)
+
+    await expect(page.locator('.page-subtitle')).toHaveText(MODEL_NAME)
+    await expect.poll(() => requestedPath).toBe(`/api/models/edit/${encodedModel}`)
+  })
+
+  test('backend logs preserve a literal percent in the model name', async ({ page }) => {
+    await page.goto(`/app/backend-logs/${encodedModel}`)
+
+    await expect(page.locator('.page-title')).toContainText(MODEL_NAME)
+  })
+
+  test('node backend logs preserve a literal percent in the model name', async ({ page }) => {
+    await page.route('**/api/nodes/test-node', (route) => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'test-node', name: 'Test node' }),
+    }))
+    await page.route('**/api/nodes/test-node/models', (route) => route.fulfill({
+      contentType: 'application/json',
+      body: '[]',
+    }))
+
+    await page.goto(`/app/node-backend-logs/test-node/${encodedModel}`)
+
+    await expect(page.locator('.page-title')).toContainText(MODEL_NAME)
+  })
+
+  test('skill editor does not decode an already decoded route parameter', async ({ page }) => {
+    await page.route(`**/api/agents/skills/${encodedSkill}`, (route) => route.fulfill({
+      contentType: 'application/json',
+      body: JSON.stringify({
+        name: SKILL_NAME,
+        description: 'A route parameter regression fixture',
+        content: '# Fixture',
+      }),
+    }))
+
+    await page.goto(`/app/skills/edit/${encodedSkill}`)
+
+    await expect(page.locator('.page-title')).toContainText(`Edit: ${SKILL_NAME}`)
+  })
+})

--- a/core/http/react-ui/src/pages/BackendLogs.jsx
+++ b/core/http/react-ui/src/pages/BackendLogs.jsx
@@ -415,7 +415,7 @@ export default function BackendLogs() {
   const { modelId } = useParams()
 
   if (modelId) {
-    return <BackendLogsRouter modelId={decodeURIComponent(modelId)} />
+    return <BackendLogsRouter modelId={modelId} />
   }
 
   // No model specified — redirect to System page

--- a/core/http/react-ui/src/pages/ModelEditor.jsx
+++ b/core/http/react-ui/src/pages/ModelEditor.jsx
@@ -438,7 +438,7 @@ export default function ModelEditor() {
           <p className="page-subtitle">
             {isCreateMode
               ? (showTemplateSelector ? t('subtitle.chooseModelType') : `${t('subtitle.newModel')}${selectedTemplate ? ` — ${selectedTemplate.label}` : ''}`)
-              : decodeURIComponent(name)}
+              : name}
           </p>
         </div>
         <div className="hstack">

--- a/core/http/react-ui/src/pages/NodeBackendLogs.jsx
+++ b/core/http/react-ui/src/pages/NodeBackendLogs.jsx
@@ -17,8 +17,7 @@ const STREAM_BADGE = {
 }
 
 export default function NodeBackendLogs() {
-  const { nodeId, modelId: rawModelId } = useParams()
-  const modelId = decodeURIComponent(rawModelId || '')
+  const { nodeId, modelId = '' } = useParams()
   const { addToast } = useOutletContext()
   const navigate = useNavigate()
 

--- a/core/http/react-ui/src/pages/SkillEdit.jsx
+++ b/core/http/react-ui/src/pages/SkillEdit.jsx
@@ -260,10 +260,9 @@ function ResourcesSection({ skillName, addToast }) {
 }
 
 export default function SkillEdit() {
-  const { name: nameParam } = useParams()
+  const { name } = useParams()
   const location = useLocation()
   const isNew = location.pathname.endsWith('/new')
-  const name = nameParam ? decodeURIComponent(nameParam) : undefined
   const navigate = useNavigate()
   const { addToast } = useOutletContext()
   const [searchParams] = useSearchParams()

--- a/core/http/react-ui/src/utils/config.js
+++ b/core/http/react-ui/src/utils/config.js
@@ -127,7 +127,7 @@ export const API_CONFIG = {
     modelsImport: '/models/import',
     vramEstimate: '/api/models/vram-estimate',
     modelsJobStatus: (uid) => `/models/jobs/${uid}`,
-    modelEditGet: (name) => `/api/models/edit/${name}`,
+    modelEditGet: (name) => `/api/models/edit/${encodeURIComponent(name)}`,
     modelEdit: (name) => `/models/edit/${name}`,
     modelToggleState: (name, action) => `/models/toggle-state/${name}/${action}`,
     modelTogglePinned: (name, action) => `/models/toggle-pinned/${name}/${action}`,


### PR DESCRIPTION
**Description**

Fixes #11882.

React Router already decodes dynamic path segments before exposing them through `useParams()`. The affected pages decoded those values a second time, which threw `URIError` for names such as `rate%model` and silently changed escape-like substrings such as a literal `%20`.

This change:

- uses route parameters directly in the model editor, skill editor, backend logs, and per-node backend logs
- encodes the model name when constructing the model editor API request
- adds Playwright regression coverage for all four affected routes

**Notes for Reviewers**

The regression fixture navigates with an encoded `rate%25model` segment and verifies that the page receives and displays `rate%model`. The model editor case also asserts that its outbound API path is encoded exactly once.

Validation:

- `npx playwright test e2e/route-param-decoding.spec.js e2e/model-config.spec.js e2e/backend-logs.spec.js e2e/skills.spec.js --workers=4` (35 passed)
- `npx eslint src/pages/BackendLogs.jsx src/pages/ModelEditor.jsx src/pages/NodeBackendLogs.jsx src/pages/SkillEdit.jsx src/utils/config.js e2e/route-param-decoding.spec.js` (0 errors; existing warnings only)
- `npm run lint:inline-styles`
- `npm run build`

The repository-wide `npm run lint` remains blocked by six pre-existing hook-rule errors in `e2e/coverage-fixtures.js` and `src/pages/Chat.jsx`; this change adds none.

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable

Documentation is not applicable because this restores correct handling of existing resource names without changing the documented interface.