### PR TITLE
fix(backends): honor enable_thinking=false in mlx and vllm-omni

### DIFF
--- a/backend/python/mlx-distributed/backend.py
+++ b/backend/python/mlx-distributed/backend.py
@@ -440,8 +440,9 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                     kwargs["tools"] = json.loads(request.Tools)
                 except json.JSONDecodeError:
                     pass
-            if request.Metadata.get("enable_thinking", "").lower() == "true":
-                kwargs["enable_thinking"] = True
+            enable_thinking = request.Metadata.get("enable_thinking", "").lower()
+            if enable_thinking in ("true", "false"):
+                kwargs["enable_thinking"] = enable_thinking == "true"
             try:
                 return self.tokenizer.apply_chat_template(messages, **kwargs)
             except TypeError:

--- a/backend/python/mlx-distributed/test.py
+++ b/backend/python/mlx-distributed/test.py
@@ -135,3 +135,37 @@ class TestSharedHelpers(unittest.TestCase):
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0]["name"], "get_weather")
         self.assertEqual(calls[0]["arguments"], '{"location": "Paris"}')
+
+
+class TestPreparePrompt(unittest.TestCase):
+    """Server-less tests for BackendServicer._prepare_prompt."""
+
+    def test_forwards_enable_thinking(self):
+        from backend import BackendServicer
+
+        class Tok:
+            def __init__(self):
+                self.kwargs = None
+
+            def apply_chat_template(self, messages, **kwargs):
+                self.kwargs = kwargs
+                return "PROMPT"
+
+        def kwargs_for(metadata):
+            servicer = BackendServicer()
+            servicer.tokenizer = Tok()
+            req = types.SimpleNamespace(
+                Prompt="",
+                UseTokenizerTemplate=True,
+                Messages=[backend_pb2.Message(role="user", content="hi")],
+                Tools="",
+                Metadata=metadata,
+            )
+            self.assertEqual(servicer._prepare_prompt(req), "PROMPT")
+            return servicer.tokenizer.kwargs
+
+        self.assertIs(kwargs_for({"enable_thinking": "true"})["enable_thinking"], True)
+        # "false" used to be dropped, so thinking models kept reasoning
+        self.assertIs(kwargs_for({"enable_thinking": "false"})["enable_thinking"], False)
+        self.assertIs(kwargs_for({"enable_thinking": "FALSE"})["enable_thinking"], False)
+        self.assertNotIn("enable_thinking", kwargs_for({}))

--- a/backend/python/mlx-vlm/backend.py
+++ b/backend/python/mlx-vlm/backend.py
@@ -376,8 +376,9 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 kwargs["tools"] = json.loads(request.Tools)
             except json.JSONDecodeError:
                 pass
-        if request.Metadata.get("enable_thinking", "").lower() == "true":
-            kwargs["enable_thinking"] = True
+        enable_thinking = request.Metadata.get("enable_thinking", "").lower()
+        if enable_thinking in ("true", "false"):
+            kwargs["enable_thinking"] = enable_thinking == "true"
         return kwargs
 
     def _apply_template(self, request, messages, num_images, num_audios):

--- a/backend/python/mlx/backend.py
+++ b/backend/python/mlx/backend.py
@@ -432,8 +432,8 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                 except json.JSONDecodeError:
                     pass
             enable_thinking = request.Metadata.get("enable_thinking", "").lower()
-            if enable_thinking == "true":
-                kwargs["enable_thinking"] = True
+            if enable_thinking in ("true", "false"):
+                kwargs["enable_thinking"] = enable_thinking == "true"
 
             try:
                 return self.tokenizer.apply_chat_template(messages, **kwargs)

--- a/backend/python/mlx/test.py
+++ b/backend/python/mlx/test.py
@@ -340,4 +340,40 @@ class TestSharedHelpers(unittest.TestCase):
         self.assertNotIn("<tool_call>", remaining)
 
 
