### PR TITLE
docs: fix dead links in the PR template and backends docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ This PR fixes #
 **Notes for Reviewers**
 
 
-**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
+**[Signed commits](../CONTRIBUTING.md#commit-messages)**
 - [ ] Yes, I signed my commits.
 - [ ] Documentation updated (docs/content/) for user-facing changes, or not applicable
  

--- a/backend/python/longcat-video/README.md
+++ b/backend/python/longcat-video/README.md
@@ -11,7 +11,7 @@ RPC. It supports:
   systems such as NVIDIA DGX Spark.
 
 Install the `longcat-video` or `longcat-video-avatar-1.5` recipe from the
-LocalAI Model Gallery. See the [LongCat user guide](../../../docs/content/features/longcat-video.md)
+LocalAI Model Gallery. LongCat video backend
 for Studio and API examples, hardware requirements, and manual configuration.
 
 The upstream source is pinned in `Makefile` and patched at build time. The

--- a/formal-verification/README.md
+++ b/formal-verification/README.md
@@ -24,11 +24,11 @@ then the implementation is checked against them.
 | `fizzbee.sha256` | Pinned checksum(s) of the FizzBee release the gate uses (created on first `install-fizzbee.sh` run). |
 
 The implementations under test live in
-[`core/http/endpoints/openai/respcoord`](../../../core/http/endpoints/openai/respcoord) (M3),
-[`core/http/endpoints/openai/turncoord`](../../../core/http/endpoints/openai/turncoord) (M2),
-[`core/http/endpoints/openai/conncoord`](../../../core/http/endpoints/openai/conncoord) (M1),
-[`core/http/endpoints/openai/compactcoord`](../../../core/http/endpoints/openai/compactcoord) (M4),
-and [`core/http/endpoints/openai/ttscoord`](../../../core/http/endpoints/openai/ttscoord) (M5).
+[`core/http/endpoints/openai/respcoord`](../core/http/endpoints/openai/respcoord) (M3),
+[`core/http/endpoints/openai/turncoord`](../core/http/endpoints/openai/turncoord) (M2),
+[`core/http/endpoints/openai/conncoord`](../core/http/endpoints/openai/conncoord) (M1),
+[`core/http/endpoints/openai/compactcoord`](../core/http/endpoints/openai/compactcoord) (M4),
+and [`core/http/endpoints/openai/ttscoord`](../core/http/endpoints/openai/ttscoord) (M5).
 
 ## Running the realtime gate
 


### PR DESCRIPTION
Three groups of dead links, each verified case-sensitively via `git ls-files`:

1. `.github/PULL_REQUEST_TEMPLATE.md`: the 'Signed commits' anchor pointed at a CONTRIBUTING.md section that doesn't exist; repointed at the existing 'Commit messages' section.
2. `backend/python/longcat-video/README.md`: linked `docs/content/features/longcat-video.md`, which was never committed; replaced the dead link with plain text.
3. `formal-verification/README.md`: five package links used `../../../core/...`, escaping the repo root; fixed to `../core/...` (all five target packages verified to exist).