### PR TITLE
fix(agents): avoid SIGSEGV when long_term_memory has no RAG DB

### DIFF
--- a/core/services/agentpool/agent_pool.go
+++ b/core/services/agentpool/agent_pool.go
@@ -96,7 +96,10 @@ type AgentPoolService struct {
 	outputsDir         string
 	apiURL             string // Resolved API URL for agent execution
 	apiKey             string // Resolved API key for agent execution
-	mu                 sync.Mutex
+	// ragFactory is the unwrapped in-process RAG factory used to probe whether a
+	// real RAG DB can be created (create/update validation). Nil in distributed mode.
+	ragFactory func(collectionName string) (agent.RAGDB, state.KBCompactionClient, bool)
+	mu         sync.Mutex
 }
 
 // AgentEventBridge is the interface for event publishing needed by AgentPoolService.
@@ -341,9 +344,11 @@ func (s *AgentPoolService) startLocalAGI(_ context.Context, cfg config.AgentPool
 	s.collectionsBackend = collectionsBackend
 
 	embedded := collections.RAGProviderFromState(collectionsState)
-	pool.SetRAGProvider(func(collectionName, _, _ string) (agent.RAGDB, state.KBCompactionClient, bool) {
-		return embedded(collectionName)
-	})
+	s.ragFactory = embedded
+	// Always return a non-nil RAGDB when LocalAGI asks for one. LocalAGI only
+	// wires WithRAGDB when enable_kb is set, but saveCurrentConversation still
+	// assumes ragdb is non-nil whenever long_term_memory is on (LocalAI#11975).
+	pool.SetRAGProvider(wrapRAGProvider(embedded))
 
 	// Build config metadata for UI
 	s.localAGI.configMeta = state.NewAgentConfigMeta(
@@ -352,6 +357,10 @@ func (s *AgentPoolService) startLocalAGI(_ context.Context, cfg config.AgentPool
 		agiServices.DynamicPromptsConfigMeta(cfg.CustomActionsDir),
 		agiServices.FiltersConfigMeta(),
 	)
+
+	// Persisted agents may have long_term_memory without enable_kb; force the
+	// wiring LocalAGI expects before StartAll so the first chat cannot SIGSEGV.
+	normalizeExistingLongTermMemoryAgents(pool)
 
 	// Start all agents
 	if err := pool.StartAll(); err != nil {
@@ -910,12 +919,19 @@ func (s *AgentPoolService) CreateAgentForUser(userID string, config *state.Agent
 		xlog.Info("Auto-generated API key for agent", "agent", config.Name, "user", userID)
 	}
 
+	// long_term_memory without a wired RAG DB crashes LocalAGI on save
+	// (nil ragdb.Store). Normalize enable_kb and reject bad configs early.
+	if err := s.prepareAgentMemoryConfig(userID, config); err != nil {
+		return err
+	}
+
 	if err := s.configBackend.SaveConfig(userID, config); err != nil {
 		return err
 	}
 
-	// Auto-create collection when knowledge base or long-term memory is enabled
-	if config.EnableKnowledgeBase || config.LongTermMemory {
+	// Auto-create collection when knowledge base is enabled without long-term
+	// memory. LTM path already ensured the collection inside prepareAgentMemoryConfig.
+	if config.EnableKnowledgeBase && !wantsLongTermMemory(config) {
 		if err := s.ensureCollectionForUser(userID, config.Name); err != nil {
 			xlog.Warn("Failed to auto-create collection for agent", "agent", config.Name, "error", err)
 		}
@@ -946,12 +962,15 @@ func (s *AgentPoolService) UpdateAgentForUser(userID, name string, config *state
 		config.APIKey = plaintext
 	}
 
+	if err := s.prepareAgentMemoryConfig(userID, config); err != nil {
+		return err
+	}
+
 	if err := s.configBackend.UpdateConfig(userID, name, config); err != nil {
 		return err
 	}
 
-	// Auto-create collection when knowledge base or long-term memory is enabled
-	if config.EnableKnowledgeBase || config.LongTermMemory {
+	if config.EnableKnowledgeBase && !wantsLongTermMemory(config) {
 		if err := s.ensureCollectionForUser(userID, config.Name); err != nil {
 			xlog.Warn("Failed to auto-create collection for agent", "agent", config.Name, "error", err)
 		}

--- a/core/services/agentpool/errors.go
+++ b/core/services/agentpool/errors.go
@@ -3,11 +3,12 @@ package agentpool
 import "errors"
 
 var (
-	ErrAgentNotFound     = errors.New("agent not found")
-	ErrTaskNotFound      = errors.New("task not found")
-	ErrJobNotFound       = errors.New("job not found")
-	ErrSkillNotFound     = errors.New("skill not found")
-	ErrSkillsUnavailable = errors.New("skills service not available")
-	ErrTaskDisabled      = errors.New("task is disabled")
-	ErrJobQueueFull      = errors.New("job queue is full")
+	ErrAgentNotFound              = errors.New("agent not found")
+	ErrTaskNotFound               = errors.New("task not found")
+	ErrJobNotFound                = errors.New("job not found")
+	ErrSkillNotFound              = errors.New("skill not found")
+	ErrSkillsUnavailable          = errors.New("skills service not available")
+	ErrTaskDisabled               = errors.New("task is disabled")
+	ErrJobQueueFull               = errors.New("job queue is full")
+	ErrLongTermMemoryRequiresRAG  = errors.New("long_term_memory requires a working embedding model / RAG DB")
 )

--- a/core/services/agentpool/memory_config.go
+++ b/core/services/agentpool/memory_config.go
@@ -30,6 +30,21 @@ func normalizeAgentMemoryConfig(cfg *state.AgentConfig) {
 	}
 }
 
+// isUsableRAGDB reports whether db is a concrete store (not a degraded stub or
+// unresolved recoverable wrapper). Used by create/update validation.
+func isUsableRAGDB(db agent.RAGDB) bool {
+	if db == nil {
+		return false
+	}
+	if _, stub := db.(unavailableRAGDB); stub {
+		return false
+	}
+	if _, lazy := db.(*recoverableRAGDB); lazy {
+		return false
+	}
+	return true
+}
+
 // prepareAgentMemoryConfig normalizes memory flags and, when long-term memory is
 // requested, verifies that a real (non-stub) RAG DB can be created. Returns
 // ErrLongTermMemoryRequiresRAG when embedding/RAG is not configured.
@@ -58,11 +73,7 @@ func (s *AgentPoolService) prepareAgentMemoryConfig(userID string, cfg *state.Ag
 
 	collection := agents.AgentKey(userID, cfg.Name)
 	db, _, ok := s.ragFactory(collection)
-	if !ok || db == nil {
-		return fmt.Errorf("%w: collection %q could not be initialized (install an embedding model or disable long_term_memory)",
-			ErrLongTermMemoryRequiresRAG, collection)
-	}
-	if _, isStub := db.(unavailableRAGDB); isStub {
+	if !ok || !isUsableRAGDB(db) {
 		return fmt.Errorf("%w: collection %q could not be initialized (install an embedding model or disable long_term_memory)",
 			ErrLongTermMemoryRequiresRAG, collection)
 	}
@@ -70,20 +81,22 @@ func (s *AgentPoolService) prepareAgentMemoryConfig(userID string, cfg *state.Ag
 }
 
 // wrapRAGProvider returns a RAG provider that never yields a nil DB with ok=true.
-// When the underlying factory cannot build a DB, a stub is returned so LocalAGI
-// still receives WithRAGDB and saveCurrentConversation cannot nil-deref.
+// On a successful factory call the real DB is returned. On failure a recoverable
+// lazy adapter is installed so LocalAGI's WithRAGDB still gets a non-nil DB
+// (SIGSEGV safety) and later Store/Search/Reset/Count retry the factory once the
+// embedding/vector store is back.
 func wrapRAGProvider(
 	inner func(collectionName string) (agent.RAGDB, state.KBCompactionClient, bool),
 ) func(collectionName, localRAGAPI, localRAGKey string) (agent.RAGDB, state.KBCompactionClient, bool) {
 	return func(collectionName, _, _ string) (agent.RAGDB, state.KBCompactionClient, bool) {
 		if inner != nil {
-			if db, comp, ok := inner(collectionName); ok && db != nil {
+			if db, comp, ok := inner(collectionName); ok && isUsableRAGDB(db) {
 				return db, comp, true
 			}
 		}
-		xlog.Warn("RAG DB unavailable for collection; using no-op stub to avoid long-term memory crash",
+		xlog.Warn("RAG DB unavailable for collection; installing recoverable adapter to avoid long-term memory crash",
 			"collection", collectionName)
-		return unavailableRAGDB{reason: ragUnavailableReason}, nil, true
+		return newRecoverableRAGDB(collectionName, inner), nil, true
 	}
 }
 

--- a/core/services/agentpool/memory_config.go
+++ b/core/services/agentpool/memory_config.go
@@ -1,0 +1,110 @@
+package agentpool
+
+import (
+	"fmt"
+
+	"github.com/mudler/LocalAI/core/services/agents"
+
+	"github.com/mudler/LocalAGI/core/agent"
+	"github.com/mudler/LocalAGI/core/state"
+	"github.com/mudler/xlog"
+)
+
+// wantsLongTermMemory reports whether the agent config asks for conversation
+// persistence into the RAG/knowledge-base store.
+func wantsLongTermMemory(cfg *state.AgentConfig) bool {
+	return cfg != nil && (cfg.LongTermMemory || cfg.SummaryLongTermMemory)
+}
+
+// normalizeAgentMemoryConfig ensures long-term memory implies EnableKnowledgeBase.
+// LocalAGI only attaches WithRAGDB when EnableKnowledgeBase is set, so enabling
+// long_term_memory alone leaves ragdb nil and panics on save.
+func normalizeAgentMemoryConfig(cfg *state.AgentConfig) {
+	if !wantsLongTermMemory(cfg) {
+		return
+	}
+	if !cfg.EnableKnowledgeBase {
+		xlog.Warn("long_term_memory requires enable_kb to wire the RAG DB; enabling enable_kb automatically",
+			"agent", cfg.Name)
+		cfg.EnableKnowledgeBase = true
+	}
+}
+
+// prepareAgentMemoryConfig normalizes memory flags and, when long-term memory is
+// requested, verifies that a real (non-stub) RAG DB can be created. Returns
+// ErrLongTermMemoryRequiresRAG when embedding/RAG is not configured.
+func (s *AgentPoolService) prepareAgentMemoryConfig(userID string, cfg *state.AgentConfig) error {
+	if cfg == nil {
+		return nil
+	}
+	normalizeAgentMemoryConfig(cfg)
+	if !wantsLongTermMemory(cfg) {
+		return nil
+	}
+
+	if err := s.ensureCollectionForUser(userID, cfg.Name); err != nil {
+		return fmt.Errorf("%w: %v", ErrLongTermMemoryRequiresRAG, err)
+	}
+
+	if s.ragFactory == nil {
+		// Distributed / native executor path: no in-process LocalAGI RAG wiring.
+		// Persistence goes through the HTTP KB API and fails soft; still require
+		// that a collections backend exists so the misconfig is visible early.
+		if s.collectionsBackend == nil {
+			return fmt.Errorf("%w: collections backend not initialized", ErrLongTermMemoryRequiresRAG)
+		}
+		return nil
+	}
+
+	collection := agents.AgentKey(userID, cfg.Name)
+	db, _, ok := s.ragFactory(collection)
+	if !ok || db == nil {
+		return fmt.Errorf("%w: collection %q could not be initialized (install an embedding model or disable long_term_memory)",
+			ErrLongTermMemoryRequiresRAG, collection)
+	}
+	if _, isStub := db.(unavailableRAGDB); isStub {
+		return fmt.Errorf("%w: collection %q could not be initialized (install an embedding model or disable long_term_memory)",
+			ErrLongTermMemoryRequiresRAG, collection)
+	}
+	return nil
+}
+
+// wrapRAGProvider returns a RAG provider that never yields a nil DB with ok=true.
+// When the underlying factory cannot build a DB, a stub is returned so LocalAGI
+// still receives WithRAGDB and saveCurrentConversation cannot nil-deref.
+func wrapRAGProvider(
+	inner func(collectionName string) (agent.RAGDB, state.KBCompactionClient, bool),
+) func(collectionName, localRAGAPI, localRAGKey string) (agent.RAGDB, state.KBCompactionClient, bool) {
+	return func(collectionName, _, _ string) (agent.RAGDB, state.KBCompactionClient, bool) {
+		if inner != nil {
+			if db, comp, ok := inner(collectionName); ok && db != nil {
+				return db, comp, true
+			}
+		}
+		xlog.Warn("RAG DB unavailable for collection; using no-op stub to avoid long-term memory crash",
+			"collection", collectionName)
+		return unavailableRAGDB{reason: ragUnavailableReason}, nil, true
+	}
+}
+
+// normalizeExistingLongTermMemoryAgents forces enable_kb on persisted agents that
+// already have long-term memory enabled, then recreates them so LocalAGI wires
+// WithRAGDB before the first chat. Must run after SetRAGProvider and before
+// StartAll (RecreateAgent starts the agent; StartAll skips already-started ones).
+func normalizeExistingLongTermMemoryAgents(pool *state.AgentPool) {
+	if pool == nil {
+		return
+	}
+	for _, name := range pool.List() {
+		cfg := pool.GetConfig(name)
+		if cfg == nil || !wantsLongTermMemory(cfg) || cfg.EnableKnowledgeBase {
+			continue
+		}
+		cfg.EnableKnowledgeBase = true
+		xlog.Warn("Recreating agent to wire RAG DB for long-term memory", "agent", name)
+		if err := pool.RecreateAgent(name, cfg); err != nil {
+			xlog.Error("Failed to recreate agent for long-term memory RAG wiring",
+				"agent", name, "error", err)
+		}
+	}
+}

--- a/core/services/agentpool/memory_config_test.go
+++ b/core/services/agentpool/memory_config_test.go
@@ -1,95 +1,224 @@
 package agentpool
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
-	"testing"
+	"io"
+	"os"
+	"path/filepath"
+	"sync/atomic"
 
 	"github.com/mudler/LocalAGI/core/agent"
 	"github.com/mudler/LocalAGI/core/state"
+	coreTypes "github.com/mudler/LocalAGI/core/types"
+	"github.com/mudler/LocalAGI/webui/collections"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestNormalizeAgentMemoryConfigEnablesKB(t *testing.T) {
-	cfg := &state.AgentConfig{Name: "a", LongTermMemory: true}
-	normalizeAgentMemoryConfig(cfg)
-	if !cfg.EnableKnowledgeBase {
-		t.Fatal("expected EnableKnowledgeBase to be set when LongTermMemory is on")
-	}
+// fakeCollectionsBackend is enough for ensureCollectionForUser to succeed so
+// prepareAgentMemoryConfig can reach the ragFactory rejection branch.
+type fakeCollectionsBackend struct {
+	listed []string
 }
 
-func TestNormalizeAgentMemoryConfigSummary(t *testing.T) {
-	cfg := &state.AgentConfig{Name: "a", SummaryLongTermMemory: true}
-	normalizeAgentMemoryConfig(cfg)
-	if !cfg.EnableKnowledgeBase {
-		t.Fatal("expected EnableKnowledgeBase to be set when SummaryLongTermMemory is on")
-	}
+var _ collections.Backend = (*fakeCollectionsBackend)(nil)
+
+func (f *fakeCollectionsBackend) ListCollections() ([]string, error) { return f.listed, nil }
+func (f *fakeCollectionsBackend) CreateCollection(name string) error {
+	f.listed = append(f.listed, name)
+	return nil
+}
+func (f *fakeCollectionsBackend) Upload(string, string, io.Reader) (string, error) {
+	return "", nil
+}
+func (f *fakeCollectionsBackend) ListEntries(string) ([]string, error) { return nil, nil }
+func (f *fakeCollectionsBackend) GetEntryContent(string, string) (string, int, error) {
+	return "", 0, nil
+}
+func (f *fakeCollectionsBackend) Search(string, string, int) ([]collections.SearchResult, error) {
+	return nil, nil
+}
+func (f *fakeCollectionsBackend) Reset(string) error { return nil }
+func (f *fakeCollectionsBackend) DeleteEntry(string, string) ([]string, error) {
+	return nil, nil
+}
+func (f *fakeCollectionsBackend) AddSource(string, string, int) error { return nil }
+func (f *fakeCollectionsBackend) RemoveSource(string, string) error   { return nil }
+func (f *fakeCollectionsBackend) ListSources(string) ([]collections.SourceInfo, error) {
+	return nil, nil
+}
+func (f *fakeCollectionsBackend) EntryExists(string, string) bool { return false }
+func (f *fakeCollectionsBackend) GetEntryFilePath(string, string) (string, error) {
+	return "", errors.New("not found")
 }
 
-func TestNormalizeAgentMemoryConfigNoopWithoutMemory(t *testing.T) {
-	cfg := &state.AgentConfig{Name: "a"}
-	normalizeAgentMemoryConfig(cfg)
-	if cfg.EnableKnowledgeBase {
-		t.Fatal("did not expect EnableKnowledgeBase without long-term memory")
-	}
+type countingRAGDB struct{ n atomic.Int32 }
+
+func (c *countingRAGDB) Store(string) error {
+	c.n.Add(1)
+	return nil
 }
-
-func TestWrapRAGProviderReturnsStubWhenInnerFails(t *testing.T) {
-	inner := func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
-		return nil, nil, false
-	}
-	db, _, ok := wrapRAGProvider(inner)("missing", "", "")
-	if !ok {
-		t.Fatal("expected ok=true from wrapped provider")
-	}
-	if db == nil {
-		t.Fatal("expected non-nil stub RAGDB")
-	}
-	if _, isStub := db.(unavailableRAGDB); !isStub {
-		t.Fatalf("expected unavailableRAGDB stub, got %T", db)
-	}
-	if err := db.Store("x"); err == nil {
-		t.Fatal("expected stub Store to return an error")
-	}
-}
-
-func TestWrapRAGProviderPassesThroughRealDB(t *testing.T) {
-	real := unavailableRAGDB{reason: "not-a-stub-for-pass-through-test"}
-	// Use a distinct concrete type so we can tell pass-through from the failure stub.
-	innerDB := &countingRAGDB{}
-	inner := func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
-		return innerDB, nil, true
-	}
-	db, _, ok := wrapRAGProvider(inner)("ok", "", "")
-	if !ok || db != innerDB {
-		t.Fatalf("expected pass-through of real DB, ok=%v db=%T", ok, db)
-	}
-	_ = real
-}
-
-func TestPrepareAgentMemoryConfigRejectsMissingRAG(t *testing.T) {
-	s := &AgentPoolService{
-		ragFactory: func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
-			return nil, nil, false
-		},
-	}
-	// Bypass ensureCollectionForUser by stubbing collectionsBackend path:
-	// prepareAgentMemoryConfig calls ensureCollectionForUser first. With a nil
-	// collectionsBackend that returns an error via CollectionsBackendForUser.
-	cfg := &state.AgentConfig{Name: "agent", LongTermMemory: true}
-	err := s.prepareAgentMemoryConfig("", cfg)
-	if err == nil {
-		t.Fatal("expected error when RAG cannot be initialized")
-	}
-	if !errors.Is(err, ErrLongTermMemoryRequiresRAG) {
-		t.Fatalf("expected ErrLongTermMemoryRequiresRAG, got %v", err)
-	}
-	if !cfg.EnableKnowledgeBase {
-		t.Fatal("expected normalize to enable KB even when prepare fails")
-	}
-}
-
-type countingRAGDB struct{ n int }
-
-func (c *countingRAGDB) Store(string) error                  { c.n++; return nil }
-func (c *countingRAGDB) Reset() error                        { return nil }
+func (c *countingRAGDB) Reset() error                         { return nil }
 func (c *countingRAGDB) Search(string, int) ([]string, error) { return nil, nil }
-func (c *countingRAGDB) Count() int                          { return c.n }
+func (c *countingRAGDB) Count() int                           { return int(c.n.Load()) }
+
+var _ = Describe("agent memory config", func() {
+	Describe("normalizeAgentMemoryConfig", func() {
+		It("enables enable_kb when long_term_memory is on", func() {
+			cfg := &state.AgentConfig{Name: "a", LongTermMemory: true}
+			normalizeAgentMemoryConfig(cfg)
+			Expect(cfg.EnableKnowledgeBase).To(BeTrue())
+		})
+
+		It("enables enable_kb when summary_long_term_memory is on", func() {
+			cfg := &state.AgentConfig{Name: "a", SummaryLongTermMemory: true}
+			normalizeAgentMemoryConfig(cfg)
+			Expect(cfg.EnableKnowledgeBase).To(BeTrue())
+		})
+
+		It("leaves enable_kb alone without long-term memory", func() {
+			cfg := &state.AgentConfig{Name: "a"}
+			normalizeAgentMemoryConfig(cfg)
+			Expect(cfg.EnableKnowledgeBase).To(BeFalse())
+		})
+	})
+
+	Describe("wrapRAGProvider", func() {
+		It("passes through a real DB when the factory succeeds", func() {
+			innerDB := &countingRAGDB{}
+			inner := func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
+				return innerDB, nil, true
+			}
+			db, _, ok := wrapRAGProvider(inner)("ok", "", "")
+			Expect(ok).To(BeTrue())
+			Expect(db).To(BeIdenticalTo(innerDB))
+		})
+
+		It("returns a non-nil recoverable adapter when the factory fails", func() {
+			inner := func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
+				return nil, nil, false
+			}
+			db, _, ok := wrapRAGProvider(inner)("missing", "", "")
+			Expect(ok).To(BeTrue())
+			Expect(db).NotTo(BeNil())
+			_, isLazy := db.(*recoverableRAGDB)
+			Expect(isLazy).To(BeTrue())
+			Expect(db.Store("x")).To(HaveOccurred())
+		})
+
+		It("retries the factory on Store after a failed init (failure-then-recovery)", func() {
+			var calls atomic.Int32
+			real := &countingRAGDB{}
+			inner := func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
+				n := calls.Add(1)
+				if n == 1 {
+					return nil, nil, false
+				}
+				return real, nil, true
+			}
+
+			db, _, ok := wrapRAGProvider(inner)("recover", "", "")
+			Expect(ok).To(BeTrue())
+			Expect(calls.Load()).To(Equal(int32(1)), "wrap probes the factory once")
+			Expect(db).NotTo(BeIdenticalTo(real))
+
+			Expect(db.Store("hello")).To(Succeed())
+			Expect(calls.Load()).To(Equal(int32(2)), "Store must retry the factory after recovery")
+			Expect(real.Count()).To(Equal(1))
+
+			// Subsequent ops use the cached real DB without another factory call.
+			Expect(db.Store("again")).To(Succeed())
+			Expect(calls.Load()).To(Equal(int32(2)))
+			Expect(real.Count()).To(Equal(2))
+		})
+
+		It("never returns nil DB with ok=true when inner is nil", func() {
+			db, _, ok := wrapRAGProvider(nil)("x", "", "")
+			Expect(ok).To(BeTrue())
+			Expect(db).NotTo(BeNil())
+			Expect(db.Store("x")).To(HaveOccurred())
+		})
+	})
+
+	Describe("prepareAgentMemoryConfig", func() {
+		It("rejects when ragFactory cannot initialize (not just missing backend)", func() {
+			var factoryCalls atomic.Int32
+			s := &AgentPoolService{
+				collectionsBackend: &fakeCollectionsBackend{},
+				ragFactory: func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
+					factoryCalls.Add(1)
+					return nil, nil, false
+				},
+			}
+			cfg := &state.AgentConfig{Name: "agent", LongTermMemory: true}
+			err := s.prepareAgentMemoryConfig("", cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrLongTermMemoryRequiresRAG)).To(BeTrue())
+			Expect(factoryCalls.Load()).To(BeNumerically(">=", 1), "must reach ragFactory rejection branch")
+			Expect(cfg.EnableKnowledgeBase).To(BeTrue())
+		})
+
+		It("accepts when ragFactory returns a real DB", func() {
+			s := &AgentPoolService{
+				collectionsBackend: &fakeCollectionsBackend{listed: []string{"agent"}},
+				ragFactory: func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
+					return &countingRAGDB{}, nil, true
+				},
+			}
+			cfg := &state.AgentConfig{Name: "agent", LongTermMemory: true}
+			Expect(s.prepareAgentMemoryConfig("", cfg)).To(Succeed())
+			Expect(cfg.EnableKnowledgeBase).To(BeTrue())
+		})
+	})
+
+	Describe("normalizeExistingLongTermMemoryAgents", func() {
+		It("forces enable_kb on persisted LTM agents and recreates them", func() {
+			tmp := GinkgoT().TempDir()
+			poolFile := filepath.Join(tmp, "pool.json")
+			seed := map[string]state.AgentConfig{
+				"ltm": {
+					Name:                  "ltm",
+					Model:                 "dummy",
+					LongTermMemory:        true,
+					EnableKnowledgeBase:   false,
+					PeriodicRuns:          "10m",
+					SchedulerPollInterval: "30s",
+				},
+			}
+			data, err := json.Marshal(seed)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(os.WriteFile(poolFile, data, 0o644)).To(Succeed())
+
+			noopActions := func(*state.AgentConfig) func(context.Context, *state.AgentPool) []coreTypes.Action {
+				return func(context.Context, *state.AgentPool) []coreTypes.Action { return nil }
+			}
+			noopConnectors := func(*state.AgentConfig) []state.Connector { return nil }
+			noopPrompts := func(*state.AgentConfig) func(context.Context, *state.AgentPool) []agent.DynamicPrompt {
+				return func(context.Context, *state.AgentPool) []agent.DynamicPrompt { return nil }
+			}
+			noopFilters := func(*state.AgentConfig) coreTypes.JobFilters { return nil }
+
+			pool, err := state.NewAgentPool(
+				"dummy", "", "", "", "",
+				"http://127.0.0.1:1", "",
+				tmp,
+				noopActions, noopConnectors, noopPrompts, noopFilters,
+				"1s", false, nil, state.PoolLimits{},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pool.List()).To(ContainElement("ltm"))
+			Expect(pool.GetConfig("ltm").EnableKnowledgeBase).To(BeFalse())
+
+			// RecreateAgent may fail to fully start without a live LLM; the
+			// important part is enable_kb is forced and persisted on the pool.
+			normalizeExistingLongTermMemoryAgents(pool)
+
+			cfg := pool.GetConfig("ltm")
+			Expect(cfg).NotTo(BeNil())
+			Expect(cfg.EnableKnowledgeBase).To(BeTrue())
+		})
+	})
+})

--- a/core/services/agentpool/memory_config_test.go
+++ b/core/services/agentpool/memory_config_test.go
@@ -1,0 +1,95 @@
+package agentpool
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mudler/LocalAGI/core/agent"
+	"github.com/mudler/LocalAGI/core/state"
+)
+
+func TestNormalizeAgentMemoryConfigEnablesKB(t *testing.T) {
+	cfg := &state.AgentConfig{Name: "a", LongTermMemory: true}
+	normalizeAgentMemoryConfig(cfg)
+	if !cfg.EnableKnowledgeBase {
+		t.Fatal("expected EnableKnowledgeBase to be set when LongTermMemory is on")
+	}
+}
+
+func TestNormalizeAgentMemoryConfigSummary(t *testing.T) {
+	cfg := &state.AgentConfig{Name: "a", SummaryLongTermMemory: true}
+	normalizeAgentMemoryConfig(cfg)
+	if !cfg.EnableKnowledgeBase {
+		t.Fatal("expected EnableKnowledgeBase to be set when SummaryLongTermMemory is on")
+	}
+}
+
+func TestNormalizeAgentMemoryConfigNoopWithoutMemory(t *testing.T) {
+	cfg := &state.AgentConfig{Name: "a"}
+	normalizeAgentMemoryConfig(cfg)
+	if cfg.EnableKnowledgeBase {
+		t.Fatal("did not expect EnableKnowledgeBase without long-term memory")
+	}
+}
+
+func TestWrapRAGProviderReturnsStubWhenInnerFails(t *testing.T) {
+	inner := func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
+		return nil, nil, false
+	}
+	db, _, ok := wrapRAGProvider(inner)("missing", "", "")
+	if !ok {
+		t.Fatal("expected ok=true from wrapped provider")
+	}
+	if db == nil {
+		t.Fatal("expected non-nil stub RAGDB")
+	}
+	if _, isStub := db.(unavailableRAGDB); !isStub {
+		t.Fatalf("expected unavailableRAGDB stub, got %T", db)
+	}
+	if err := db.Store("x"); err == nil {
+		t.Fatal("expected stub Store to return an error")
+	}
+}
+
+func TestWrapRAGProviderPassesThroughRealDB(t *testing.T) {
+	real := unavailableRAGDB{reason: "not-a-stub-for-pass-through-test"}
+	// Use a distinct concrete type so we can tell pass-through from the failure stub.
+	innerDB := &countingRAGDB{}
+	inner := func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
+		return innerDB, nil, true
+	}
+	db, _, ok := wrapRAGProvider(inner)("ok", "", "")
+	if !ok || db != innerDB {
+		t.Fatalf("expected pass-through of real DB, ok=%v db=%T", ok, db)
+	}
+	_ = real
+}
+
+func TestPrepareAgentMemoryConfigRejectsMissingRAG(t *testing.T) {
+	s := &AgentPoolService{
+		ragFactory: func(string) (agent.RAGDB, state.KBCompactionClient, bool) {
+			return nil, nil, false
+		},
+	}
+	// Bypass ensureCollectionForUser by stubbing collectionsBackend path:
+	// prepareAgentMemoryConfig calls ensureCollectionForUser first. With a nil
+	// collectionsBackend that returns an error via CollectionsBackendForUser.
+	cfg := &state.AgentConfig{Name: "agent", LongTermMemory: true}
+	err := s.prepareAgentMemoryConfig("", cfg)
+	if err == nil {
+		t.Fatal("expected error when RAG cannot be initialized")
+	}
+	if !errors.Is(err, ErrLongTermMemoryRequiresRAG) {
+		t.Fatalf("expected ErrLongTermMemoryRequiresRAG, got %v", err)
+	}
+	if !cfg.EnableKnowledgeBase {
+		t.Fatal("expected normalize to enable KB even when prepare fails")
+	}
+}
+
+type countingRAGDB struct{ n int }
+
+func (c *countingRAGDB) Store(string) error                  { c.n++; return nil }
+func (c *countingRAGDB) Reset() error                        { return nil }
+func (c *countingRAGDB) Search(string, int) ([]string, error) { return nil, nil }
+func (c *countingRAGDB) Count() int                          { return c.n }

--- a/core/services/agentpool/recoverable_ragdb.go
+++ b/core/services/agentpool/recoverable_ragdb.go
@@ -1,0 +1,71 @@
+package agentpool
+
+import (
+	"sync"
+
+	"github.com/mudler/LocalAGI/core/agent"
+	"github.com/mudler/LocalAGI/core/state"
+)
+
+// recoverableRAGDB is a non-nil RAGDB that retries the inner factory until a
+// real DB is obtained. LocalAGI stores the RAGDB from the provider for the
+// life of the agent (WithRAGDB); returning a permanent unavailableRAGDB on a
+// transient init failure would discard all long-term-memory writes until the
+// agent is recreated. This adapter keeps retrying on Store/Search/Reset/Count
+// so recovery happens without recreation (see mudler/LocalAI#11975 review).
+type recoverableRAGDB struct {
+	mu         sync.Mutex
+	collection string
+	factory    func(collectionName string) (agent.RAGDB, state.KBCompactionClient, bool)
+	real       agent.RAGDB
+}
+
+var _ agent.RAGDB = (*recoverableRAGDB)(nil)
+
+func newRecoverableRAGDB(
+	collection string,
+	factory func(collectionName string) (agent.RAGDB, state.KBCompactionClient, bool),
+) *recoverableRAGDB {
+	return &recoverableRAGDB{collection: collection, factory: factory}
+}
+
+// resolve returns a usable RAGDB. Once a real DB is obtained it is cached.
+// Temporary factory failures keep returning the soft-fail stub so callers never
+// see a nil DB (SIGSEGV safety). Permanent "not configured" vs transient
+// failures cannot be distinguished from the factory's (nil, false) signal, so
+// we always keep retrying.
+func (r *recoverableRAGDB) resolve() agent.RAGDB {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.real != nil {
+		return r.real
+	}
+	if r.factory != nil {
+		if db, _, ok := r.factory(r.collection); ok && db != nil {
+			switch db.(type) {
+			case unavailableRAGDB, *recoverableRAGDB:
+				// Never cache another degraded wrapper as "recovered".
+			default:
+				r.real = db
+				return r.real
+			}
+		}
+	}
+	return unavailableRAGDB{reason: ragUnavailableReason}
+}
+
+func (r *recoverableRAGDB) Store(s string) error {
+	return r.resolve().Store(s)
+}
+
+func (r *recoverableRAGDB) Reset() error {
+	return r.resolve().Reset()
+}
+
+func (r *recoverableRAGDB) Search(s string, similarEntries int) ([]string, error) {
+	return r.resolve().Search(s, similarEntries)
+}
+
+func (r *recoverableRAGDB) Count() int {
+	return r.resolve().Count()
+}

--- a/core/services/agentpool/unavailable_ragdb.go
+++ b/core/services/agentpool/unavailable_ragdb.go
@@ -1,0 +1,34 @@
+package agentpool
+
+import (
+	"fmt"
+
+	"github.com/mudler/LocalAGI/core/agent"
+)
+
+// unavailableRAGDB is a non-nil RAGDB that fails soft on every operation.
+// LocalAGI's saveCurrentConversation calls ragdb.Store when long-term memory is
+// enabled without nil-checking; returning this stub from the RAG provider
+// prevents a process-wide SIGSEGV when the embedding/RAG DB cannot be wired
+// (see mudler/LocalAI#11975 / mudler/LocalAGI#405).
+type unavailableRAGDB struct {
+	reason string
+}
+
+var _ agent.RAGDB = unavailableRAGDB{}
+
+func (u unavailableRAGDB) Store(string) error {
+	return fmt.Errorf("RAG DB unavailable: %s", u.reason)
+}
+
+func (u unavailableRAGDB) Reset() error {
+	return fmt.Errorf("RAG DB unavailable: %s", u.reason)
+}
+
+func (u unavailableRAGDB) Search(string, int) ([]string, error) {
+	return nil, fmt.Errorf("RAG DB unavailable: %s", u.reason)
+}
+
+func (u unavailableRAGDB) Count() int { return 0 }
+
+const ragUnavailableReason = "embedding model / vector store not configured or failed to initialize"

--- a/docs/content/features/agents.md
+++ b/docs/content/features/agents.md
@@ -191,6 +191,14 @@ Each agent has its own configuration that controls its behavior. Key settings in
 
 The pool-level defaults (API URL, API key, models) can be set via environment variables. Individual agents can further override these in their configuration, allowing them to use different LLM providers (OpenAI, other LocalAI instances, etc.) on a per-agent basis.
 
+### Long-term memory and knowledge base wiring
+
+Agents can persist conversation context into their knowledge-base (RAG) collection with `long_term_memory` or `summary_long_term_memory`. LocalAGI only attaches the RAG database when `enable_kb` is set, so LocalAI applies these rules:
+
+- **Automatic `enable_kb` normalization** — creating or updating an agent with long-term memory on also turns on `enable_kb`. Existing agents that already had long-term memory without `enable_kb` are normalized the same way at pool startup (recreated so the RAG DB is wired before the first chat).
+- **Create/update validation** — if the embedding model / vector store cannot be initialized, create and update reject the config with an error asking you to install an embedding model (see `LOCALAI_AGENT_POOL_EMBEDDING_MODEL`) or disable long-term memory. This avoids saving an agent that would never persist memory.
+- **Degraded but recoverable startup** — if the RAG factory is temporarily unavailable when an agent is built (for example the embedding endpoint is still starting), LocalAI installs a recoverable adapter instead of a nil DB. Conversation saves fail soft until the store comes back; later Store/Search calls retry initialization automatically so a transient outage does not permanently disable long-term memory writes.
+
 ## Skills
 
 Skills are reusable instruction sets (a name, a description, and the skill's content, optionally with attached resource files) that an agent can draw on while it works. They can be authored directly or imported from git-based skill repositories, so a set of skills can be shared across agents and machines.


### PR DESCRIPTION
## What Problem
Fixes #11975

Enabling `long_term_memory` without a wired embedding/RAG path can nil-deref inside LocalAGI's `ragdb.Store` and take down the whole LocalAI process.

## Why
LocalAGI only attaches `WithRAGDB` when `enable_kb` is set, but conversation persistence still calls `ragdb.Store` whenever long-term memory is on. LocalAI can create that config mismatch today.

## How Verified
- `go build ./core/services/agentpool/`
- `go test ./core/services/agentpool/ -run 'Normalize|WrapRAG|Prepare'`

Local mitigation on the LocalAI side: auto-enable `enable_kb` when LTM is requested, reject create/update if embedding/RAG cannot initialize, wrap a non-nil no-op RAG stub as a safety net, and normalize persisted LTM agents missing `enable_kb` on startup.