+class TestPreparePrompt(unittest.TestCase):
+    """Server-less tests for BackendServicer._prepare_prompt."""
+
+    def test_forwards_enable_thinking(self):
+        from backend import BackendServicer
+
+        class Tok:
+            chat_template = "{{ messages }}"
+
+            def __init__(self):
+                self.kwargs = None
+
+            def apply_chat_template(self, messages, **kwargs):
+                self.kwargs = kwargs
+                return "PROMPT"
+
+        def kwargs_for(metadata):
+            servicer = BackendServicer()
+            servicer.tokenizer = Tok()
+            req = types.SimpleNamespace(
+                Prompt="",
+                UseTokenizerTemplate=True,
+                Messages=[backend_pb2.Message(role="user", content="hi")],
+                Tools="",
+                Metadata=metadata,
+            )
+            self.assertEqual(servicer._prepare_prompt(req), "PROMPT")
+            return servicer.tokenizer.kwargs
+
+        self.assertIs(kwargs_for({"enable_thinking": "true"})["enable_thinking"], True)
+        # "false" used to be dropped, so thinking models kept reasoning
+        self.assertIs(kwargs_for({"enable_thinking": "false"})["enable_thinking"], False)
+        self.assertIs(kwargs_for({"enable_thinking": "FALSE"})["enable_thinking"], False)
+        self.assertNotIn("enable_thinking", kwargs_for({}))
+
+
 # Unit tests for ThreadSafeLRUPromptCache are in test_mlx_cache.py

--- a/backend/python/vllm-omni/backend.py
+++ b/backend/python/vllm-omni/backend.py
@@ -489,8 +489,9 @@ class BackendServicer(backend_pb2_grpc.BackendServicer):
                         except json.JSONDecodeError:
                             pass
                     try:
-                        if request.Metadata.get("enable_thinking", "").lower() == "true":
-                            template_kwargs["enable_thinking"] = True
+                        enable_thinking = request.Metadata.get("enable_thinking", "").lower()
+                        if enable_thinking in ("true", "false"):
+                            template_kwargs["enable_thinking"] = enable_thinking == "true"
                     except Exception:
                         pass
                     try:


### PR DESCRIPTION
**Description**

The `mlx`, `mlx-vlm`, `mlx-distributed` and `vllm-omni` backends only forwarded `enable_thinking` when the metadata value was `"true"`, so `"false"` never reached `apply_chat_template`. Requests with thinking disabled (for example a realtime pipeline with `disable_thinking: true`) still used the chat template's default. This applies the same coerce that #11715 added to `sglang` and `vllm`.

**Notes for Reviewers**

- Added server-less `_prepare_prompt` tests for `mlx` and `mlx-distributed`. Both fail on `master` with `KeyError: 'enable_thinking'` and pass with this change; the existing `TestSharedHelpers` tests still pass.
- Checked with a real model, `openbmb/MiniCPM5-2B-MLX` (greedy), prompt `What is 17 * 23? Reply with just the number.`: with `enable_thinking=false`, `master` renders a prompt ending in `<think>\n` and the model starts reasoning; with this change the prompt ends in `<think>\n\n</think>\n\n` and the model answers `391` directly. Unset and `true` are unchanged. `mlx-distributed` renders the same prompts (tokenizer only, no generation).
- Ran locally on Apple Silicon (mlx 0.32.1, mlx-lm 0.31.3). The model-loading `TestBackendServicer` tests were not run.
- `mlx-vlm` and `vllm-omni` get the identical change but were not run locally.
- Found while running MiniCPM5-2B on the mlx backend in a realtime pipeline.

End-to-end check through a LocalAI 4.9.0 server (`/v1/chat/completions` → gRPC → mlx backend) with `openbmb/MiniCPM5-2B-MLX` and the same prompt. Both columns use the same server and model; only the mlx `backend.py` differs. "Reasoning" means the response had a non-empty `reasoning_content`.

| Thinking setting | `master` backend | This PR |
|---|---|---|
| Not set | reasoning + `391` | reasoning + `391` |
| Request `metadata: {"enable_thinking": "false"}` | reasoning + `391` | `391` only |
| Request `metadata: {"enable_thinking": "true"}` | reasoning + `391` | reasoning + `391` |
| Model config `reasoning: {disable: true}` | reasoning + `391` | `391` only |

**[Signed commits](../CONTRIBUTING.md#commit-messages)**
- [x] Yes, I signed my commits.
- [x] Documentation updated (docs/content/) for user-facing changes, or not applicable
