### PR TITLE
docs: fix dead anchors and a dead section link

### DIFF
--- a/docs/content/advanced/_index.en.md
+++ b/docs/content/advanced/_index.en.md
@@ -103,8 +103,7 @@ Before diving into advanced topics, ensure you have:
 ## Related Sections
 
 - 📚 [Reference](../reference/) - API documentation and command reference
-- 🔌 [Installation](../installation/) - Deployment options and requirements
-- ⭐ [Features](../features/) - Overview of LocalAI capabilities
+- - ⭐ [Features](../features/) - Overview of LocalAI capabilities
 
 ---
 

--- a/docs/content/operations/middleware.md
+++ b/docs/content/operations/middleware.md
@@ -45,7 +45,7 @@ routing, `/api/pii/events` for redaction and block actions.
 PII redaction is **NER-based and runs request-side (input)**. It is
 **off by default**, flipping to **on for any `cloud-proxy` backend**
 because that traffic crosses the network to a third-party provider. Pick a
-[default detector](#instance-wide-defaults) so those models are actually
+[default detector](#instance-wide-default-detector) so those models are actually
 scanned. Explicit `pii.enabled` in a model's YAML always wins over the
 backend default.
 

--- a/docs/content/reference/_index.en.md
+++ b/docs/content/reference/_index.en.md
@@ -168,8 +168,7 @@ Before using reference documentation, ensure you have:
 ## Related Sections
 
 - 📖 [Advanced](../advanced/) - Deep dive into configuration and optimization
-- 🔌 [Installation](../installation/) - Setup and deployment
-- ⭐ [Features](../features/) - Feature overview
+- - ⭐ [Features](../features/) - Feature overview
 
 ---
 


### PR DESCRIPTION
1. `docs/content/operations/middleware.md`: the 'default detector' link used `#instance-wide-defaults`; the actual heading is `### Instance-wide default detector` (the same file already links the correct slug at line 269).
2. `docs/content/advanced/_index.en.md` + `docs/content/reference/_index.en.md`: the 'Related Sections' blocks linked an `installation/` directory that does not exist under `docs/content` (404 on the built site, while every sibling link resolves); dropped the dead bullets.