### PR TITLE
fix(gallery): default audio-cpp models to backend:best

### DIFF
--- a/docs/content/features/audio-cpp.md
+++ b/docs/content/features/audio-cpp.md
@@ -28,6 +28,11 @@ key stored *inside* the GGUF, which cannot be read from a remote repository, and
 upstream GGUF repository hosts every family in one place. Set `backend: audio-cpp`
 in the model YAML, or select it explicitly in the import form.
 
+The bundled audio-cpp gallery entries set `backend:best` in `options` to select
+an available compute backend, with CPU as the fallback. To force CPU execution,
+replace that option with `backend:cpu`. Model configurations that omit this
+option still default to CPU.
+
 ## What it serves
 
 One model serves one family, and a family advertises the tasks it can perform. The

--- a/gallery/index.yaml
+++ b/gallery/index.yaml
@@ -56383,6 +56383,8 @@
     known_usecases:
       - tts
     name: audio-cpp-indextts-2.5
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/index-tts2_5-orig.gguf
   files:
@@ -56420,6 +56422,8 @@
     known_usecases:
       - tts
     name: audio-cpp-supertonic
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/supertonic-3-orig.gguf
   files:
@@ -56462,6 +56466,8 @@
     known_usecases:
       - tts
     name: audio-cpp-higgs-audio-v3
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/higgs-audio-v3-tts-4b-q8_0.gguf
   files:
@@ -56511,6 +56517,8 @@
       - tts
       - audio_transform
     name: audio-cpp-chatterbox
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/chatterbox-q8_0.gguf
   files:
@@ -56547,6 +56555,8 @@
     known_usecases:
       - transcript
     name: audio-cpp-citrinet-asr
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/citrinet-asr-q8_0.gguf
   files:
@@ -56583,6 +56593,8 @@
     known_usecases:
       - transcript
     name: audio-cpp-nemotron-asr
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/nemotron-3.5-asr-streaming-0.6b-f16.gguf
   files:
@@ -56620,6 +56632,8 @@
     known_usecases:
       - diarization
     name: audio-cpp-sortformer-diarization
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/sortformer-diar-4spk-v1-q8_0.gguf
   files:
@@ -56657,6 +56671,8 @@
     known_usecases:
       - audio_transform
     name: audio-cpp-htdemucs
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/htdemucs-f16.gguf
   files:
@@ -56696,6 +56712,8 @@
     known_usecases:
       - sound_generation
     name: audio-cpp-stable-audio-sfx
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/stable-audio-3-small-sfx-q8_0.gguf
   files:
@@ -56734,6 +56752,8 @@
     known_usecases:
       - transcript
     name: audio-cpp-forced-aligner
+    options:
+      - backend:best
     parameters:
       language: en
       model: audio-cpp/qwen3-forced-aligner-0.6b-q8_0.gguf
@@ -56763,6 +56783,7 @@
       - vad
     name: audio-cpp-silero-vad
     options:
+      - backend:best
       - family:silero_vad
     parameters:
       model: bundled:silero_vad
@@ -56790,6 +56811,7 @@
       - vad
     name: audio-cpp-marblenet-vad
     options:
+      - backend:best
       - family:marblenet_vad
     parameters:
       model: bundled:marblenet_vad
@@ -56829,6 +56851,8 @@
     known_usecases:
       - tts
     name: audio-cpp-irodori-voicedesign
+    options:
+      - backend:best
     parameters:
       model: audio-cpp/irodori-tts-600m-v3-voicedesign-q8_0.gguf
   files:
@@ -56873,6 +56897,7 @@
       - audio_transform
     name: audio-cpp-seedvc-singing
     options:
+      - backend:best
       - task:svc
     parameters:
       model: audio-cpp/seed-vc-mlx-q8_0.gguf
@@ -56925,6 +56950,7 @@
       - audio_transform
     name: audio-cpp-vevo2-speech-to-speech
     options:
+      - backend:best
       - task:s2s
     parameters:
       model: audio-cpp/vevo2-q8_0.gguf


### PR DESCRIPTION
**Description**

The audio-cpp engine creates its session on the CPU backend when no backend option is given, so every gallery model ran CPU-only even on machines where a CUDA/Vulkan/Metal device was registered. backend:best selects the best available backend and falls back to CPU.


**[Signed commits](../CONTRIBUTING.md#commit-messages)**
- [x] Yes, I signed my commits.
- [ ] Documentation updated (docs/content/) for user-facing changes, or not applicable
 
<!--
Thank you for contributing to LocalAI! 

Contributing Conventions
-------------------------

The draft above helps to give a quick overview of your PR.

Remember to remove this comment and to at least:

1. Include descriptive PR titles with [<component-name>] prepended. We use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
2. Build and test your changes before submitting a PR (`make build`). 
3. Sign your commits
4. **Tag maintainer:** for a quicker response, tag the relevant maintainer (see below).
5. **X/Twitter handle:** we announce bigger features on X/Twitter. If your PR gets announced, and you'd like a mention, we'll gladly shout you out!

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.

If no one reviews your PR within a few days, please @-mention @mudler.
-->